### PR TITLE
fix nginx build context and gate celery behind a compose profile

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -22,13 +22,9 @@ cd ..
 
 echo "=== All tests passed — starting builds ==="
 
-cd react-app
-npm run build
-cd ..
-
-cd nginx
-docker build -t johnfattore/nginx .
-cd ..
+# nginx is hermetic: it builds the React bundle and Django static itself,
+# but its COPY paths are relative to the repo root, so build from here
+docker build -f nginx/Dockerfile -t johnfattore/nginx .
 
 cd django
 docker build -t johnfattore/django .

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -56,8 +56,12 @@ sudo docker compose up -d
 # Routine operations (from this directory)
 # ---------------------------------------------------------------------------
 
-# deploy the latest pushed images
+# deploy the latest pushed images (celery is off by default -- see below)
 sudo docker compose pull && sudo docker compose up -d
+
+# celery-worker/celery-beat sit behind the "celery" profile: bare compose
+# commands skip them. Include them (enables the FRED/yfinance cache tasks):
+sudo docker compose --profile celery pull && sudo docker compose --profile celery up -d
 
 # apply Django migrations (one-shot container, same image + secret as django)
 sudo docker compose run --rm django python manage.py migrate

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -26,11 +26,16 @@ services:
     restart: unless-stopped
 
   # Same image + secret as django; only the command differs.
+  # Off by default (profile): a bare `up -d` skips celery. Opt in with
+  #   docker compose --profile celery up -d
+  # Without the workers the load_fred_cache/load_yfinance_cache scheduled
+  # tasks do not run.
   celery-worker:
     image: johnfattore/django:${TAG:-latest}
     container_name: celery-worker
     command: celery -A mysite worker -E -n worker
     env_file: .env
+    profiles: [celery]
     networks: [dockerNet]
     restart: unless-stopped
 
@@ -39,6 +44,7 @@ services:
     container_name: celery-beat
     command: celery -A mysite worker --beat -E -n beat
     env_file: .env
+    profiles: [celery]
     networks: [dockerNet]
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary
- `deploy/build.sh` built the nginx image with `nginx/` as context, but the hermetic Dockerfile COPYs repo-root paths (`nginx/`, `django/`, `react-app/`) — every build failed with `"/nginx/index.html": not found`. Build from the repo root (`docker build -f nginx/Dockerfile .`), matching CI and the Dockerfile's own header; the host-side `npm run build` step is dropped since stage 1 of the image does it.
- `celery-worker`/`celery-beat` now sit behind a `celery` compose profile: a bare `docker compose up -d` deploys only django/springboot/nginx, so deploys can't resurrect workers that are intentionally off. Opt in with `docker compose --profile celery up -d` (needed for the FRED/yfinance cache tasks); `compose.sh` runbook documents both.

## Test plan
- `docker compose config --services` → django, springboot, nginx only; with `--profile celery` → all five
- Remaining: rerun `deploy/build.sh` end-to-end to confirm the nginx image builds and pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)