### PR TITLE
Ignore eslint-plugin-react-refresh 0.5.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # 0.5.x requires eslint >=9; unpin after the ESLint 9 migration.
+      - dependency-name: eslint-plugin-react-refresh
+        versions: [">=0.5.0"]
 
   - package-ecosystem: maven
     directory: /springboot


### PR DESCRIPTION
`eslint-plugin-react-refresh` 0.5.x requires ESLint ≥9 as a peer dependency; the project is on ESLint 8, so including it fails `npm ci` and blocks the entire npm minor-patch group (#41). Parks it at 0.4.x until the ESLint 9 migration; #41 will be recreated without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)