### PR TITLE
define redux-persist storage engine inline to fix Vite 8 prod crash

### DIFF
--- a/react-app/src/store.ts
+++ b/react-app/src/store.ts
@@ -1,8 +1,17 @@
 import { configureStore } from "@reduxjs/toolkit";
 import rootReducer from './reducers/rootReducer';
-import { persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
+import { persistReducer, Storage } from 'redux-persist';
 import { djangoApi, springbootApi } from "./functions/api";
+
+// Vite 8 production builds mis-resolve the CJS default export of
+// redux-persist/lib/storage (the import becomes the module namespace, so
+// storage.getItem is missing and the app crashes on boot). Define the
+// localStorage engine directly instead of importing it.
+const storage: Storage = {
+    getItem: (key) => Promise.resolve(localStorage.getItem(key)),
+    setItem: (key, value) => Promise.resolve(localStorage.setItem(key, value)),
+    removeItem: (key) => Promise.resolve(localStorage.removeItem(key)),
+};
 
 const persistConfig = {
     key: 'root', // The key to store the data in storage


### PR DESCRIPTION
## Summary
- Production site crashes on boot with `Uncaught TypeError: r.getItem is not a function` since the Vite 8 upgrade shipped: Vite 8 prod builds resolve the CJS default export of `redux-persist/lib/storage` to the module namespace object (`{ __esModule, default }`), so the storage engine passed to `persistReducer` has no `getItem`. Dev mode pre-bundles CJS differently, which is why it only broke after deploy.
- Because the store crashes at boot the whole SPA dies — this is also why no Spring Boot data was coming through.
- Fix: drop the fragile import and define the localStorage engine inline (three Promise wrappers, identical to `createWebStorage('local')`), typed with redux-persist's `Storage` interface. No CJS interop left to break.

## Test plan
- Reproduced the bug empirically: built a probe entry through the app's own Vite 8 pipeline and confirmed the imported storage was `{ __esModule, default }` with `getItem: undefined`.
- After the fix, built the real store module through the prod pipeline and ran `persistStore` against it in Node: rehydration completes (`bootstrapped: true`) where it previously threw.
- `npm run build` (tsc + vite) passes; all 65 vitest tests pass; lint clean.
- Remaining: confirm in the browser after the auto-deploy from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)