### PR TITLE
build images on arm64 runners to match the Graviton host

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,10 @@ concurrency:
 jobs:
   build:
     name: Build ${{ matrix.image }} image
-    runs-on: ubuntu-latest
+    # arm64 runner: the production EC2 host is a t4g (Graviton/arm64), so the
+    # images must be linux/arm64. Native arm builds avoid QEMU emulation;
+    # these runners are free for public repos.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -168,6 +168,10 @@ Package settings → Change visibility → Public. Until then the host's pull
 
 ## Notes & limits
 
+- Images are **linux/arm64 only** — the EC2 host is a t4g (Graviton), and CI
+  builds natively on GitHub's arm64 runners. An amd64 host (or local
+  `docker run` on an Intel machine) can't run them without adding a
+  multi-arch build.
 - SSM returns at most ~24 KB of command output to `get-command-invocation`;
   `deploy.sh` keeps its logging terse so failures fit. For full logs:
   `journalctl` / `docker compose logs` on the host.


### PR DESCRIPTION
## Summary
- First automated deploy (run 28741380629) failed pulling the images: `no matching manifest for linux/arm64/v8`. The EC2 host is a `t4g.small` (Graviton/arm64); `ubuntu-latest` produced amd64-only images. The old Docker Hub images only worked because they were built on an Apple Silicon Mac.
- Switch the build matrix to `ubuntu-24.04-arm` (free for public repos) so the images are native linux/arm64 — no QEMU emulation, PR merge checks now validate the architecture production actually runs.
- Note the arm64-only constraint in `deploy/DEPLOY.md`.
- The pull-before-evict ordering in `deploy.sh` worked as designed: the failed deploy left the live site untouched.

## Test plan
- PR build jobs on the arm runners are themselves the test — all three images must build.
- After merge: the main run should push arm64 images and the deploy job should complete the cutover (GHCR packages turned out to be public already via repo-visibility inheritance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)