### PR TITLE
Ignore React 19 major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,16 @@ updates:
       # 0.5.x requires eslint >=9; unpin after the ESLint 9 migration.
       - dependency-name: eslint-plugin-react-refresh
         versions: [">=0.5.0"]
+      # React 19 is a coordinated migration (testing-library 16+, types,
+      # react-bootstrap/recharts compat) — do it deliberately, not via PR.
+      - dependency-name: react
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-dom
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: maven
     directory: /springboot


### PR DESCRIPTION
Companion to #44. The `@dependabot ignore this major version` comment doesn't work on multi-dependency PRs (#22 bundles react-dom + @types/react-dom), so the ignore moves to config: react, react-dom, and their types packages are held at majors until the React 19 migration is done deliberately (together with react-router 7 / testing-library 16). #22 gets closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)