### PR TITLE
Python 3.14 base image + numpy 2.5 (step 2 of runtime upgrade)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,6 @@ updates:
       - /nginx
     schedule:
       interval: weekly
-    ignore:
-      # Python base image is pinned until pandas 3 / Django 6 land; bump manually after.
-      - dependency-name: python
 
   - package-ecosystem: github-actions
     directory: /

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,4 @@
-# FROM python:3.12-slim
-FROM python:3.10-slim
+FROM python:3.14-slim
 
 # set a directory for this app
 WORKDIR /django/

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -32,7 +32,7 @@ redis==4.5.5
 # torch==2.0.1 
 # pandas for numerical computations
 pandas==2.3.3
-numpy==1.26.0
+numpy==2.5.0
 google-generativeai==0.8.6
 django-redis==5.4.0
 pandas-market-calendars==5.4.0


### PR DESCRIPTION
Step 2 of the staged path to Python 3.14 + Django 6:

- `django/Dockerfile`: `python:3.10-slim` → `python:3.14-slim` — works now that pandas 2.3.3 (step 1, #31) ships cp314 wheels
- `numpy==1.26.0` → `2.5.0` — numpy 1.26 has no wheels past Python 3.12
- `dependabot.yml`: removed the temporary ignore on the python docker image

Verified: full Django test suite (80/80) passes **inside the 3.14 container** (tests dir mounted, since `.dockerignore` excludes it from the image), plus locally on the 3.12 venv against numpy 2.5.

Remaining: step 3 — Django 5.2 → 6.0 with `django-filter` 25.x and Django-6-compatible `django-celery-beat` / `django-simple-history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)