### PR TITLE
Add local dev Compose deployment; fix Flyway disabled since Boot 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ react-app/node_modules
 react-app/dist
 .env.*
 !deploy/.env.example
+!react-app/.env.compose
 react-app/coverage
 react-app/.sass-cache
 react-app/src/styles/custom.css

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -72,3 +72,31 @@ sudo docker compose down
 
 # infra changes (rare; postgres/redis version bumps etc.)
 sudo docker compose -f docker-compose.infra.yml up -d
+
+# ---------------------------------------------------------------------------
+# Local development deployment (docker-compose.dev.yml)
+# ---------------------------------------------------------------------------
+# Approximates production on a dev machine: builds django/springboot from
+# source, plain dev env vars instead of Secrets Manager, stock nginx on
+# http://localhost (no SSL). No sudo needed with Docker Desktop.
+
+# 1. Build the frontend for the compose mode (URLs point at http://localhost)
+#    and collect Django static files -- nginx bind-mounts both:
+#      cd react-app
+#      npx sass src/styles/custom.scss src/styles/custom.css
+#      npx vite build --mode compose --emptyOutDir
+#      cd ../django && uv run python manage.py collectstatic --noinput
+
+# 2. Build images + start the stack (from deploy/)
+docker compose -f docker-compose.dev.yml up -d --build
+
+# 3. Apply Django migrations (Spring Boot's Flyway migrates itself on start)
+docker compose -f docker-compose.dev.yml run --rm django python manage.py migrate
+
+# App: http://localhost  |  Django admin: http://localhost/django/admin/
+
+# status / logs / teardown (-v also wipes the dev database volume)
+docker compose -f docker-compose.dev.yml ps
+docker compose -f docker-compose.dev.yml logs -f django
+docker compose -f docker-compose.dev.yml down
+docker compose -f docker-compose.dev.yml down -v

--- a/deploy/dev-init/springboot-db.sql
+++ b/deploy/dev-init/springboot-db.sql
@@ -1,0 +1,4 @@
+-- Runs on first-time init of the dev postgres volume only. Django uses the
+-- default "postgres" database; Spring Boot expects its own (Flyway migrates
+-- the schema on app start).
+CREATE DATABASE springboot;

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -18,15 +18,15 @@ name: fattorestreet-dev
 
 x-django-env: &django-env
   DATABASE: postgresDocker
-  POSTGRES_PASSWORD: postgres
-  SECRET_KEY: dev-only-secret-key-do-not-use-in-production
+  POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
+  SECRET_KEY: dev-only-secret-key-do-not-use-in-production  # pragma: allowlist secret
   DEBUG: "True"
   REDIS_URL: redis://redis:6379
   DJANGO_FORCE_SCRIPT_NAME: /django
   HOME_URL: http://localhost/
   SPRINGBOOT_BASE_URL: http://springboot:8080/
   # chatbot views read this at request time; a dummy breaks only the chatbot
-  GOOGLE_API_KEY: dev-dummy-google-api-key
+  GOOGLE_API_KEY: dev-dummy-google-api-key  # pragma: allowlist secret
 
 services:
   postgres:
@@ -37,7 +37,7 @@ services:
       # the default "postgres" db); Flyway migrates the schema on app start
       - ./dev-init:/docker-entrypoint-initdb.d:ro
     environment:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
     restart: unless-stopped
 
   redis:
@@ -67,10 +67,10 @@ services:
   springboot:
     build: ../springboot
     environment:
-      SECRET_KEY: dev-only-secret-key-do-not-use-in-production
+      SECRET_KEY: dev-only-secret-key-do-not-use-in-production  # pragma: allowlist secret
       DB_URL: jdbc:postgresql://postgres:5432/springboot
       DB_USERNAME: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
       SEC_CONTACT_EMAIL: johnefattore@gmail.com
       DJANGO_PORTFOLIO_BASE_URL: http://django:8000
       # llama.cpp runs on the host, not in compose

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,0 +1,93 @@
+# FattoreStreet local development deployment -- approximates production on a
+# dev machine. Differences from the production files (docker-compose.yml +
+# docker-compose.infra.yml), which stay untouched:
+#
+#   - django/springboot images are BUILT from local source, not pulled
+#   - config is plain env vars below (no SECRETS_ARN / Secrets Manager;
+#     the entrypoints skip the fetch when SECRETS_ARN is unset)
+#   - stock nginx with nginx.dev.conf + the built frontend bind-mounted
+#     (port 80, no SSL) instead of the baked johnfattore/nginx image
+#   - postgres/redis use a named volume and stay unpublished; the app talks
+#     to them over the compose network
+#   - default json-file logging (no awslogs), own isolated network
+#
+# Prerequisites + commands: see the "Local development deployment" section in
+# compose.sh. All values below are dev-only defaults -- nothing secret.
+
+name: fattorestreet-dev
+
+x-django-env: &django-env
+  DATABASE: postgresDocker
+  POSTGRES_PASSWORD: postgres
+  SECRET_KEY: dev-only-secret-key-do-not-use-in-production
+  DEBUG: "True"
+  REDIS_URL: redis://redis:6379
+  DJANGO_FORCE_SCRIPT_NAME: /django
+  HOME_URL: http://localhost/
+  SPRINGBOOT_BASE_URL: http://springboot:8080/
+  # chatbot views read this at request time; a dummy breaks only the chatbot
+  GOOGLE_API_KEY: dev-dummy-google-api-key
+
+services:
+  postgres:
+    image: postgres:17
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      # creates the extra "springboot" database on first init (django uses
+      # the default "postgres" db); Flyway migrates the schema on app start
+      - ./dev-init:/docker-entrypoint-initdb.d:ro
+    environment:
+      POSTGRES_PASSWORD: postgres
+    restart: unless-stopped
+
+  redis:
+    image: redis:8
+    restart: unless-stopped
+
+  django:
+    build: ../django
+    environment: *django-env
+    depends_on: [postgres, redis]
+    restart: unless-stopped
+
+  celery-worker:
+    build: ../django
+    command: celery -A mysite worker -E -n worker
+    environment: *django-env
+    depends_on: [postgres, redis]
+    restart: unless-stopped
+
+  celery-beat:
+    build: ../django
+    command: celery -A mysite worker --beat -E -n beat
+    environment: *django-env
+    depends_on: [postgres, redis]
+    restart: unless-stopped
+
+  springboot:
+    build: ../springboot
+    environment:
+      SECRET_KEY: dev-only-secret-key-do-not-use-in-production
+      DB_URL: jdbc:postgresql://postgres:5432/springboot
+      DB_USERNAME: postgres
+      POSTGRES_PASSWORD: postgres
+      SEC_CONTACT_EMAIL: johnefattore@gmail.com
+      DJANGO_PORTFOLIO_BASE_URL: http://django:8000
+      # llama.cpp runs on the host, not in compose
+      LLM_SERVER_URL: http://host.docker.internal:8081
+    depends_on: [postgres]
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.31
+    ports:
+      - "80:80"
+    volumes:
+      - ../nginx/nginx.dev.conf:/etc/nginx/nginx.conf:ro
+      - ../nginx/dist:/var/www/dist:ro
+      - ../nginx/static:/var/www/static:ro
+    depends_on: [django, springboot]
+    restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -32,6 +32,10 @@ Watchtower-based auto-updates are retired: deploys are an explicit, ordered `com
 
 ## 🔄 Environments
 
+### Local (Compose)
+- **Goal**: Approximate production on a dev machine (for day-to-day coding, the dev servers — `npm run dev`, `runserver`, `spring-boot:run` — remain the primary loop).
+- **Config**: `deploy/docker-compose.dev.yml` — builds django/springboot from source, plain dev env vars instead of Secrets Manager, stock nginx on `http://localhost` with `nginx/nginx.dev.conf` (no SSL) and the frontend built via `npx vite build --mode compose`. Commands in `deploy/compose.sh`.
+
 ### Staging
 - **Goal**: Mirror production as closely as possible.
 - **Config**: Uses `nginx.conf` (local), updates Port mappings.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -96,29 +96,32 @@ We use Sass for custom styling of React Bootstrap.
 
 ---
 
-## 🐳 Running with Docker (Staging Setup)
+## 🐳 Running with Docker (Local Compose Deployment)
 
-To replicate the production environment locally using Docker:
+To approximate the production environment locally, use `deploy/docker-compose.dev.yml` — it builds Django/Spring Boot from source, uses plain dev env vars (no AWS Secrets Manager), and serves everything through nginx at `http://localhost`.
 
-1.  **Navigate to the django directory** (where `docker-compose.yml` resides - *Note: Verify if compose file is in root or django dir, assuming django based on previous readme*):
+1.  **Build the frontend and static files** (nginx bind-mounts them):
     ```bash
-    cd django
+    cd react-app
+    npx sass src/styles/custom.scss src/styles/custom.css
+    npx vite build --mode compose --emptyOutDir
+    cd ../django && uv run python manage.py collectstatic --noinput
     ```
 
-2.  **Build and Start Containers:**
+2.  **Build images and start the stack:**
     ```bash
-    docker compose up --build
+    cd deploy
+    docker compose -f docker-compose.dev.yml up -d --build
+    docker compose -f docker-compose.dev.yml run --rm django python manage.py migrate
     ```
-    This spins up:
-    - **Nginx** (Reverse Proxy)
-    - **Gunicorn** (Django App)
-    - **Postgres** (Database)
+    This spins up nginx, Django (Gunicorn), two Celery containers, Spring Boot (Flyway migrates its schema on start), Postgres 17, and Redis 8. Open `http://localhost`.
 
-3.  **Run Frontend (Staging Mode):**
-    In `react-app/`:
+3.  **Teardown** (`-v` also wipes the dev database volume):
     ```bash
-    npm run staging
+    docker compose -f docker-compose.dev.yml down -v
     ```
+
+Full command reference: [`deploy/compose.sh`](../deploy/compose.sh).
 
 ---
 

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,0 +1,48 @@
+# Dev variant of nginx.conf for the local compose deployment
+# (deploy/docker-compose.dev.yml): port 80 only, no SSL/certbot/pgadmin,
+# same proxy routes as production.
+events {}
+http {
+    include    mime.types;
+
+    proxy_buffer_size       16k;
+    proxy_buffers           8 32k;
+    proxy_busy_buffers_size 64k;
+    proxy_temp_file_write_size 64k;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        # Docker embedded DNS – re-resolve upstream hostnames every 10s
+        resolver 127.0.0.11 valid=10s;
+
+        location / {
+            root /var/www/dist;
+            # accomidates react router
+            try_files $uri /index.html;
+        }
+
+        location /django/ {
+            set $upstream_django http://django:8000;
+            rewrite ^/django(/.*)$ $1 break;
+            proxy_pass $upstream_django;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_redirect off;
+        }
+
+        location /springboot/ {
+            set $upstream_springboot http://springboot:8080;
+            rewrite ^/springboot(/.*)$ $1 break;
+            proxy_pass $upstream_springboot;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_redirect off;
+        }
+
+        location /static/ {
+            root /var/www;
+        }
+    }
+}

--- a/react-app/.env.compose
+++ b/react-app/.env.compose
@@ -1,0 +1,7 @@
+# Vite mode for the local compose deployment (deploy/docker-compose.dev.yml):
+# the app is served by nginx on http://localhost, with Django and Spring Boot
+# proxied under path prefixes. Build with: npx vite build --mode compose
+# No secrets here -- committed on purpose (unlike the other .env.* modes).
+VITE_APP_DJANGO_URL="http://localhost/django/"
+VITE_APP_FINNHUB_URL="https://finnhub.io/api/v1/"
+VITE_APP_SPRINGBOOT_URL="http://localhost/springboot/"

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -35,10 +35,10 @@ Application code under `com.fattorestreet.sec_api`: `client` (SEC HTTP / `WebSer
 
 ### Database migrations
 
-- **[Flyway](https://flywaydb.org/)** (`flyway-core` + `flyway-database-postgresql`) runs migrations from [`src/main/resources/db/migration`](src/main/resources/db/migration) at startup, before Hibernate initializes.
+- **[Flyway](https://flywaydb.org/)** (`spring-boot-starter-flyway` + `flyway-database-postgresql`; Boot 4 moved the auto-configuration into this per-feature starter, so bare `flyway-core` no longer activates it) runs migrations from [`src/main/resources/db/migration`](src/main/resources/db/migration) at startup, before Hibernate initializes.
 - **`spring.jpa.hibernate.ddl-auto=validate`** — Hibernate checks the schema against entities but does not alter tables. Any entity change needs a **new Flyway migration** (for example `V2__...sql`).
 - **Initial install (empty PostgreSQL):** Flyway applies `V1__initial_schema.sql` (base tables + Hibernate Envers `revinfo` and `*_aud` tables).
-- **Existing database** that already matches the app but has no `flyway_schema_history` table: use Flyway **baseline** so duplicate DDL is not applied — for example set `spring.flyway.baseline-on-migrate=true` (and align `spring.flyway.baseline-version` with your situation) or run the Flyway baseline command against that database, then use `V2+` for future changes. Coordinate with your deployment process so greenfield and brownfield paths stay consistent.
+- **Existing database** that already matches the app but has no `flyway_schema_history` table: `application.properties` sets `spring.flyway.baseline-on-migrate=true`, so Flyway baselines at V1 instead of re-applying duplicate DDL; future changes go in `V2+`. A fresh (empty) database still runs `V1__initial_schema.sql` normally.
 - **Tests:** the `test` profile sets `spring.flyway.enabled=false` and uses H2 with `ddl-auto=create-drop`, so Hibernate builds the schema in memory and tests do not require PostgreSQL or Flyway.
 
 ## Data Licensing Policy

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -35,9 +35,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+		<!-- Boot 4 moved Flyway auto-configuration into the per-feature
+		     spring-boot-flyway module; bare flyway-core no longer activates it -->
 		<dependency>
-			<groupId>org.flywaydb</groupId>
-			<artifactId>flyway-core</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-flyway</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>

--- a/springboot/src/main/resources/application.properties
+++ b/springboot/src/main/resources/application.properties
@@ -15,6 +15,9 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=validate
+# On a database that predates Flyway (schema exists, no flyway_schema_history),
+# baseline at V1 instead of failing; a fresh database runs V1__initial_schema.sql.
+spring.flyway.baseline-on-migrate=true
 spring.jpa.show-sql=${SHOW_JPA_SQL:false}
 spring.jpa.open-in-view=false
 


### PR DESCRIPTION
Follow-up to #59 (these two commits were pushed after it merged).

## Summary
- Adds `deploy/docker-compose.dev.yml`, a **local development deployment** approximating production on a dev machine: django/celery/springboot built from source, plain dev env vars (no Secrets Manager — the entrypoints skip the fetch when `SECRETS_ARN` is unset), postgres 17 + redis 8 on a named volume, and stock nginx on `http://localhost` via the new `nginx/nginx.dev.conf` (port 80, no SSL, same proxy routes as prod)
- Adds a committed `react-app/.env.compose` Vite mode so `npx vite build --mode compose --emptyOutDir` bakes `http://localhost/django/`-style URLs into the bundle (gitignore negation included)
- Adds `deploy/dev-init/springboot-db.sql` (creates the `springboot` database on first postgres init) and dev commands in `deploy/compose.sh`; replaces the stale Docker section in `docs/GETTING_STARTED.md`
- **Fixes Flyway silently disabled since the Spring Boot 4 migration**: Boot 4 moved Flyway auto-configuration into the per-feature `spring-boot-starter-flyway` module, so bare `flyway-core` never activated it — unnoticed in prod because the schema already exists, but any future entity change would have failed `ddl-auto=validate` with no migration having run. Surfaced by the dev stack's empty database. Also sets `spring.flyway.baseline-on-migrate=true` so a pre-Flyway database baselines at V1 instead of failing on the next deploy

## Test plan
- [x] Dev stack brought up end-to-end locally: React serves at `http://localhost` (compose-mode API URLs verified in the bundle), Django admin + static 200 through nginx, migrations apply, Flyway creates `flyway_schema_history` and applies `V1__initial_schema.sql` on the fresh database, Spring Boot starts and answers through the proxy
- [x] `mvn test` after the Flyway dependency change: 279 tests, 0 failures
- [x] `docker compose -f docker-compose.dev.yml config` renders cleanly with the expected services

🤖 Generated with [Claude Code](https://claude.com/claude-code)