### PR TITLE
Migrate host deploys to Docker Compose, retire watchtower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ django/restaurants/yelp_dataset
 react-app/node_modules
 react-app/dist
 .env.*
+!deploy/.env.example
 react-app/coverage
 react-app/.sass-cache
 react-app/src/styles/custom.css

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,9 @@
+# Copy to .env on the host (deploy/.env is gitignored). No secret VALUES here:
+# SECRETS_ARN is just the pointer to the fattorestreet/env Secrets Manager
+# secret; each container's entrypoint fetches the real config at start.
+SECRETS_ARN=arn:aws:secretsmanager:us-east-1:<ACCOUNT_ID>:secret:fattorestreet/env-XXXXXX
+AWS_REGION=us-east-1
+
+# Image tag to deploy (only "latest" is published today; per-commit tags will
+# enable pinned deploys/rollbacks once CI publishes them).
+TAG=latest

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# FattoreStreet Docker Compose runbook (successor to the docker-run commands
+# in run.sh, which is kept as-is for reference on the current live setup).
+#
+# SAFE TO COMMIT: no secret values live in this file. All app config/credentials
+# come from a single AWS Secrets Manager secret (fattorestreet/env); containers
+# are passed only its ARN via SECRETS_ARN (from deploy/.env, see .env.example)
+# and fetch the rest at start (see each image's docker-entrypoint.sh).
+#
+# The containers are defined in the compose files next to this script:
+#   docker-compose.yml        app services (django, celery-worker, celery-beat,
+#                             springboot, nginx) -- the deploy unit
+#   docker-compose.infra.yml  stateful infra (postgres, redis, pgadmin4) --
+#                             never touched by a routine deploy
+#
+# This file is a copy/paste runbook, not a script to execute top-to-bottom.
+
+# ---------------------------------------------------------------------------
+# One-time host setup
+# ---------------------------------------------------------------------------
+
+# 1. Shared bridge network (both compose files reference it as external)
+sudo docker network create --driver bridge dockerNet
+
+# 2. Env file for compose: copy the template and fill in the real secret ARN
+#    (the fattorestreet/env secret itself is created per the doc block in
+#    run.sh; requires the EC2 instance role to allow secretsmanager:GetSecretValue
+#    and IMDSv2 hop limit >= 2)
+cp .env.example .env
+
+# 3. Stateful infra (postgres, redis, pgadmin4). POSTGRES_PASSWORD is only read
+# on FIRST-TIME init of an empty /mnt/ebs/postgres-data volume -- see the
+# comments in docker-compose.infra.yml for the fetch-from-secret recipe.
+# PGADMIN_DEFAULT_PASSWORD seeds the pgadmin admin account on first run only.
+sudo docker compose -f docker-compose.infra.yml up -d
+
+# 4. App services
+sudo docker compose up -d
+
+# 5. SSL cert: run the certbot certonly command from run.sh (nginx must be up
+# to serve the webroot challenge; rerun to renew)
+
+# ---------------------------------------------------------------------------
+# One-time cutover from the old docker-run/watchtower setup (run.sh)
+# ---------------------------------------------------------------------------
+# Watchtower is retired: deploys are now an explicit compose pull/up. Data is
+# safe -- postgres/certbot state lives in the /mnt/ebs bind mounts.
+#
+#   sudo docker stop watchtower && sudo docker rm watchtower
+#   sudo docker stop nginx django springboot celery postgres redis pgadmin4
+#   sudo docker rm   nginx django springboot celery postgres redis pgadmin4
+#   sudo docker compose -f docker-compose.infra.yml up -d
+#   sudo docker compose up -d
+
+# ---------------------------------------------------------------------------
+# Routine operations (from this directory)
+# ---------------------------------------------------------------------------
+
+# deploy the latest pushed images
+sudo docker compose pull && sudo docker compose up -d
+
+# apply Django migrations (one-shot container, same image + secret as django)
+sudo docker compose run --rm django python manage.py migrate
+
+# status / logs / shell
+sudo docker compose ps
+sudo docker compose logs -f django
+sudo docker exec -it django bash
+
+# stop the whole app (infra keeps running)
+sudo docker compose down
+
+# infra changes (rare; postgres/redis version bumps etc.)
+sudo docker compose -f docker-compose.infra.yml up -d

--- a/deploy/docker-compose.infra.yml
+++ b/deploy/docker-compose.infra.yml
@@ -1,0 +1,60 @@
+# FattoreStreet stateful infrastructure -- postgres, redis, pgadmin.
+#
+# NOT part of the deploy unit: routine deploys (docker compose pull/up in this
+# directory) never touch these services. Manage them explicitly with:
+#   docker compose -f docker-compose.infra.yml up -d
+
+name: fattorestreet-infra
+
+services:
+  # POSTGRES_PASSWORD is the single DB-password key: the postgres image reads it
+  # ONLY during first-time init (empty data dir), and django + springboot use the
+  # same key to connect. With an already-initialized volume the entrypoint
+  # ignores it -- the real password lives in the volume + in fattorestreet/env
+  # (POSTGRES_PASSWORD).
+  #
+  # FRESH VOLUME ONLY: to re-initialize from an empty /mnt/ebs/postgres-data,
+  # fetch the password from the secret on the host (the EC2 instance role can
+  # read it) and pass it just for that run:
+  #   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
+  #         --query SecretString --output text | jq -r .POSTGRES_PASSWORD)
+  #   POSTGRES_PASSWORD="$PW" docker compose -f docker-compose.infra.yml up -d postgres
+  postgres:
+    image: postgres:17
+    container_name: postgres
+    volumes:
+      - /mnt/ebs/postgres-data:/var/lib/postgresql/data
+    ports:
+      - "0.0.0.0:5432:5432"
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+    networks: [dockerNet]
+    restart: unless-stopped
+
+  # Major pinned like postgres; bump deliberately with the redis-py/django-redis
+  # client pins in django/pyproject.toml.
+  redis:
+    image: redis:8
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks: [dockerNet]
+    restart: unless-stopped
+
+  # PGADMIN_DEFAULT_PASSWORD seeds the admin account on first run only
+  # (persisted thereafter). Supply the real value via the host env -- do NOT
+  # hardcode it here.
+  pgadmin4:
+    image: dpage/pgadmin4
+    container_name: pgadmin4
+    ports:
+      - "5050:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: johnefattore@gmail.com
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-}
+    networks: [dockerNet]
+    restart: unless-stopped
+
+networks:
+  dockerNet:
+    external: true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,76 @@
+# FattoreStreet app services -- the deploy unit.
+#
+# SAFE TO COMMIT: no secret values live in this file. All app config/credentials
+# come from a single AWS Secrets Manager secret (fattorestreet/env); each app
+# container is passed only its ARN via SECRETS_ARN (from ./.env, see
+# .env.example) and fetches the rest at start (see each image's
+# docker-entrypoint.sh). Stateful infra (postgres/redis/pgadmin) lives in
+# docker-compose.infra.yml and is never touched by a deploy.
+#
+# deploy (from this directory):
+#   docker compose pull && docker compose up -d
+# migrate:
+#   docker compose run --rm django python manage.py migrate
+#
+# TAG defaults to latest (the only tag build.sh pushes today); once CI publishes
+# per-commit tags, deploy/rollback becomes: TAG=<sha> docker compose pull && up -d
+
+name: fattorestreet
+
+services:
+  django:
+    image: johnfattore/django:${TAG:-latest}
+    container_name: django
+    env_file: .env
+    networks: [dockerNet]
+    restart: unless-stopped
+
+  # Same image + secret as django; only the command differs.
+  celery-worker:
+    image: johnfattore/django:${TAG:-latest}
+    container_name: celery-worker
+    command: celery -A mysite worker -E -n worker
+    env_file: .env
+    networks: [dockerNet]
+    restart: unless-stopped
+
+  celery-beat:
+    image: johnfattore/django:${TAG:-latest}
+    container_name: celery-beat
+    command: celery -A mysite worker --beat -E -n beat
+    env_file: .env
+    networks: [dockerNet]
+    restart: unless-stopped
+
+  springboot:
+    image: johnfattore/springboot:${TAG:-latest}
+    container_name: springboot
+    env_file: .env
+    networks: [dockerNet]
+    restart: unless-stopped
+
+  nginx:
+    image: johnfattore/nginx:${TAG:-latest}
+    container_name: nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /mnt/ebs/certbot/letsencrypt:/etc/letsencrypt
+      - /mnt/ebs/certbot/www:/var/www/certbot
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: us-east-1
+        awslogs-group: nginx-logs
+        # tag templates the CloudWatch log stream name per container
+        tag: nginx-{{.ID}}
+    # start after the backends; nginx.conf re-resolves their IPs every 10s
+    # via Docker DNS, so recreated backends are picked up without a restart
+    depends_on: [django, springboot]
+    networks: [dockerNet]
+    restart: unless-stopped
+
+networks:
+  dockerNet:
+    external: true

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -1,35 +1,21 @@
 #!/bin/sh
-# FattoreStreet host setup + operations runbook.
+# FattoreStreet container launch commands.
 #
 # SAFE TO COMMIT: no secret values live in this file. All app config/credentials
-# come from a single AWS Secrets Manager secret (fattorestreet/env); containers
-# are passed only its ARN via SECRETS_ARN (from deploy/.env, see .env.example)
-# and fetch the rest at start (see each image's docker-entrypoint.sh).
-#
-# The containers themselves are defined in the compose files next to this
-# script and are NOT started here:
-#   docker-compose.yml        app services (django, celery-worker, celery-beat,
-#                             springboot, nginx) -- the deploy unit
-#   docker-compose.infra.yml  stateful infra (postgres, redis, pgadmin4) --
-#                             never touched by a routine deploy
-#
-# This file is a copy/paste runbook, not a script to execute top-to-bottom.
+# come from a single AWS Secrets Manager secret (fattorestreet/env); each of our
+# containers is passed only its ARN via -e SECRETS_ARN and fetches the rest at
+# start (see each image's docker-entrypoint.sh). Fill in the placeholders below
+# (<...>) on the host before running.
 
-# ---------------------------------------------------------------------------
-# One-time host setup
-# ---------------------------------------------------------------------------
-
-# 1. Shared bridge network (both compose files reference it as external)
+# network
 sudo docker network create --driver bridge dockerNet
 
-# 2. Env file for compose: copy the template and fill in the real secret ARN
-cp .env.example .env
-
-# 3. Secrets: ALL app config lives in ONE Secrets Manager secret,
-# fattorestreet/env. Each container's entrypoint fetches this secret and
-# exports every key as an env var at start. Extra keys a given service doesn't
-# use are harmless. One-time setup (run with the REAL values; they are NOT
-# stored in this file):
+# ---------------------------------------------------------------------------
+# Secrets: ALL app config lives in ONE Secrets Manager secret, fattorestreet/env.
+# Each container is passed only -e SECRETS_ARN (+ -e AWS_REGION); its image's
+# docker-entrypoint.sh fetches this secret and exports every key as an env var at
+# start. Extra keys a given service doesn't use are harmless. One-time setup
+# (run with the REAL values; they are NOT stored in this file):
 #
 #   aws secretsmanager create-secret --name fattorestreet/env --secret-string '{
 #     "DATABASE": "postgresDocker",
@@ -49,19 +35,88 @@ cp .env.example .env
 #
 # Requires: EC2 instance role with secretsmanager:GetSecretValue on the secret,
 # and IMDSv2 hop limit >= 2 (see springboot/deploy/terraform README / the
-# secrets-from-arn skill).
+# secrets-from-arn skill). Substitute the secret's real ARN below.
+SECRETS_ARN=arn:aws:secretsmanager:us-east-1:<ACCOUNT_ID>:secret:fattorestreet/env-XXXXXX
+# ---------------------------------------------------------------------------
 
-# 4. Stateful infra (postgres, redis, pgadmin4). POSTGRES_PASSWORD is only read
-# on FIRST-TIME init of an empty /mnt/ebs/postgres-data volume -- see the
-# comments in docker-compose.infra.yml for the fetch-from-secret recipe.
-# PGADMIN_DEFAULT_PASSWORD seeds the pgadmin admin account on first run only.
-sudo docker compose -f docker-compose.infra.yml up -d
+# postgres
+# POSTGRES_PASSWORD is the single DB-password key: the postgres image reads it
+# ONLY during first-time init (empty data dir), and django + springboot use the
+# same key to connect. The volume below is already initialized, so the entrypoint
+# ignores it here -- the real password lives in the volume + in fattorestreet/env
+# (POSTGRES_PASSWORD).
+#
+# FRESH VOLUME ONLY: to re-initialize from an empty /mnt/ebs/postgres-data, the
+# password must be supplied once. Fetch it from the secret on the host (the EC2
+# instance role can read it) and pass it just for that run, e.g.:
+#   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
+#         --query SecretString --output text | jq -r .POSTGRES_PASSWORD)
+#   sudo docker run ... -e POSTGRES_PASSWORD="$PW" ... postgres:17
+sudo docker run -d \
+  --name postgres \
+  --network dockerNet \
+  -v /mnt/ebs/postgres-data:/var/lib/postgresql/data \
+  -p 0.0.0.0:5432:5432 \
+  postgres:17
 
-# 5. App services
-sudo docker compose up -d
+# django (config from fattorestreet/env via SECRETS_ARN)
+sudo docker run --name django --network dockerNet -d \
+  -e SECRETS_ARN=$SECRETS_ARN \
+  -e AWS_REGION=us-east-1 \
+  johnfattore/django
 
-# 6. Certbot get SSL cert (nginx must be up to serve the webroot challenge;
-# rerun to renew)
+# springboot (config from fattorestreet/env via SECRETS_ARN)
+sudo docker run --name springboot --network dockerNet -d \
+  -e SECRETS_ARN=$SECRETS_ARN \
+  -e AWS_REGION=us-east-1 \
+  johnfattore/springboot
+
+# nginx
+sudo docker run --name nginx --network dockerNet \
+  -v /mnt/ebs/certbot/letsencrypt:/etc/letsencrypt \
+  -v /mnt/ebs/certbot/www:/var/www/certbot \
+  -p 80:80 -p 443:443 \
+  --log-driver=awslogs \
+  --log-opt awslogs-region=us-east-1 \
+  --log-opt awslogs-group=nginx-logs \
+  --log-opt awslogs-stream=nginx-{{.ID}} \
+  -d johnfattore/nginx
+
+# Redis (major pinned like postgres above; bump deliberately with the
+# redis-py/django-redis client pins in django/pyproject.toml)
+sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
+
+# pgadmin4
+# PGADMIN_DEFAULT_PASSWORD seeds the admin account on first run only (persisted
+# thereafter). Supply the real value via the $PGADMIN_DEFAULT_PASSWORD env on the
+# host -- do NOT hardcode it here.
+sudo docker run -d \
+  --name pgadmin4 \
+  --network dockerNet \
+  -p 5050:80 \
+  -e PGADMIN_DEFAULT_EMAIL=johnefattore@gmail.com \
+  -e PGADMIN_DEFAULT_PASSWORD="$PGADMIN_DEFAULT_PASSWORD" \
+  dpage/pgadmin4
+
+# Celery beat worker (same image + secret as django; only the command differs)
+sudo docker run \
+  --name celery \
+  --network dockerNet \
+  -e SECRETS_ARN=$SECRETS_ARN \
+  -e AWS_REGION=us-east-1 \
+  -d johnfattore/django \
+  celery -A mysite worker --beat -E -n beat
+
+# Celery worker (same image + secret as django; only the command differs)
+sudo docker run \
+  --name celery \
+  --network dockerNet \
+  -e SECRETS_ARN=$SECRETS_ARN \
+  -e AWS_REGION=us-east-1 \
+  -d johnfattore/django \
+  celery -A mysite worker -E -n worker
+
+# Certbot get SSL cert
 sudo docker run --rm \
   --name certbot \
   --network dockerNet \
@@ -74,35 +129,49 @@ sudo docker run --rm \
   --email johnefattore@gmail.com \
   --agree-tos
 
-# ---------------------------------------------------------------------------
-# One-time cutover from the old docker-run/watchtower setup
-# ---------------------------------------------------------------------------
-# Watchtower is retired: deploys are now an explicit compose pull/up. Data is
-# safe -- postgres/certbot state lives in the /mnt/ebs bind mounts.
-#
-#   sudo docker stop watchtower && sudo docker rm watchtower
-#   sudo docker stop nginx django springboot celery postgres redis pgadmin4
-#   sudo docker rm   nginx django springboot celery postgres redis pgadmin4
-#   sudo docker compose -f docker-compose.infra.yml up -d
-#   sudo docker compose up -d
+# watchtower for updates, doesnt work maybe as well as i hope. if django restarts, nginx needs to as well
+sudo docker run -d \
+  --name watchtower \
+  --network dockerNet \
+  -e WATCHTOWER_POLL_INTERVAL=300 \
+  -e WATCHTOWER_CLEANUP=true \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower
 
 # ---------------------------------------------------------------------------
-# Routine operations (from this directory)
+# Teardown / maintenance
 # ---------------------------------------------------------------------------
+sudo docker stop postgres
+sudo docker container rm postgres
+sudo docker image rm postgres
 
-# deploy the latest pushed images
-sudo docker compose pull && sudo docker compose up -d
+sudo docker stop celery
+sudo docker container rm celery
 
-# apply Django migrations (one-shot container, same image + secret as django)
-sudo docker compose run --rm django python manage.py migrate
+sudo docker stop django
+sudo docker container rm django
+sudo docker image rm johnfattore/django
 
-# status / logs / shell
-sudo docker compose ps
-sudo docker compose logs -f django
+sudo docker stop springboot
+sudo docker container rm springboot
+sudo docker image rm johnfattore/springboot
+
+sudo docker stop nginx
+sudo docker container rm nginx
+sudo docker image rm johnfattore/nginx
+
+sudo docker stop pgadmin4
+sudo docker container rm pgadmin4
+sudo docker image rm dpage/pgadmin4
+
+sudo docker stop redis
+sudo docker container rm redis
+
+sudo docker stop watchtower
+sudo docker container rm watchtower
+
+# exec into django
 sudo docker exec -it django bash
 
-# stop the whole app (infra keeps running)
-sudo docker compose down
-
-# infra changes (rare; postgres/redis version bumps etc.)
-sudo docker compose -f docker-compose.infra.yml up -d
+# migrate database changes
+python3 manage.py migrate

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -1,21 +1,35 @@
 #!/bin/sh
-# FattoreStreet container launch commands.
+# FattoreStreet host setup + operations runbook.
 #
 # SAFE TO COMMIT: no secret values live in this file. All app config/credentials
-# come from a single AWS Secrets Manager secret (fattorestreet/env); each of our
-# containers is passed only its ARN via -e SECRETS_ARN and fetches the rest at
-# start (see each image's docker-entrypoint.sh). Fill in the placeholders below
-# (<...>) on the host before running.
-
-# network
-sudo docker network create --driver bridge dockerNet
+# come from a single AWS Secrets Manager secret (fattorestreet/env); containers
+# are passed only its ARN via SECRETS_ARN (from deploy/.env, see .env.example)
+# and fetch the rest at start (see each image's docker-entrypoint.sh).
+#
+# The containers themselves are defined in the compose files next to this
+# script and are NOT started here:
+#   docker-compose.yml        app services (django, celery-worker, celery-beat,
+#                             springboot, nginx) -- the deploy unit
+#   docker-compose.infra.yml  stateful infra (postgres, redis, pgadmin4) --
+#                             never touched by a routine deploy
+#
+# This file is a copy/paste runbook, not a script to execute top-to-bottom.
 
 # ---------------------------------------------------------------------------
-# Secrets: ALL app config lives in ONE Secrets Manager secret, fattorestreet/env.
-# Each container is passed only -e SECRETS_ARN (+ -e AWS_REGION); its image's
-# docker-entrypoint.sh fetches this secret and exports every key as an env var at
-# start. Extra keys a given service doesn't use are harmless. One-time setup
-# (run with the REAL values; they are NOT stored in this file):
+# One-time host setup
+# ---------------------------------------------------------------------------
+
+# 1. Shared bridge network (both compose files reference it as external)
+sudo docker network create --driver bridge dockerNet
+
+# 2. Env file for compose: copy the template and fill in the real secret ARN
+cp .env.example .env
+
+# 3. Secrets: ALL app config lives in ONE Secrets Manager secret,
+# fattorestreet/env. Each container's entrypoint fetches this secret and
+# exports every key as an env var at start. Extra keys a given service doesn't
+# use are harmless. One-time setup (run with the REAL values; they are NOT
+# stored in this file):
 #
 #   aws secretsmanager create-secret --name fattorestreet/env --secret-string '{
 #     "DATABASE": "postgresDocker",
@@ -35,88 +49,19 @@ sudo docker network create --driver bridge dockerNet
 #
 # Requires: EC2 instance role with secretsmanager:GetSecretValue on the secret,
 # and IMDSv2 hop limit >= 2 (see springboot/deploy/terraform README / the
-# secrets-from-arn skill). Substitute the secret's real ARN below.
-SECRETS_ARN=arn:aws:secretsmanager:us-east-1:<ACCOUNT_ID>:secret:fattorestreet/env-XXXXXX
-# ---------------------------------------------------------------------------
+# secrets-from-arn skill).
 
-# postgres
-# POSTGRES_PASSWORD is the single DB-password key: the postgres image reads it
-# ONLY during first-time init (empty data dir), and django + springboot use the
-# same key to connect. The volume below is already initialized, so the entrypoint
-# ignores it here -- the real password lives in the volume + in fattorestreet/env
-# (POSTGRES_PASSWORD).
-#
-# FRESH VOLUME ONLY: to re-initialize from an empty /mnt/ebs/postgres-data, the
-# password must be supplied once. Fetch it from the secret on the host (the EC2
-# instance role can read it) and pass it just for that run, e.g.:
-#   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
-#         --query SecretString --output text | jq -r .POSTGRES_PASSWORD)
-#   sudo docker run ... -e POSTGRES_PASSWORD="$PW" ... postgres:17
-sudo docker run -d \
-  --name postgres \
-  --network dockerNet \
-  -v /mnt/ebs/postgres-data:/var/lib/postgresql/data \
-  -p 0.0.0.0:5432:5432 \
-  postgres:17
+# 4. Stateful infra (postgres, redis, pgadmin4). POSTGRES_PASSWORD is only read
+# on FIRST-TIME init of an empty /mnt/ebs/postgres-data volume -- see the
+# comments in docker-compose.infra.yml for the fetch-from-secret recipe.
+# PGADMIN_DEFAULT_PASSWORD seeds the pgadmin admin account on first run only.
+sudo docker compose -f docker-compose.infra.yml up -d
 
-# django (config from fattorestreet/env via SECRETS_ARN)
-sudo docker run --name django --network dockerNet -d \
-  -e SECRETS_ARN=$SECRETS_ARN \
-  -e AWS_REGION=us-east-1 \
-  johnfattore/django
+# 5. App services
+sudo docker compose up -d
 
-# springboot (config from fattorestreet/env via SECRETS_ARN)
-sudo docker run --name springboot --network dockerNet -d \
-  -e SECRETS_ARN=$SECRETS_ARN \
-  -e AWS_REGION=us-east-1 \
-  johnfattore/springboot
-
-# nginx
-sudo docker run --name nginx --network dockerNet \
-  -v /mnt/ebs/certbot/letsencrypt:/etc/letsencrypt \
-  -v /mnt/ebs/certbot/www:/var/www/certbot \
-  -p 80:80 -p 443:443 \
-  --log-driver=awslogs \
-  --log-opt awslogs-region=us-east-1 \
-  --log-opt awslogs-group=nginx-logs \
-  --log-opt awslogs-stream=nginx-{{.ID}} \
-  -d johnfattore/nginx
-
-# Redis (major pinned like postgres above; bump deliberately with the
-# redis-py/django-redis client pins in django/pyproject.toml)
-sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
-
-# pgadmin4
-# PGADMIN_DEFAULT_PASSWORD seeds the admin account on first run only (persisted
-# thereafter). Supply the real value via the $PGADMIN_DEFAULT_PASSWORD env on the
-# host -- do NOT hardcode it here.
-sudo docker run -d \
-  --name pgadmin4 \
-  --network dockerNet \
-  -p 5050:80 \
-  -e PGADMIN_DEFAULT_EMAIL=johnefattore@gmail.com \
-  -e PGADMIN_DEFAULT_PASSWORD="$PGADMIN_DEFAULT_PASSWORD" \
-  dpage/pgadmin4
-
-# Celery beat worker (same image + secret as django; only the command differs)
-sudo docker run \
-  --name celery \
-  --network dockerNet \
-  -e SECRETS_ARN=$SECRETS_ARN \
-  -e AWS_REGION=us-east-1 \
-  -d johnfattore/django \
-  celery -A mysite worker --beat -E -n beat
-
-# Celery worker (same image + secret as django; only the command differs)
-sudo docker run \
-  --name celery \
-  --network dockerNet \
-  -e SECRETS_ARN=$SECRETS_ARN \
-  -e AWS_REGION=us-east-1 \
-  -d johnfattore/django \
-  celery -A mysite worker -E -n worker
-
-# Certbot get SSL cert
+# 6. Certbot get SSL cert (nginx must be up to serve the webroot challenge;
+# rerun to renew)
 sudo docker run --rm \
   --name certbot \
   --network dockerNet \
@@ -129,49 +74,35 @@ sudo docker run --rm \
   --email johnefattore@gmail.com \
   --agree-tos
 
-# watchtower for updates, doesnt work maybe as well as i hope. if django restarts, nginx needs to as well
-sudo docker run -d \
-  --name watchtower \
-  --network dockerNet \
-  -e WATCHTOWER_POLL_INTERVAL=300 \
-  -e WATCHTOWER_CLEANUP=true \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  containrrr/watchtower
+# ---------------------------------------------------------------------------
+# One-time cutover from the old docker-run/watchtower setup
+# ---------------------------------------------------------------------------
+# Watchtower is retired: deploys are now an explicit compose pull/up. Data is
+# safe -- postgres/certbot state lives in the /mnt/ebs bind mounts.
+#
+#   sudo docker stop watchtower && sudo docker rm watchtower
+#   sudo docker stop nginx django springboot celery postgres redis pgadmin4
+#   sudo docker rm   nginx django springboot celery postgres redis pgadmin4
+#   sudo docker compose -f docker-compose.infra.yml up -d
+#   sudo docker compose up -d
 
 # ---------------------------------------------------------------------------
-# Teardown / maintenance
+# Routine operations (from this directory)
 # ---------------------------------------------------------------------------
-sudo docker stop postgres
-sudo docker container rm postgres
-sudo docker image rm postgres
 
-sudo docker stop celery
-sudo docker container rm celery
+# deploy the latest pushed images
+sudo docker compose pull && sudo docker compose up -d
 
-sudo docker stop django
-sudo docker container rm django
-sudo docker image rm johnfattore/django
+# apply Django migrations (one-shot container, same image + secret as django)
+sudo docker compose run --rm django python manage.py migrate
 
-sudo docker stop springboot
-sudo docker container rm springboot
-sudo docker image rm johnfattore/springboot
-
-sudo docker stop nginx
-sudo docker container rm nginx
-sudo docker image rm johnfattore/nginx
-
-sudo docker stop pgadmin4
-sudo docker container rm pgadmin4
-sudo docker image rm dpage/pgadmin4
-
-sudo docker stop redis
-sudo docker container rm redis
-
-sudo docker stop watchtower
-sudo docker container rm watchtower
-
-# exec into django
+# status / logs / shell
+sudo docker compose ps
+sudo docker compose logs -f django
 sudo docker exec -it django bash
 
-# migrate database changes
-python3 manage.py migrate
+# stop the whole app (infra keeps running)
+sudo docker compose down
+
+# infra changes (rare; postgres/redis version bumps etc.)
+sudo docker compose -f docker-compose.infra.yml up -d

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,48 +4,38 @@ The **Portfolio Manager** is designed to be cloud-agnostic but is currently opti
 
 ## ☁️ Production Hosting (AWS)
 
-The production environment currently uses:
-- **AWS Fargate (ECS)**: Runs the application containers (Gunicorn & Nginx).
-- **AWS RDS**: Managed PostgreSQL database.
-- **Application Load Balancer (ALB)**: Handles HTTPS termination and traffic routing.
-- **Route 53**: DNS management.
+The production environment runs on a single EC2 instance behind Route 53:
+- **EC2 instance**: Runs all containers on a shared Docker bridge network (`dockerNet`).
+- **Nginx container**: Terminates SSL (Let's Encrypt via certbot), serves the React build and Django static files, and reverse-proxies to Django and Spring Boot.
+- **EBS volume** (`/mnt/ebs`): Persists PostgreSQL data and certbot certificates across container recreation.
+- **Route 53**: DNS management — `A` record points to the EC2 instance.
+- **Secrets Manager**: One secret (`fattorestreet/env`) holds all app config/credentials. Containers receive only its ARN (`SECRETS_ARN`); each image's entrypoint fetches and exports the values at start. The EC2 instance role grants `secretsmanager:GetSecretValue`.
 
 ### Dev Ops System Overview
-1.  **DNS (Route 53)**:
-    - `A` record points to the ALB.
-    - `CNAME` validates the SSL certificate.
-2.  **Load Balancer (ALB)**:
-    - Listeners on Port 80 (HTTP) redirect to Port 443 (HTTPS).
-    - Port 443 forwards to the Fargate service Target Group.
-3.  **Fargate Service**:
-    - **Nginx Container**: Reverse proxy, serves static files (React build), forwards API requests to Gunicorn.
-    - **Gunicorn Container**: Runs the Django WSGI server.
-4.  **Database**:
-    - Gunicorn communicates with RDS (Postgres) via private VPC networking.
+1.  **DNS (Route 53)**: `A` record points to the EC2 instance's public IP.
+2.  **Nginx (ports 80/443)**: Port 80 serves ACME challenges and redirects to HTTPS; port 443 terminates SSL and routes `/django/`, `/springboot/`, `/pgadmin4/`, and static paths (see `nginx/nginx.conf`).
+3.  **App containers**: Django (Gunicorn), two Celery containers (worker + beat), Spring Boot.
+4.  **Data stores**: PostgreSQL 17 and Redis 8 containers on the same Docker network, with Postgres data on the EBS volume.
 
-### Domain Naming
-- **Certificate**: `*.fattore.com` (Wildcard support).
-- **Hosted Zone**: `fattorestreet.com`.
+## 🚀 Build & Deploy
 
-## 🚀 CI/CD Pipeline
+- **CI**: GitHub Actions (`.github/workflows/ci.yml`) runs frontend, Django, and Spring Boot tests plus a secret scan on every push/PR to `main`.
+- **Build**: `deploy/build.sh` re-runs all tests, builds the React app and the three Docker images (`johnfattore/{nginx,django,springboot}`), and pushes them to Docker Hub.
+- **Deploy**: Docker Compose on the EC2 host, from the `deploy/` directory:
+  - `docker-compose.yml` — the deploy unit: `django`, `celery-worker`, `celery-beat`, `springboot`, `nginx`. Deploy = `docker compose pull && docker compose up -d`.
+  - `docker-compose.infra.yml` — stateful infra: `postgres`, `redis`, `pgadmin4`. Never touched by a routine deploy; managed explicitly with `docker compose -f docker-compose.infra.yml up -d`.
+  - `SECRETS_ARN`/`AWS_REGION` come from `deploy/.env` on the host (template: `deploy/.env.example`).
+- **Migrations**: `docker compose run --rm django python manage.py migrate` after deploying a release that changes models.
+- **Runbook**: `deploy/run.sh` documents one-time host setup (network, secret creation, certbot) and the routine deploy/migrate/logs commands.
 
-The project uses a continuous integration and deployment pipeline.
-- **Build**: `kubernetes/build.sh` script handles building Docker images.
-- **Watchtower**: A container running in the cluster monitors for new image versions and automatically updates the running services.
-- **Tests**: Automated tests run for both Django and React before build.
-
-## 📦 Kubernetes
-
-While currently running via ECS/Docker Compose strategies, the `kubernetes/` folder contains manifests for migrating to a full K8s cluster.
-- This allows for auto-scaling of pods if traffic increases.
-- Useful for managing the complex interaction between Celery workers, Redis, and the Web server.
+Watchtower-based auto-updates are retired: deploys are an explicit, ordered `compose pull && up -d`, so nginx and the backends restart in a coordinated way.
 
 ## 🔄 Environments
 
 ### Staging
 - **Goal**: Mirror production as closely as possible.
 - **Config**: Uses `nginx.conf` (local), updates Port mappings.
-- **Network**: Docker Bridge network (172.x.x.x) vs Host networking in some AWS configurations.
+- **Network**: Docker Bridge network (172.x.x.x), same as production.
 
 ### Production
-- **Config**: Uses production `nginx.conf` with SSL termination handled by ALB (so Nginx sees HTTP).
+- **Config**: Uses production `nginx.conf`; SSL terminates at Nginx with Let's Encrypt certificates renewed via certbot (webroot challenge).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,7 +26,7 @@ The production environment runs on a single EC2 instance behind Route 53:
   - `docker-compose.infra.yml` — stateful infra: `postgres`, `redis`, `pgadmin4`. Never touched by a routine deploy; managed explicitly with `docker compose -f docker-compose.infra.yml up -d`.
   - `SECRETS_ARN`/`AWS_REGION` come from `deploy/.env` on the host (template: `deploy/.env.example`).
 - **Migrations**: `docker compose run --rm django python manage.py migrate` after deploying a release that changes models.
-- **Runbook**: `deploy/run.sh` documents one-time host setup (network, secret creation, certbot) and the routine deploy/migrate/logs commands.
+- **Runbook**: `deploy/compose.sh` documents one-time host setup, the cutover from the old docker-run/watchtower setup, and the routine deploy/migrate/logs commands. `deploy/run.sh` is kept as reference for the pre-Compose setup (including secret creation and certbot commands).
 
 Watchtower-based auto-updates are retired: deploys are an explicit, ordered `compose pull && up -d`, so nginx and the backends restart in a coordinated way.
 


### PR DESCRIPTION
## Summary
- Adds `deploy/docker-compose.yml` as the app deploy unit (`django`, `celery-worker`, `celery-beat`, `springboot`, `nginx`) on the existing external `dockerNet` network; app config still comes from the single Secrets Manager secret via `SECRETS_ARN` (now supplied through `deploy/.env`, template in `deploy/.env.example`)
- Adds `deploy/docker-compose.infra.yml` for stateful infra (`postgres:17`, `redis:8`, `pgadmin4`) — never touched by a routine deploy
- Adds `deploy/docker-compose.dev.yml`, a **local development deployment**: builds django/springboot from source, plain dev env vars (no Secrets Manager), stock nginx on `http://localhost` (`nginx/nginx.dev.conf`, no SSL) serving a frontend built with the new committed `--mode compose` Vite env
- Adds `deploy/compose.sh`, a runbook for the Compose workflows: one-time host setup, cutover from the old docker-run/watchtower setup, routine deploy/migrate/logs commands, and the local dev commands. `deploy/run.sh` is kept unchanged as reference for the current live setup
- Retires watchtower: deploys become an explicit `docker compose pull && docker compose up -d`, so nginx and the backends restart in coordinated order
- Fixes the latent duplicate `celery` container name from `run.sh` (worker and beat now have distinct names)
- **Fixes Flyway silently disabled since the Spring Boot 4 migration**: Boot 4 moved Flyway auto-configuration into `spring-boot-starter-flyway`; with bare `flyway-core` it never ran (unnoticed in prod because the schema already exists — surfaced by the dev stack's empty database). Also sets `spring.flyway.baseline-on-migrate=true` so a pre-Flyway prod database baselines at V1 instead of failing
- Updates `docs/DEPLOYMENT.md` and `docs/GETTING_STARTED.md` to match (removes stale Fargate/Kubernetes/watchtower claims and the outdated Docker staging section)

## Test plan
- [x] `docker compose config` renders all three files cleanly with the expected services
- [x] Every flag from the old `docker run` commands mapped to a compose key (ports, volumes, env, network, awslogs driver, celery commands); the `awslogs-stream=nginx-{{.ID}}` option became the `tag: nginx-{{.ID}}` log option, which Docker actually templates
- [x] Dev stack brought up end-to-end locally: React app serves at `http://localhost` (compose-mode API URLs verified in the bundle), Django admin redirects + static CSS 200s through nginx, migrations apply, Flyway creates `flyway_schema_history` and applies `V1__initial_schema.sql` on the fresh database, Spring Boot starts and answers through the proxy
- [x] `mvn test` after the Flyway dependency change: 279 tests, 0 failures
- [ ] On-host cutover (post-merge, per the runbook in `deploy/compose.sh`): stop/remove watchtower and old containers, bring up infra then app compose, verify site

🤖 Generated with [Claude Code](https://claude.com/claude-code)