### PR TITLE
Pin Redis server image to redis:8 in deploy script

### DIFF
--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -82,8 +82,9 @@ sudo docker run --name nginx --network dockerNet \
   --log-opt awslogs-stream=nginx-{{.ID}} \
   -d johnfattore/nginx
 
-# Redis
-sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis
+# Redis (major pinned like postgres above; bump deliberately with the
+# redis-py/django-redis client pins in django/requirements.txt)
+sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
 
 # pgadmin4
 # PGADMIN_DEFAULT_PASSWORD seeds the admin account on first run only (persisted


### PR DESCRIPTION
The Redis container in `deploy/run.sh` ran untagged (`redis` = `latest`), so each deploy silently took whatever Redis shipped that day — invisible to Dependabot since it's a shell script, not a Dockerfile. Pins to `redis:8`, matching the major-level convention already used for `postgres:17`, with a comment tying future bumps to the redis-py/django-redis client pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)