### PR TITLE
Build Docker images in CI as a PR merge check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Context filter for repo-root builds (nginx/Dockerfile). Whitelist style:
+# only the three directories that build needs, minus their local artifacts --
+# keeps the context small and stale gitignored files (nginx/dist, custom.css)
+# out of the image. django's own build uses django/ as context with its own
+# django/.dockerignore.
+*
+!django
+!nginx
+!react-app
+django/.venv
+django/db.sqlite3
+django/**/__pycache__
+nginx/dist
+nginx/static
+react-app/node_modules
+react-app/coverage
+react-app/src/styles/custom.css
+react-app/src/styles/custom.css.map

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,51 @@
+name: Docker images
+
+# Builds all three production images as a merge check: every PR (and push to
+# main) proves the Dockerfiles still build from a clean checkout. Images are
+# NOT pushed anywhere -- publishing is a separate concern (deploy/build.sh
+# today; a publish job can extend this later).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # nginx builds the React bundle + Django static inside the image,
+          # so it needs the repo root as context
+          - image: nginx
+            context: .
+            dockerfile: nginx/Dockerfile
+          - image: django
+            context: django
+            dockerfile: django/Dockerfile
+          - image: springboot
+            context: springboot
+            dockerfile: springboot/Dockerfile
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
+          tags: johnfattore/${{ matrix.image }}:ci
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ react-app/dist
 .env.*
 !deploy/.env.example
 !react-app/.env.compose
+# public URLs only (no secrets); committed so the hermetic nginx image build
+# produces the real production bundle from a clean checkout
+!react-app/.env.production
 react-app/coverage
 react-app/.sass-cache
 react-app/src/styles/custom.css

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -19,7 +19,7 @@ The production environment runs on a single EC2 instance behind Route 53:
 
 ## 🚀 Build & Deploy
 
-- **CI**: GitHub Actions (`.github/workflows/ci.yml`) runs frontend, Django, and Spring Boot tests plus a secret scan on every push/PR to `main`.
+- **CI**: GitHub Actions (`.github/workflows/ci.yml`) runs frontend, Django, and Spring Boot tests plus a secret scan on every push/PR to `main`. A second workflow (`.github/workflows/docker-build.yml`) builds all three Docker images on the same triggers as a merge check (build-only, no push); the nginx image builds the React bundle and Django static files itself, so it works from a clean checkout.
 - **Build**: `deploy/build.sh` re-runs all tests, builds the React app and the three Docker images (`johnfattore/{nginx,django,springboot}`), and pushes them to Docker Hub.
 - **Deploy**: Docker Compose on the EC2 host, from the `deploy/` directory:
   - `docker-compose.yml` — the deploy unit: `django`, `celery-worker`, `celery-beat`, `springboot`, `nginx`. Deploy = `docker compose pull && docker compose up -d`.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -136,6 +136,8 @@ On every push and pull request to `main`, [`.github/workflows/ci.yml`](../.githu
 - **Spring Boot** (`springboot/`): `mvn test` (H2 in-memory for tests). Local runs need `SECRET_KEY` in `.env` (same as Django) so JWT validation works for `/admin/**` integration checks.
 - **Secrets**: `pre-commit run detect-secrets --all-files` (same baseline as local pre-commit)
 
+A second workflow, [`.github/workflows/docker-build.yml`](../.github/workflows/docker-build.yml), builds all three production Docker images (`nginx`, `django`, `springboot`) on the same triggers as a merge check — images are built but not pushed. The nginx image is hermetic: it compiles the React bundle and runs `collectstatic` inside the build, so it needs no pre-built local artifacts.
+
 The frontend **lint** step runs `eslint` with zero warnings allowed; if it fails on GitHub, run `npm run lint` in `react-app/` and fix or suppress the reported issues.
 
 ### Backend Tests

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,39 @@
-FROM nginx:1.31
+# Hermetic build: produces the React bundle and Django static files itself, so
+# the image builds from a clean checkout (nginx/dist and nginx/static are
+# gitignored build artifacts). Build from the REPO ROOT:
+#   docker build -f nginx/Dockerfile -t johnfattore/nginx .
 
-# copy configuration into image
-# COPY nginx.conf /etc/nginx/nginx.conf
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY index.html /var/www/index.html
-COPY dist/ var/www/dist
-COPY static var/www/static
+# Stage 1: React build (sass generates the gitignored custom.css that
+# index.html links, then Vite emits ../nginx/dist -- the /app layout mirrors
+# the repo so the relative outDir in vite.config.ts works)
+FROM node:20-slim AS react-build
+WORKDIR /app/react-app
+COPY react-app/package.json react-app/package-lock.json ./
+RUN npm ci
+COPY react-app/ ./
+RUN npx sass src/styles/custom.scss src/styles/custom.css \
+    && npm run build
+
+# Stage 2: Django collectstatic (base image + uv pattern mirrors
+# django/Dockerfile; dummy env values match the django job in ci.yml --
+# settings just needs them present to import)
+FROM python:3.14-slim AS django-static
+COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /uvx /bin/
+WORKDIR /app/django
+ENV UV_PYTHON_DOWNLOADS=never
+COPY django/pyproject.toml django/uv.lock ./
+RUN uv sync --frozen --no-cache
+COPY django/ ./
+# STATIC_ROOT is ../nginx/static relative to the Django BASE_DIR
+RUN SECRET_KEY=build-only-dummy-secret-key \
+    DATABASE=sqlite \
+    REDIS_URL=redis://127.0.0.1:6379/0 \
+    GOOGLE_API_KEY=build-only-dummy-google-api-key \
+    uv run python manage.py collectstatic --noinput
+
+# Stage 3: nginx serving the artifacts from the stages above
+FROM nginx:1.31
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/index.html /var/www/index.html
+COPY --from=react-build /app/nginx/dist /var/www/dist
+COPY --from=django-static /app/nginx/static /var/www/static

--- a/react-app/.env.production
+++ b/react-app/.env.production
@@ -1,0 +1,3 @@
+VITE_APP_DJANGO_URL="https://fattorestreet.com/django/"
+VITE_APP_FINNHUB_URL="https://finnhub.io/api/v1/"
+VITE_APP_SPRINGBOOT_URL="https://fattorestreet.com/springboot/"


### PR DESCRIPTION
## Summary
First CD-pipeline step on top of the Compose migration: every PR now proves all three production images build from a clean checkout.

- **`.github/workflows/docker-build.yml`** (new): builds `nginx`, `django`, and `springboot` images (matrix, `fail-fast: false`) on every PR and push to `main`. Build-only — nothing is pushed to Docker Hub; publishing stays with `deploy/build.sh` until a later publish job. Per-image GitHub Actions layer cache keeps rebuilds fast.
- **`nginx/Dockerfile`** rewritten as a hermetic 3-stage build from the repo root: stage 1 runs sass + Vite (React bundle), stage 2 runs Django `collectstatic` (same base-image/uv pattern as `django/Dockerfile`), stage 3 copies both into `nginx:1.31`. Previously the image silently depended on gitignored, laptop-built `nginx/dist` and `nginx/static`.
- **Root `.dockerignore`** (whitelist style) keeps the repo-root build context down to the three directories the nginx build needs, minus local artifacts.
- **`react-app/.env.production` is now committed** (gitignore negation): it contains only public URLs, and without it a clean-checkout build would bake `undefined` API URLs into the bundle.

## Test plan
- [x] `docker build -f nginx/Dockerfile .` from the repo root succeeds locally; image contains the Vite `dist/` assets and `admin`/`rest_framework` static dirs
- [x] `actionlint` passes on the new workflow
- [x] The workflow run on this very PR is the end-to-end test — all three image builds must go green below
- [ ] Optional follow-up: mark the three "Build \<image\> image" checks as required in branch protection so they actually block merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)