### PR TITLE
Pin CI Django job to Python 3.14 (match Dockerfile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          # Must match the base image in django/Dockerfile
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: django/requirements.txt
 


### PR DESCRIPTION
The django CI job ran on Python 3.12 while the container ran 3.10 — which is how the Django 6 bump (#16) passed CI but broke the Docker build. Pins the runner to 3.14 to match `django/Dockerfile` after #32, with a comment noting the two must move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)