### PR TITLE
correct EC2 instance role name in deploy docs

### DIFF
--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -31,12 +31,12 @@ run with real values.
 
 ### 1. EC2 instance → SSM (managed instance)
 
-The instance role (`EC2CloudWatchLoggingRole`, which already reads the
+The instance role (`EC2FattoreStreetRole`, which already reads the
 `fattorestreet/env` secret) needs the SSM agent policy:
 
 ```sh
 aws iam attach-role-policy \
-  --role-name EC2CloudWatchLoggingRole \
+  --role-name EC2FattoreStreetRole \
   --policy-arn arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
 ```
 


### PR DESCRIPTION
## Summary
- The SSM setup section of `deploy/DEPLOY.md` referenced `EC2CloudWatchLoggingRole`, but the instance role that actually reads the `fattorestreet/env` secret is `EC2FattoreStreetRole` — the `attach-role-policy` command as written would have targeted the wrong role.

## Test plan
- Docs-only change; verified the diff only updates the role name in the prose and the `aws iam attach-role-policy` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)