### PR TITLE
Django 5.2.15 LTS + pandas 2.3.3 (step 1 of runtime upgrade)

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -1,5 +1,5 @@
 # The Django Framework
-Django==6.0.6
+Django==5.2.15
 # Security for communication with the react frontend
 django-cors-headers==4.9.0
 # API library
@@ -31,7 +31,7 @@ redis==4.5.5
 # PyTorch for machine learning
 # torch==2.0.1 
 # pandas for numerical computations
-pandas==2.1.1
+pandas==2.3.3
 numpy==1.26.0
 google-generativeai==0.8.6
 django-redis==5.4.0


### PR DESCRIPTION
Step 1 of the staged path to Python 3.14 + Django 6:

- **Django 6.0.6 → 5.2.15**: Django 6 requires Python ≥3.12; the image is on 3.10 until step 2. 5.2.15 is LTS (supported to April 2028) and clears both critical SQL-injection alerts.
- **pandas 2.1.1 → 2.3.3**: same 2.x API, but ships wheels through cp314 — this is what unblocks the base-image bump in step 2.

Verified locally: full Django test suite passes (80/80), and `docker build` succeeds on `python:3.10-slim`.

Next: step 2 bumps the base image to 3.14; step 3 is Django 6 + the packages that need it (django-filter 25, celery-beat, simple-history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)