### PR TITLE
save plan-mode plans to a versioned .claude/plans directory

### DIFF
--- a/.claude/plans/README.md
+++ b/.claude/plans/README.md
@@ -1,0 +1,3 @@
+# Plans
+
+Plan-mode plans from Claude Code are written here as markdown files (see `plansDirectory` in `.claude/settings.json`). They are committed so the repo keeps a versioned history of implementation plans alongside the code they produced.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "plansDirectory": ".claude/plans"
+}


### PR DESCRIPTION
## Summary
- Add project-level `.claude/settings.json` with `plansDirectory: ".claude/plans"` so Claude Code writes accepted plan-mode plans as markdown files into the repo instead of `~/.claude/plans/`
- Add `.claude/plans/README.md` so the directory is tracked in git and the convention is documented
- Plans get committed alongside the code they produced, giving the repo a versioned history of implementation plans that is readable in VS Code

## Test plan
- Validated `.claude/settings.json` parses with `jq`
- Remaining: accept a plan in a new Claude Code session and confirm the markdown file lands in `.claude/plans/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)