### PR TITLE
sync CLAUDE.md and project overview with actual architecture

### DIFF
--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -11,17 +11,17 @@ Monorepo with three deployable services behind an Nginx reverse proxy, plus loca
 |---------|------|-------|---------|
 | `react-app/` | Frontend | React 18 + TypeScript + Vite | SPA with Redux Toolkit (RTK Query) |
 | `django/` | Backend API | Django 5 + DRF + Celery + Redis | Portfolio management, yfinance data, FRED data |
-| `springboot/` | Microservice | Spring Boot 3.4 + Java 17 + JPA | SEC EDGAR filings & quarterly data |
+| `springboot/` | Microservice | Spring Boot 4.1 + Java 17 + JPA | SEC EDGAR filings & quarterly data |
 | `llm/` | Local AI | llama.cpp + CUDA, stable-diffusion.cpp, Kokoro TTS | Qwen2.5-7B (chat), SD 1.5 (images), Kokoro-82M (TTS) |
 
 ## Key Architecture Details
 
 - **Auth**: JWT via `djangorestframework-simplejwt`; React stores tokens in Redux (persisted)
-- **API layer**: React uses RTK Query with a custom Axios base query; Django base URL from `VITE_APP_DJANGO_PORTFOLIO_URL`, Spring Boot from `VITE_APP_SPRINGBOOT_URL`
+- **API layer**: React uses RTK Query with a custom Axios base query (`src/functions/api/`); legacy features still use axios thunks in `src/functions/axiosFunctions.tsx`. Django base URL from `VITE_APP_DJANGO_URL`, Spring Boot from `VITE_APP_SPRINGBOOT_URL`
 - **Styling**: Bootstrap 5 via `react-bootstrap` + a global `custom.scss` theme using CSS custom properties (`--primary`, `--secondary`, `--tertiary`, `--quaternary`) with dark-mode support
 - **Database**: PostgreSQL for both Django and Spring Boot
-- **Infra**: Docker containers, Kubernetes manifests in `kubernetes/`, Nginx in `nginx/`, AWS configs in `aws/`
-- **Dev workflow**: Trunk-based development on `main`
+- **Infra**: Docker Compose stacks and deploy scripts in `deploy/` (images on GHCR, deployed via AWS SSM), Nginx in `nginx/`, Terraform for the one-shot Fargate price load in `springboot/deploy/terraform/`
+- **Dev workflow**: Feature branches merged to `main` via PRs; CI runs per-service lint/test jobs
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,14 +54,14 @@ mvn clean test                                   # Clean + test
 ### Request Flow
 ```
 Browser → Nginx (443 SSL)
-  /                     → React static files (SPA)
-  /users/api/           → Django (port 8000)
-  /portfolio/api/       → Django (port 8000)
-  /restaurants/api/     → Django (port 8000)
-  /chatbot/api/         → Django (port 8000)
-  /admin/               → Django admin
-  /springboot/          → Spring Boot (port 8080)  [path rewritten]
+  /             → React static files (SPA, try_files → index.html)
+  /django/      → Django (port 8000)       [prefix stripped]
+  /springboot/  → Spring Boot (port 8080)  [prefix stripped]
+  /pgadmin4/    → pgAdmin                  [prefix stripped]
+  /static/      → Django collected static files
 ```
+
+Django mounts each app under its own prefix (`users/`, `portfolio/`, `restaurants/`, `chatbot/`, `changeflow/`, `blog/`, `entertainment/`, plus `admin/`), with API routes at `<app>/api/...` — e.g. `POST /django/users/api/token/` from the browser reaches Django as `POST /users/api/token/`. Set `DJANGO_FORCE_SCRIPT_NAME=/django` in production so redirects and `{% url %}` include the prefix.
 
 ### Authentication
 - Django issues SimpleJWT Access + Refresh tokens via `POST /users/api/token/`
@@ -75,8 +75,10 @@ Browser → Nginx (443 SSL)
 - `chatbot/` — Boglehead AI advisor (Google Gemini)
 - `restaurants/` — Restaurant reviews/recommendations
 - `changeflow/` — Changelog + feedback tickets
+- `blog/` — Blog posts with categories and tags
+- `entertainment/` — Media recommendations (books, movies, shows, music, podcasts, games, websites)
 
-**Async Tasks (Celery)**: `load_fred_cache`, `load_yfinance_cache` — scheduled via django-celery-beat.
+**Async Tasks (Celery)**: `load_fred_cache`, `load_yfinance_cache`, `load_iex_hist` — scheduled via django-celery-beat.
 
 ### Spring Boot Packages
 ```
@@ -106,9 +108,9 @@ Test classes mirror source under `src/test/java/.../sec_api/`.
 - `MarketIndex`, `IndexMember`, `ListingIndexMetrics` — Index infrastructure
 
 ### React State & API
-- All API calls use **RTK Query** via `src/functions/api.ts` with a custom Axios base query
+- Newer API calls use **RTK Query** via `src/functions/api/` (`djangoApi.ts`, `springbootApi.ts`, shared `baseQuery.ts`); use RTK Query for all new code
+- Legacy features (restaurants, chatbot, watchlist, auth forms) still call `createAsyncThunk` thunks in `src/functions/axiosFunctions.tsx` backed by per-entity slices in `src/reducers/` — a migration to RTK Query is pending
 - API responses use snake_case (Django convention); RTK Query transforms to camelCase for components
-- Redux slices in `src/reducers/` for auth and portfolio state
 - All pages protected by `<StateHandler>` for loading/error display
 
 ## Conventions
@@ -138,9 +140,14 @@ Content lives in one place; the other tool gets a pointer file. Never duplicate 
 ### Django (`.env` in `django/`)
 - `SECRET_KEY` — required
 - `DEBUG` — bool, default `True`
-- `DATABASE` — `postgresLocal`, `postgresDocker`, or omit for SQLite
-- `REDIS_URL` — required in production
+- `DATABASE` — required: `postgresLocal`, `postgresDocker`, or any other value (e.g. `sqlite`) for SQLite; unset raises at startup
+- `POSTGRES_PASSWORD` — required when `DATABASE=postgresDocker`
+- `REDIS_URL` — always required (Celery broker; also the cache backend when `DEBUG=False`)
+- `GOOGLE_API_KEY` — Gemini key for the chatbot app
+- `FINNHUB_API_KEY`, `FRED_API_KEY` — portfolio quotes and FRED economic data
 - `SEC_CONTACT_EMAIL` — email for SEC API User-Agent header (required by SEC)
+- `SPRINGBOOT_BASE_URL` — internal Spring Boot base URL for the `load_iex_hist` Celery task (no nginx prefix, e.g. `http://springboot:8080`)
+- `DJANGO_FORCE_SCRIPT_NAME` — set to `/django` when served behind the nginx prefix
 
 ### Spring Boot (`.env` in `springboot/`, auto-imported)
 - `DB_URL`, `DB_USERNAME`, `POSTGRES_PASSWORD` — PostgreSQL connection (`POSTGRES_PASSWORD` is the shared DB-password key used by Django and the postgres image too)
@@ -150,4 +157,8 @@ Content lives in one place; the other tool gets a pointer file. Never duplicate 
 - `SEC_CONTACT_EMAIL` — email for SEC API User-Agent header (required by SEC)
 
 ### React (`.env.*` per mode)
-- `VITE_API_URL` — backend base URL per environment (dev/staging/production)
+- `VITE_APP_DJANGO_URL` — Django base URL (`http://127.0.0.1:8000/` in dev, `https://fattorestreet.com/django/` in production)
+- `VITE_APP_SPRINGBOOT_URL` — Spring Boot base URL
+- `VITE_APP_FINNHUB_URL` — Finnhub API base URL
+
+Committed modes: `development`, `production`, `test`, `compose` (for the local nginx compose stack).


### PR DESCRIPTION
## Summary
Fixes item 1 from the repo review: the agent-facing docs (root `CLAUDE.md` and `.cursor/rules/project-overview.mdc`) had drifted from the code they describe, which misleads every Claude/Cursor session that loads them.

- **Request flow**: nginx actually proxies `/django/` and `/springboot/` with the prefix stripped (plus `/pgadmin4/` and `/static/`) — not per-app `/users/api/` routes. Added a note on Django's internal app mounts and `DJANGO_FORCE_SCRIPT_NAME`.
- **React env vars**: replaced the fictional `VITE_API_URL` / `VITE_APP_DJANGO_PORTFOLIO_URL` with the real `VITE_APP_DJANGO_URL`, `VITE_APP_SPRINGBOOT_URL`, `VITE_APP_FINNHUB_URL` and the committed modes.
- **Django apps**: added `blog/` and `entertainment/`, and `load_iex_hist` to the Celery task list.
- **React API layer**: "All API calls use RTK Query" overstated reality — documented the legacy axios-thunk layer (`axiosFunctions.tsx`) still used by restaurants/chatbot/watchlist/auth, with RTK Query as the rule for new code.
- **Django env vars**: `DATABASE` raises when unset (docs said "omit for SQLite"); `REDIS_URL` is always required (Celery broker); documented `GOOGLE_API_KEY`, `FINNHUB_API_KEY`, `FRED_API_KEY`, `POSTGRES_PASSWORD`, `SPRINGBOOT_BASE_URL`, `DJANGO_FORCE_SCRIPT_NAME`.
- **Cursor rule**: Spring Boot 3.4 → 4.1; removed references to nonexistent `kubernetes/` and `aws/` dirs in favor of the real `deploy/` compose + SSM + Terraform setup; corrected the dev-workflow line to PR-based.

Every claim was verified against the source (`nginx/nginx.conf`, `mysite/settings.py` and `urls.py`, `react-app/.env.*`, `portfolio/tasks.py`, `springboot/pom.xml`).

## Test plan
- Docs-only change; no runtime surface. Checked `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md`, and `docs/API_REFERENCE.md` for the same stale claims — they're accurate as written (API reference uses Django-relative paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)