### PR TITLE
Revert Django base image to python:3.10-slim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
       - /nginx
     schedule:
       interval: weekly
+    ignore:
+      # Python base image is pinned until pandas 3 / Django 6 land; bump manually after.
+      - dependency-name: python
 
   - package-ecosystem: github-actions
     directory: /

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 # FROM python:3.12-slim
-FROM python:3.14-slim
+FROM python:3.10-slim
 
 # set a directory for this app
 WORKDIR /django/


### PR DESCRIPTION
Reverts the python 3.14-slim bump from #5. pandas 2.1.1 has no cp314 wheels, so pip falls back to a source build that fails on the compiler-less slim image.

- `django/Dockerfile`: back to `python:3.10-slim` (verified: `docker build` succeeds locally)
- `dependabot.yml`: ignore the `python` docker dependency so 3.14 isn't re-offered; the image gets bumped manually after pandas 3 / Django 6 land

🤖 Generated with [Claude Code](https://claude.com/claude-code)