### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /django
+    schedule:
+      interval: weekly
+    groups:
+      pip-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /react-app
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: maven
+    directory: /springboot
+    schedule:
+      interval: weekly
+    groups:
+      maven-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directories:
+      - /django
+      - /springboot
+      - /nginx
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering all package ecosystems in the monorepo:

- **pip** (`django/`) — weekly, minor/patch grouped into one PR
- **npm** (`react-app/`) — weekly, minor/patch grouped
- **maven** (`springboot/`) — weekly, minor/patch grouped
- **docker** (`django/`, `springboot/`, `nginx/`) — weekly base-image bumps
- **github-actions** — weekly

Dependabot security updates (auto-fix PRs for existing alerts) were also enabled via repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)