### PR TITLE
overhaul springboot tests: split monolith, add coverage gate

### DIFF
--- a/.claude/plans/take-a-look-at-vectorized-bee.md
+++ b/.claude/plans/take-a-look-at-vectorized-bee.md
@@ -1,0 +1,91 @@
+# Spring Boot Test Suite Overhaul
+
+## Context
+
+The `springboot/` service (Spring Boot 4.1.0, Java 17) has a passing suite — 30 classes, 279 tests, `mvn test` → BUILD SUCCESS — but structural weaknesses: no coverage tooling, zero `@DataJpaTest` repository tests, ~15 classes with no tests at all (including real-I/O `IexHistService` and `PcapParser`), a 1017-line `MainControllerTest` monolith covering two controllers with ~20 `@MockitoBean`s, and the real `springboot/.env` (live secrets) leaking into the `@SpringBootTest` context via `spring.config.import=optional:file:.env[.properties]` (application.properties line 2). Goal: fix these, add coverage measurement with an enforced floor, and expand coverage to the riskiest untested logic.
+
+**User decisions:** JaCoCo enforces a coverage floor (fails build on regression). Constructor-injection refactor of `HttpClient` in two production classes approved.
+
+**Conventions:** follow `.cursor/skills/springboot-tests/SKILL.md` — lightest slice per target (plain JUnit for utils, `MockitoExtension` for services, `@WebMvcTest`+`@MockitoBean` for controllers, `@DataJpaTest` for repos), tests mirror the main package tree. Boot 4 APIs only (`@MockitoBean` not `@MockBean`, `spring-boot-webmvc-test` artifact, Jackson 3 `tools.jackson` where used). Suite stays hermetic — no real network/DB. Reuse `testsupport/TestJwtTokens.java` for controller auth.
+
+## Phase 1 — Fix existing problems
+
+### 1.1 Split `MainControllerTest`
+`src/test/java/.../controller/MainControllerTest.java` (57 tests) → two classes:
+- `AdminControllerTest`: `@WebMvcTest(AdminController.class)` + `@Import(SecurityConfig.class)` + `@TestPropertySource` SECRET_KEY; only AdminController's collaborators as `@MockitoBean`. Includes auth matrix: no token → 401, non-admin (`user_id=2`) → 403, admin (`user_id=1`) → 200, via `TestJwtTokens`.
+- `PublicControllerTest`: `@WebMvcTest(PublicController.class)`; the 9 public GET endpoints, verifying anonymous access permitted.
+- New `config/SecurityConfigTest`: explicit security-matrix tests — expired token → 401, wrong-signature token → 401, public path with no token → 200.
+- Delete `MainControllerTest` only after the combined new test count ≥ 57 and both classes pass.
+
+### 1.2 Neutralize `.env` leakage into tests
+- `pom.xml`: add `maven-surefire-plugin` with `<workingDirectory>${project.build.directory}</workingDirectory>` so `optional:file:.env` resolves against `target/` (no `.env` there). First check no test reads files relative to cwd.
+- `src/test/resources/application-test.properties`: pin env-sensitive keys as belt-and-braces (`SEC_CONTACT_EMAIL`, `DJANGO_PORTFOLIO_BASE_URL`, `LLM_SERVER_URL` pointing at unroutable localhost).
+- Guard assertion in `SecApiApplicationTests`: `SECRET_KEY` env property equals the test value (proves `.env` didn't win).
+
+### 1.3 Remove Mockito leniency
+`IndexMetricsRefreshServiceTest` line ~41 uses `@MockitoSettings(strictness = LENIENT)`. Remove it; fix each `UnnecessaryStubbingException` by scoping stubs to the tests that use them (or targeted `lenient().when(...)` for genuinely shared setup). Grep for other `lenient` usages and audit.
+
+## Phase 2 — Infrastructure: JaCoCo
+
+Add `jacoco-maven-plugin` (0.8.13) to `pom.xml`: `prepare-agent`, `report` bound to `test`, and `check` with a BUNDLE line-coverage floor. Measure the post-Phase-1 baseline first, set the floor as a placeholder, then **ratchet it to (final Phase-3 coverage − 2 pts) at the end**. Exclude `SecApiApplication` bootstrap from the rule if it distorts numbers. Don't set a surefire `argLine` (would clobber the agent), or use `@{argLine}` if one is ever needed.
+
+## Phase 3 — Expand coverage (riskiest first)
+
+Use `@ParameterizedTest` (`@CsvSource`/`@MethodSource`) for input matrices — the suite currently has none.
+
+### 3.1 Utilities (plain JUnit)
+- `util/SecDateParsingUtilsTest` — parameterized over all date formats (ISO, "January 5, 2024", slash/short-year variants), `parseAnyDate` dispatch, `extractAllDates`, `previousBusinessDay` over weekends; nulls/blanks/garbage/invalid dates.
+- `util/SecTextUtilsTest`, `util/SecNumberUtilsTest` — full public surface incl. null/empty and epsilon boundaries.
+- `util/PcapParserTest` — **no committed binaries**: build pcap bytes programmatically in a shared helper `testsupport/PcapTestData.java` (global header + packet records with IEX trade-report messages); gzip through `GZIPOutputStream` into `@TempDir` for `parseGzip`. Cover valid trade reports, multiple packets, non-trade messages skipped, truncated stream, empty capture.
+
+### 3.2 corporateaction (MockitoExtension)
+- `EdgarFilingDiscoveryServiceTest` — `@Mock WebService`, real Jackson `ObjectMapper`. Fixtures: trimmed SEC submissions JSON in `src/test/resources/fixtures/edgar/`. Cover form-type filtering, pagination across submission files, malformed JSON, WebService failures, empty recent filings.
+- `support/EquitySplitDetectorTest` — split detection from companyfacts JSON fixture, ratio computation, duplicate skip, no-split → zero stats, missing units/dates.
+- `support/EtfActionPersisterTest` — each `PersistResult` branch (inserted/duplicate/updated) with `ArgumentCaptor` on repository saves.
+- `CorporateActionValidationServiceTest` — **needs refactor R1**. Mock `HttpClient` serving Django dividends/splits JSON. Cover `validateTicker`: matched events, SEC-only, Django-only, amount mismatch beyond epsilon, `minDateInclusive` filtering, Django endpoint failure → graceful degradation, `summarizeBatch` KPIs. Keep `CorporateActionValidationCanaryTest` unchanged.
+
+### 3.3 marketdata
+- `IexHistServiceTest` — **needs refactor R2**. Mock `HttpClient` + reuse `PcapTestData` bytes. Cover `loadHistData`: OHLCV persistence via captor (first=open, max=high, min=low, last=close, sum=volume), weekend/holiday skipping, non-200 responses, empty HIST index.
+
+### 3.4 index
+- `IndexMemberApiServiceTest` — row mapping for `listAll`/`listByIndexCode`, unknown code → empty, missing metrics/listing edges.
+- `IwbHoldingsTickerSetTest` — real classpath CSV via `DefaultResourceLoader`; missing-resource path via stub loader → empty set, no throw.
+
+### 3.5 repository — first `@DataJpaTest`s (`@ActiveProfiles("test")`, H2, seed via `TestEntityManager`)
+- `IndexMemberRepositoryTest` — `findAllWithListingAndAsset` fetch joins initialized.
+- `ListingIndexMetricsRepositoryTest` — `findAllWithListingAndAssetByYear` year filter + joins.
+- `DailyPriceRepositoryTest` — `findDistinctTickers`, `findTickersWithUnadjustedPrices` (null/non-null `adjustedClose` mix), `findTopByTickerAndTradeDateLessThanEqual` (exact/earlier/no match).
+- `CorporateActionRepositoryTest` — `findDistinctTickers` + derived finders used by upsert paths.
+- `AssetRepositoryTest` — `findEquityAssetsByTickers` excludes funds, `findAllWithListings`.
+
+These also validate entity mappings and that every custom JPQL parses. Watch-out: hibernate-envers on the classpath — if `create-drop` audit tables cause `@DataJpaTest` startup issues, adjust envers test properties.
+
+### 3.6 Thicken thin spots
+- `fundamentals/EdgarServiceTest` (774-LOC class, 7 tests): after JaCoCo lands, target the red methods — frames sync, fact-sheet assembly, malformed-JSON error paths.
+- Convert repetitive existing extractor/normalizer tests to `@ParameterizedTest` only where it deletes real duplication.
+
+## Production refactors (approved, minimal)
+
+- **R1** `corporateaction/CorporateActionValidationService.java:50` — add a constructor taking `HttpClient`; existing constructor delegates with `HttpClient.newBuilder().build()`. No behavior change.
+- **R2** `marketdata/IexHistService.java:60` — same pattern, preserving the HTTP/1.1 + redirect settings in the default. Optionally widen `OhlcvAccumulator` to package-private for direct assertion.
+- Everything else is already constructor-injected and mockable.
+
+## Sequencing
+
+1. Baseline `mvn test` (279 green). 2. Phase 1 items, running the suite after each. 3. JaCoCo + record baseline %. 4. Phase 3 in order 3.1 → 3.6 (R1 with 3.2, R2 with 3.3), `mvn test` after each package group. 5. Ratchet JaCoCo floor. 6. Final `mvn test` + `mvn spotbugs:check` (R1/R2 touched production code).
+
+## Verification
+
+- `cd springboot && mvn test` → BUILD SUCCESS, test count up from 279 to roughly 430–480, zero skipped.
+- Hermeticity: suite passes with network unavailable (one-off run with `-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=1`); temporarily rename `springboot/.env` → identical results.
+- Coverage: `open springboot/target/site/jacoco/index.html`; previously-red classes (`EdgarFilingDiscoveryService`, `EquitySplitDetector`, `IexHistService`, `PcapParser`, `SecDateParsingUtils`) show covered; `mvn verify` passes the `jacoco:check` floor.
+- Controller-split parity: new controller tests ≥ 57 combined before deleting `MainControllerTest`.
+
+## Critical files
+
+- `springboot/pom.xml` — surefire workingDirectory, JaCoCo
+- `springboot/src/test/java/com/fattorestreet/sec_api/controller/MainControllerTest.java` — split source
+- `springboot/src/test/resources/application-test.properties` — env pinning
+- `springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java` — R1
+- `springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java` — R2
+- `springboot/src/test/java/com/fattorestreet/sec_api/testsupport/` — `TestJwtTokens` (reuse), new `PcapTestData`

--- a/.cursor/skills/springboot-tests/SKILL.md
+++ b/.cursor/skills/springboot-tests/SKILL.md
@@ -106,24 +106,40 @@ class EdgarControllerTest {
 
 ### Repository Test (DataJpaTest)
 
+Boot 4 relocated the JPA test slice: `@DataJpaTest` lives in `spring-boot-data-jpa-test` and `TestEntityManager` in `spring-boot-jpa-test` (both already declared in the pom). Use `@ActiveProfiles("test")` so the H2 URL with `NON_KEYWORDS=YEAR` is used — `spring.test.database.replace=none` in `application-test.properties` keeps it from being swapped out.
+
 ```java
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
 class EdgarRepositoryTest {
 
     @Autowired
     private EdgarRepository repository;
+    @Autowired
+    private TestEntityManager em;
 
     @Test
     void findsFilingsByTicker() {
-        // Entity is auto-persisted via test data or setUp
+        // Seed with em.persist(...), then em.flush(); em.clear() before querying
         var results = repository.findByTicker("MSFT");
         assertFalse(results.isEmpty());
     }
 }
 ```
+
+## Shared Test Helpers (`testsupport/`)
+
+- `TestJwtTokens` — mints HS256 JWTs for controller auth tests (`accessToken(secret, userId)`, plus an expiry-aware overload); pair with `@Import(SecurityConfig.class)` and `@TestPropertySource(properties = "SECRET_KEY=...")`
+- `PcapTestData` — builds IEX TOPS pcap byte streams programmatically (no committed binaries) for `PcapParser`/`IexHistService` tests
+
+## Coverage
+
+JaCoCo runs with `mvn test`; report at `target/site/jacoco/index.html`. `mvn verify` fails if bundle line coverage drops below the floor configured in `pom.xml` (`jacoco:check`) — raise the floor when coverage meaningfully improves, never lower it to make a build pass.
 
 ## Workflow
 

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -268,6 +268,8 @@ Already-summarized filings (by accession number) are skipped on re-runs.
 mvn test
 ```
 
+Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` import in `application.properties` never leaks real secrets into test contexts. JaCoCo runs with the suite: the HTML report lands in `target/site/jacoco/index.html`, and `mvn verify` enforces a minimum line-coverage floor (`jacoco:check`). Repository tests use `@DataJpaTest` against the in-memory H2 database (Boot 4 artifact `spring-boot-data-jpa-test`).
+
 ## Documentation
 
 - [API Reference](../docs/API_REFERENCE.md) (covers all endpoints for Django and Spring Boot)

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -73,6 +73,12 @@
 			<artifactId>spring-boot-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Boot 4 ships @DataJpaTest in a per-module test artifact -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-jpa-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
@@ -94,6 +100,57 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<!-- Run tests from target/ so the optional .env import in
+					     application.properties never resolves the real springboot/.env -->
+					<workingDirectory>${project.build.directory}</workingDirectory>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.13</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.76</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+							<excludes>
+								<exclude>com/fattorestreet/sec_api/SecApiApplication.class</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
@@ -41,13 +41,22 @@ public class CorporateActionValidationService {
     private final HttpClient httpClient;
     private final String djangoPortfolioBaseUrl;
 
+    @org.springframework.beans.factory.annotation.Autowired
     public CorporateActionValidationService(
             CorporateActionRepository corporateActionRepository,
             ObjectMapper objectMapper,
             @Value("${DJANGO_PORTFOLIO_BASE_URL:http://localhost:8000/portfolio}") String djangoPortfolioBaseUrl) {
+        this(corporateActionRepository, objectMapper, djangoPortfolioBaseUrl, HttpClient.newBuilder().build());
+    }
+
+    CorporateActionValidationService(
+            CorporateActionRepository corporateActionRepository,
+            ObjectMapper objectMapper,
+            String djangoPortfolioBaseUrl,
+            HttpClient httpClient) {
         this.corporateActionRepository = corporateActionRepository;
         this.objectMapper = objectMapper;
-        this.httpClient = HttpClient.newBuilder().build();
+        this.httpClient = httpClient;
         this.djangoPortfolioBaseUrl = trimTrailingSlash(djangoPortfolioBaseUrl);
     }
 

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/EdgarFilingDiscoveryService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/EdgarFilingDiscoveryService.java
@@ -54,6 +54,9 @@ public class EdgarFilingDiscoveryService {
             String recentSubmissionJson,
             Map<String, FilingMeta> out,
             int maxSubmissionFilesToScan) {
+        if (recentSubmissionJson == null || recentSubmissionJson.isBlank()) {
+            return;
+        }
         try {
             JsonNode root = objectMapper.readTree(recentSubmissionJson);
             JsonNode files = root.path("filings").path("files");

--- a/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java
@@ -53,15 +53,22 @@ public class IexHistService {
         return t;
     });
 
+    @org.springframework.beans.factory.annotation.Autowired
     public IexHistService(DailyPriceRepository dailyPriceRepository,
                           ObjectMapper objectMapper) {
-        this.dailyPriceRepository = dailyPriceRepository;
-        this.objectMapper = objectMapper;
-        this.httpClient = HttpClient.newBuilder()
+        this(dailyPriceRepository, objectMapper, HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
                 .followRedirects(HttpClient.Redirect.NORMAL)
                 .connectTimeout(Duration.ofSeconds(60))
-                .build();
+                .build());
+    }
+
+    IexHistService(DailyPriceRepository dailyPriceRepository,
+                   ObjectMapper objectMapper,
+                   HttpClient httpClient) {
+        this.dailyPriceRepository = dailyPriceRepository;
+        this.objectMapper = objectMapper;
+        this.httpClient = httpClient;
     }
 
     /**

--- a/springboot/src/main/java/com/fattorestreet/sec_api/util/SecDateParsingUtils.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/util/SecDateParsingUtils.java
@@ -15,7 +15,9 @@ public final class SecDateParsingUtils {
     private static final Pattern ISO_DATE_PATTERN = Pattern.compile("(\\d{4}-\\d{2}-\\d{2})");
     private static final Pattern YEAR_SLASH_DATE_PATTERN = Pattern.compile("(\\d{4}/\\d{1,2}/\\d{1,2})");
     private static final Pattern SLASH_DATE_PATTERN = Pattern.compile("(\\d{1,2}/\\d{1,2}/\\d{4})");
-    private static final Pattern SLASH_SHORT_YEAR_DATE_PATTERN = Pattern.compile("(\\d{1,2}/\\d{1,2}/\\d{2})");
+    // Digit guards keep this from matching the truncated prefix of a full-year date ("3/15/2024"
+    // must not also yield "3/15/20") or the tail of a year-first date.
+    private static final Pattern SLASH_SHORT_YEAR_DATE_PATTERN = Pattern.compile("(?<!\\d)(\\d{1,2}/\\d{1,2}/\\d{2})(?!\\d)");
     private static final Pattern DASH_DATE_PATTERN = Pattern.compile("(\\d{1,2}-\\d{1,2}-\\d{4})");
     private static final Pattern US_DATE_PATTERN = Pattern.compile(
             "(?i)(Jan\\.?|January|Feb\\.?|February|Mar\\.?|March|Apr\\.?|April|May|Jun\\.?|June|Jul\\.?|July|Aug\\.?|August|Sep\\.?|Sept\\.?|September|Oct\\.?|October|Nov\\.?|November|Dec\\.?|December)\\s+\\d{1,2},?\\s+\\d{4}");
@@ -34,18 +36,30 @@ public final class SecDateParsingUtils {
         }
     }
 
+    // Case-insensitive: US_DATE_PATTERN matches any case (e.g. all-caps filing text), so the
+    // parsers must accept it too.
+    private static final List<DateTimeFormatter> US_DATE_FORMATS = List.of(
+            usFormatter("MMMM d, uuuu"),
+            usFormatter("MMM d, uuuu"),
+            usFormatter("MMMM d uuuu"),
+            usFormatter("MMM d uuuu")
+    );
+
+    private static DateTimeFormatter usFormatter(String pattern) {
+        return new java.time.format.DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .appendPattern(pattern)
+                .toFormatter(Locale.US);
+    }
+
     public static LocalDate parseUsDate(String dateText) {
         if (dateText == null || dateText.isBlank()) {
             return null;
         }
         String normalizedDateText = dateText.replaceAll("(?i)\\b(Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\\.", "$1");
-        List<DateTimeFormatter> formats = List.of(
-                DateTimeFormatter.ofPattern("MMMM d, uuuu", Locale.US),
-                DateTimeFormatter.ofPattern("MMM d, uuuu", Locale.US),
-                DateTimeFormatter.ofPattern("MMMM d uuuu", Locale.US),
-                DateTimeFormatter.ofPattern("MMM d uuuu", Locale.US)
-        );
-        for (DateTimeFormatter format : formats) {
+        // "Sept" is matched by US_DATE_PATTERN but MMM only accepts "Sep"
+        normalizedDateText = normalizedDateText.replaceAll("(?i)\\bSept\\b", "Sep");
+        for (DateTimeFormatter format : US_DATE_FORMATS) {
             try {
                 return LocalDate.parse(normalizedDateText, format);
             } catch (DateTimeParseException ignored) {

--- a/springboot/src/test/java/com/fattorestreet/sec_api/SecApiApplicationTests.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/SecApiApplicationTests.java
@@ -1,15 +1,30 @@
 package com.fattorestreet.sec_api;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class SecApiApplicationTests {
 
+	@Autowired
+	private Environment environment;
+
 	@Test
 	void contextLoads() {
 	}
 
+	@Test
+	void testSecretKeyWinsOverAnyDotEnvImport() {
+		// application.properties optionally imports springboot/.env; the surefire
+		// workingDirectory plus test-profile pinning must keep real secrets out.
+		assertEquals("test-jwt-signing-secret-32chars-min!", environment.getProperty("SECRET_KEY"));
+		assertEquals("test-jwt-signing-secret-32chars-min!",
+				environment.getProperty("app.django-jwt-secret"));
+	}
 }

--- a/springboot/src/test/java/com/fattorestreet/sec_api/config/SecurityConfigTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/config/SecurityConfigTest.java
@@ -1,0 +1,101 @@
+package com.fattorestreet.sec_api.config;
+
+import com.fattorestreet.sec_api.controller.IwbReferenceHoldingsController;
+import com.fattorestreet.sec_api.index.IwbHoldingsTickerSet;
+import com.fattorestreet.sec_api.testsupport.TestJwtTokens;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security matrix for {@link SecurityConfig}: public routes are anonymous, /admin/** requires a
+ * valid HS256 JWT whose user_id claim is the Django admin (1). Sliced on the smallest controller;
+ * /admin/** requests are decided by the filter chain before any handler mapping, so an
+ * authenticated admin request lands on 404 here (no AdminController in the slice) — which proves
+ * authorization passed.
+ */
+@WebMvcTest(IwbReferenceHoldingsController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = "SECRET_KEY=test-jwt-signing-secret-32chars-min!") // pragma: allowlist secret
+class SecurityConfigTest {
+
+    private static final String JWT_TEST_SECRET = "test-jwt-signing-secret-32chars-min!"; // pragma: allowlist secret
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IwbHoldingsTickerSet iwbHoldingsTickerSet;
+
+    @Test
+    void publicEndpoint_noToken_permitted() throws Exception {
+        when(iwbHoldingsTickerSet.equityRows()).thenReturn(List.of());
+
+        mockMvc.perform(get("/iwb-reference-holdings"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void adminRoute_noToken_returns401() throws Exception {
+        mockMvc.perform(get("/admin/asset-load"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void adminRoute_expiredAdminToken_returns401() throws Exception {
+        // Well past the resource server's default 60s clock skew.
+        String expired = TestJwtTokens.accessToken(
+                JWT_TEST_SECRET, 1L, new Date(System.currentTimeMillis() - 7_200_000L));
+
+        mockMvc.perform(get("/admin/asset-load")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + expired))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void adminRoute_wrongSignature_returns401() throws Exception {
+        String forged = TestJwtTokens.accessToken("attacker-secret-that-is-32-chars-xx", 1L);
+
+        mockMvc.perform(get("/admin/asset-load")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + forged))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void adminRoute_malformedToken_returns401() throws Exception {
+        mockMvc.perform(get("/admin/asset-load")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer not-a-jwt"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void adminRoute_nonAdminUserId_returns403() throws Exception {
+        String nonAdmin = TestJwtTokens.accessToken(JWT_TEST_SECRET, 2L);
+
+        mockMvc.perform(get("/admin/asset-load")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + nonAdmin))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminRoute_adminToken_passesAuthorization() throws Exception {
+        String admin = TestJwtTokens.accessToken(JWT_TEST_SECRET, 1L);
+
+        // No AdminController in this slice: 404 (not 401/403) means the filter chain let it through.
+        mockMvc.perform(get("/admin/asset-load")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + admin))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/controller/AdminControllerTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/controller/AdminControllerTest.java
@@ -1,29 +1,14 @@
 package com.fattorestreet.sec_api.controller;
 
-import com.fattorestreet.sec_api.index.IndexMemberApiService;
-import com.fattorestreet.sec_api.index.IndexMemberApiService.IndexMemberRow;
-import com.fattorestreet.sec_api.index.IndexMemberApiService.StockRow;
 import com.fattorestreet.sec_api.model.Asset;
-import com.fattorestreet.sec_api.model.CorporateAction;
-import com.fattorestreet.sec_api.model.CorporateAction.ActionType;
-import com.fattorestreet.sec_api.model.DailyPrice;
-import com.fattorestreet.sec_api.model.FilingSummary;
-import com.fattorestreet.sec_api.model.MarketIndex;
-import com.fattorestreet.sec_api.model.Quarter;
 import com.fattorestreet.sec_api.repository.AssetRepository;
-import com.fattorestreet.sec_api.repository.CorporateActionRepository;
-import com.fattorestreet.sec_api.repository.FilingSummaryRepository;
-import com.fattorestreet.sec_api.repository.MarketIndexRepository;
-import com.fattorestreet.sec_api.repository.QuarterRepository;
 import com.fattorestreet.sec_api.client.WebService;
 import com.fattorestreet.sec_api.filing.FilingSummaryService;
 import com.fattorestreet.sec_api.fundamentals.EdgarService;
-import com.fattorestreet.sec_api.fundamentals.FinancialService;
 import com.fattorestreet.sec_api.listing.AssetService;
 import com.fattorestreet.sec_api.listing.EtfIdentityService;
 import com.fattorestreet.sec_api.listing.ListingService;
 import com.fattorestreet.sec_api.marketdata.IexHistService;
-import com.fattorestreet.sec_api.repository.DailyPriceRepository;
 import com.fattorestreet.sec_api.corporateaction.PriceAdjustmentService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,13 +23,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.Year;
 import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,10 +36,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest({AdminController.class, PublicController.class})
+@WebMvcTest(AdminController.class)
 @Import(SecurityConfig.class)
 @TestPropertySource(properties = "SECRET_KEY=test-jwt-signing-secret-32chars-min!") // pragma: allowlist secret
-class MainControllerTest {
+class AdminControllerTest {
 
     private static final String JWT_TEST_SECRET = "test-jwt-signing-secret-32chars-min!"; // pragma: allowlist secret
 
@@ -75,18 +58,11 @@ class MainControllerTest {
     @MockitoBean private AssetService assetService;
     @MockitoBean private AssetRepository assetRepository;
     @MockitoBean private ListingService listingService;
-    @MockitoBean private QuarterRepository quarterRepository;
     @MockitoBean private EdgarService edgarService;
-    @MockitoBean private FinancialService financialService;
-    @MockitoBean private DailyPriceRepository dailyPriceRepository;
     @MockitoBean private PriceAdjustmentService priceAdjustmentService;
     @MockitoBean private IexHistService iexHistService;
     @MockitoBean private EtfIdentityService etfIdentityService;
     @MockitoBean private FilingSummaryService filingSummaryService;
-    @MockitoBean private FilingSummaryRepository filingSummaryRepository;
-    @MockitoBean private CorporateActionRepository corporateActionRepository;
-    @MockitoBean private MarketIndexRepository marketIndexRepository;
-    @MockitoBean private IndexMemberApiService indexMemberApiService;
     @MockitoBean private com.fattorestreet.sec_api.index.IndexMetricsRefreshService indexMetricsRefreshService;
     @MockitoBean(name = "fattore50IndexRebuildService")
     private com.fattorestreet.sec_api.index.FattoreIndexRebuildService fattore50IndexRebuildService;
@@ -102,130 +78,7 @@ class MainControllerTest {
         return a;
     }
 
-    private Quarter buildQuarter(Asset asset, int year, int qtr, LocalDate end, Long revenue, Long netIncome) {
-        Quarter q = new Quarter();
-        q.setAsset(asset);
-        q.setYear(year);
-        q.setQuarter(qtr);
-        q.setPeriodStart(end.minusMonths(3));
-        q.setPeriodEnd(end);
-        q.setRevenues(revenue);
-        q.setNetIncomeLoss(netIncome);
-        q.setAssets(500L);
-        q.setLiabilities(300L);
-        q.setStockholdersEquity(200L);
-        q.setCashAndCashEquivalentsAtCarryingValue(80L);
-        q.setInventoryNet(40L);
-        q.setEarningsPerShareBasic(1.50);
-        return q;
-    }
-
-    // --- /quarters endpoint ---
-
-    @Test
-    void quarters_validTicker_returns200WithData() throws Exception {
-        Asset asset = buildAsset(320193L);
-        Quarter q = buildQuarter(asset, 2024, 4, LocalDate.of(2024, 12, 31), 100L, 25L);
-
-        when(assetRepository.findByListings_Ticker("AAPL")).thenReturn(asset);
-        when(quarterRepository.findByAsset(asset)).thenReturn(List.of(q));
-
-        mockMvc.perform(get("/quarters").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.cik").value("320193"))
-                .andExpect(jsonPath("$.quarters").isArray())
-                .andExpect(jsonPath("$.quarters[0].year").value(2024))
-                .andExpect(jsonPath("$.quarters[0].revenues").value(100));
-    }
-
-    @Test
-    void quarters_unknownTicker_returns404() throws Exception {
-        when(assetRepository.findByListings_Ticker("ZZZZ")).thenReturn(null);
-
-        mockMvc.perform(get("/quarters").param("ticker", "ZZZZ"))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void quarters_invalidTickerFormat_throwsConstraintViolation() {
-        assertThrows(jakarta.servlet.ServletException.class, () ->
-                mockMvc.perform(get("/quarters").param("ticker", "aapl"))
-        );
-    }
-
-    @Test
-    void quarters_missingTicker_returns400() throws Exception {
-        mockMvc.perform(get("/quarters"))
-                .andExpect(status().isBadRequest());
-    }
-
-    // --- /company-fact-sheet endpoint ---
-
-    @Test
-    void companyFactSheet_validTicker_returns200WithMetrics() throws Exception {
-        Asset asset = buildAsset(320193L);
-        Quarter q = buildQuarter(asset, 2024, 4, LocalDate.of(2024, 12, 31), 100L, 25L);
-
-        Map<String, Object> metrics = new HashMap<>();
-        metrics.put("ttmNetIncome", 78.0);
-        metrics.put("ttmRevenue", 355.0);
-        metrics.put("ttmOperatingCashFlow", 105.0);
-        metrics.put("ttmOperatingIncome", 118.0);
-        metrics.put("ttmGrossProfit", 177.0);
-        metrics.put("ttmNetIncomeYoY", 0.42);
-        metrics.put("ttmRevenueYoY", 0.12);
-        metrics.put("latestAssets", 500L);
-        metrics.put("latestLiabilities", 300L);
-        metrics.put("latestEquity", 200L);
-        metrics.put("latestInventory", 40L);
-        metrics.put("latestCash", 80L);
-        metrics.put("latestEps", 1.50);
-        metrics.put("netMargin", 0.2197);
-        metrics.put("grossMargin", 0.4986);
-        metrics.put("debtToAssets", 0.60);
-        metrics.put("cashToLiabilities", 0.2667);
-        metrics.put("roA", 0.156);
-        metrics.put("ocfToNetIncome", 1.346);
-
-        when(assetRepository.findByListings_Ticker("AAPL")).thenReturn(asset);
-        when(quarterRepository.findByAsset(asset)).thenReturn(List.of(q));
-        when(financialService.calculateMetrics(anyList())).thenReturn(metrics);
-
-        mockMvc.perform(get("/company-fact-sheet").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.cik").value("320193"))
-                .andExpect(jsonPath("$.ttmRevenue").exists())
-                .andExpect(jsonPath("$.ttmNetIncome").exists())
-                .andExpect(jsonPath("$.netMargin").exists())
-                .andExpect(jsonPath("$.latestQuarterEnd").value("2024-12-31"));
-    }
-
-    @Test
-    void companyFactSheet_unknownTicker_returns404() throws Exception {
-        when(assetRepository.findByListings_Ticker("ZZZZ")).thenReturn(null);
-
-        mockMvc.perform(get("/company-fact-sheet").param("ticker", "ZZZZ"))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void companyFactSheet_emptyQuarters_returnsMinimalResponse() throws Exception {
-        Asset asset = buildAsset(320193L);
-
-        when(assetRepository.findByListings_Ticker("AAPL")).thenReturn(asset);
-        when(quarterRepository.findByAsset(asset)).thenReturn(Collections.emptyList());
-        when(financialService.calculateMetrics(anyList())).thenReturn(Collections.emptyMap());
-
-        mockMvc.perform(get("/company-fact-sheet").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.cik").value("320193"))
-                .andExpect(jsonPath("$.ttmRevenue").doesNotExist());
-    }
-
-    // --- Admin endpoints ---
+    // --- /admin/asset-load endpoint ---
 
     @Test
     void adminAssetLoad_validKey_returns200() throws Exception {
@@ -367,6 +220,8 @@ class MainControllerTest {
         verify(etfIdentityService).enrichFundListingIdentities(true);
     }
 
+    // --- /admin/sync-frames endpoint ---
+
     @Test
     void adminSyncFrames_validKey_returns200() throws Exception {
         when(edgarService.syncFramesFull()).thenReturn(
@@ -381,168 +236,6 @@ class MainControllerTest {
     void adminSyncFrames_noBearer_returns401() throws Exception {
         mockMvc.perform(get("/admin/sync-frames"))
                 .andExpect(status().isUnauthorized());
-    }
-
-    // --- /prices endpoint ---
-
-    @Test
-    void prices_validTicker_returns200WithData() throws Exception {
-        DailyPrice dp = new DailyPrice();
-        dp.setTicker("AAPL");
-        dp.setTradeDate(LocalDate.of(2025, 3, 15));
-        dp.setOpenPrice(172.5);
-        dp.setHighPrice(174.2);
-        dp.setLowPrice(171.8);
-        dp.setClosePrice(173.9);
-        dp.setAdjustedOpen(171.95);
-        dp.setAdjustedHigh(173.65);
-        dp.setAdjustedLow(171.25);
-        dp.setAdjustedClose(173.35);
-        dp.setVolume(45230L);
-
-        when(dailyPriceRepository.findByTickerOrderByTradeDateDesc("AAPL")).thenReturn(List.of(dp));
-
-        mockMvc.perform(get("/prices").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.prices").isArray())
-                .andExpect(jsonPath("$.prices[0].date").value("2025-03-15"))
-                .andExpect(jsonPath("$.prices[0].open").value(172.5))
-                .andExpect(jsonPath("$.prices[0].close").value(173.9))
-                .andExpect(jsonPath("$.prices[0].adjustedOpen").value(171.95))
-                .andExpect(jsonPath("$.prices[0].adjustedClose").value(173.35))
-                .andExpect(jsonPath("$.prices[0].volume").value(45230));
-    }
-
-    @Test
-    void prices_withDateRange_returns200() throws Exception {
-        when(dailyPriceRepository.findByTickerAndTradeDateBetweenOrderByTradeDateDesc(
-                org.mockito.ArgumentMatchers.eq("AAPL"),
-                org.mockito.ArgumentMatchers.any(LocalDate.class),
-                org.mockito.ArgumentMatchers.any(LocalDate.class)))
-                .thenReturn(List.of());
-
-        mockMvc.perform(get("/prices")
-                        .param("ticker", "AAPL")
-                        .param("start", "2025-01-01")
-                        .param("end", "2025-06-30"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.prices").isArray());
-    }
-
-    @Test
-    void prices_missingTicker_returns400() throws Exception {
-        mockMvc.perform(get("/prices"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void dividends_validTicker_returns200WithData() throws Exception {
-        CorporateAction d1 = new CorporateAction();
-        d1.setTicker("AAPL");
-        d1.setActionType(ActionType.DIVIDEND);
-        d1.setEffectiveDate(LocalDate.of(2025, 2, 10));
-        d1.setRatio(0.25);
-        d1.setRawDividend(0.25);
-        d1.setAdjustedDividend(0.25);
-        d1.setSourceType(CorporateAction.SourceType.SEC_EQUITY_XBRL);
-        d1.setFormType("8-K");
-        d1.setAccessionNumber("0000320193-25-000010");
-        d1.setRecordDate(LocalDate.of(2025, 2, 10));
-        d1.setPayDate(LocalDate.of(2025, 2, 13));
-        d1.setConfidenceScore(87.0);
-
-        CorporateAction d2 = new CorporateAction();
-        d2.setTicker("AAPL");
-        d2.setActionType(ActionType.DIVIDEND);
-        d2.setEffectiveDate(LocalDate.of(2025, 5, 12));
-        d2.setRatio(0.26);
-        d2.setRawDividend(0.065);
-        d2.setAdjustedDividend(0.26);
-
-        CorporateAction split = new CorporateAction();
-        split.setTicker("AAPL");
-        split.setActionType(ActionType.SPLIT);
-        split.setEffectiveDate(LocalDate.of(2020, 8, 31));
-        split.setRatio(0.25);
-
-        when(corporateActionRepository.findByTicker("AAPL")).thenReturn(List.of(d2, split, d1));
-
-        mockMvc.perform(get("/dividends").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.dividends").isArray())
-                .andExpect(jsonPath("$.dividends", hasSize(2)))
-                .andExpect(jsonPath("$.dividends[0].date").value("2025-02-10"))
-                .andExpect(jsonPath("$.dividends[0].rawValue").value(0.25))
-                .andExpect(jsonPath("$.dividends[0].adjustedValue").value(0.25))
-                .andExpect(jsonPath("$.dividends[0].value").value(0.25))
-                .andExpect(jsonPath("$.dividends[0].source").value("SEC_EQUITY_XBRL"))
-                .andExpect(jsonPath("$.dividends[0].formType").value("8-K"))
-                .andExpect(jsonPath("$.dividends[0].accessionNumber").value("0000320193-25-000010"))
-                .andExpect(jsonPath("$.dividends[0].recordDate").value("2025-02-10"))
-                .andExpect(jsonPath("$.dividends[0].payDate").value("2025-02-13"))
-                .andExpect(jsonPath("$.dividends[0].confidenceScore").value(87.0))
-                .andExpect(jsonPath("$.dividends[1].date").value("2025-05-12"))
-                .andExpect(jsonPath("$.dividends[1].rawValue").value(0.065))
-                .andExpect(jsonPath("$.dividends[1].adjustedValue").value(0.26))
-                .andExpect(jsonPath("$.dividends[1].value").value(0.26));
-    }
-
-    @Test
-    void dividends_missingTicker_returns400() throws Exception {
-        mockMvc.perform(get("/dividends"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void splits_validTicker_returns200WithData() throws Exception {
-        CorporateAction s1 = new CorporateAction();
-        s1.setTicker("AAPL");
-        s1.setActionType(ActionType.SPLIT);
-        s1.setEffectiveDate(LocalDate.of(2014, 6, 9));
-        s1.setRatio(0.1428571429);
-        s1.setSourceType(CorporateAction.SourceType.SEC_EQUITY_XBRL);
-        s1.setFormType("8-K");
-        s1.setAccessionNumber("0000320193-14-000070");
-        s1.setConfidenceScore(90.0);
-
-        CorporateAction s2 = new CorporateAction();
-        s2.setTicker("AAPL");
-        s2.setActionType(ActionType.SPLIT);
-        s2.setEffectiveDate(LocalDate.of(2020, 8, 31));
-        s2.setRatio(0.25);
-        s2.setSourceType(CorporateAction.SourceType.SEC_EQUITY_XBRL);
-        s2.setFormType("8-K");
-        s2.setAccessionNumber("0000320193-20-000096");
-        s2.setConfidenceScore(93.0);
-
-        CorporateAction dividend = new CorporateAction();
-        dividend.setTicker("AAPL");
-        dividend.setActionType(ActionType.DIVIDEND);
-        dividend.setEffectiveDate(LocalDate.of(2025, 2, 10));
-        dividend.setRatio(0.25);
-
-        when(corporateActionRepository.findByTicker("AAPL")).thenReturn(List.of(dividend, s2, s1));
-
-        mockMvc.perform(get("/splits").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.splits").isArray())
-                .andExpect(jsonPath("$.splits", hasSize(2)))
-                .andExpect(jsonPath("$.splits[0].date").value("2014-06-09"))
-                .andExpect(jsonPath("$.splits[0].ratio").value(0.1428571429))
-                .andExpect(jsonPath("$.splits[0].value").value(0.1428571429))
-                .andExpect(jsonPath("$.splits[1].date").value("2020-08-31"))
-                .andExpect(jsonPath("$.splits[1].ratio").value(0.25))
-                .andExpect(jsonPath("$.splits[1].value").value(0.25));
-    }
-
-    @Test
-    void splits_missingTicker_returns400() throws Exception {
-        mockMvc.perform(get("/splits"))
-                .andExpect(status().isBadRequest());
     }
 
     // --- /admin/load-hist endpoint ---
@@ -929,89 +622,5 @@ class MainControllerTest {
     void rebuildFattore1000_noBearer_returns401() throws Exception {
         mockMvc.perform(post("/admin/indexes/rebuild-fattore-1000"))
                 .andExpect(status().isUnauthorized());
-    }
-
-    // --- /filing-summaries endpoint ---
-
-    @Test
-    void filingSummaries_validTicker_returns200() throws Exception {
-        FilingSummary fs = new FilingSummary();
-        fs.setTicker("AAPL");
-        fs.setFilingDate(java.time.LocalDate.of(2024, 10, 31));
-        fs.setAccessionNumber("0000320193-24-000123");
-        fs.setSummary("Apple reported strong revenue growth driven by iPhone sales.");
-
-        when(filingSummaryRepository.findByTickerOrderByFilingDateDesc("AAPL"))
-                .thenReturn(List.of(fs));
-
-        mockMvc.perform(get("/filing-summaries").param("ticker", "AAPL"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.ticker").value("AAPL"))
-                .andExpect(jsonPath("$.summaries").isArray())
-                .andExpect(jsonPath("$.summaries[0].filingDate").value("2024-10-31"))
-                .andExpect(jsonPath("$.summaries[0].summary").value(containsString("strong revenue growth")));
-    }
-
-    @Test
-    void filingSummaries_missingTicker_returns400() throws Exception {
-        mockMvc.perform(get("/filing-summaries"))
-                .andExpect(status().isBadRequest());
-    }
-
-    // --- /indexes endpoint ---
-
-    @Test
-    void listIndexes_returns200() throws Exception {
-        MarketIndex fat50 = new MarketIndex();
-        fat50.setCode("FAT50");
-        fat50.setDisplayName("Fattore 50");
-        MarketIndex fat100 = new MarketIndex();
-        fat100.setCode("FAT100");
-        fat100.setDisplayName("Fattore 100");
-        MarketIndex fat1000 = new MarketIndex();
-        fat1000.setCode("FAT1000");
-        fat1000.setDisplayName("Fattore 1000");
-        when(marketIndexRepository.findAll()).thenReturn(List.of(fat50, fat100, fat1000));
-
-        mockMvc.perform(get("/indexes"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].code").value("FAT100"))
-                .andExpect(jsonPath("$[0].displayName").value("Fattore 100"))
-                .andExpect(jsonPath("$[1].code").value("FAT1000"))
-                .andExpect(jsonPath("$[1].displayName").value("Fattore 1000"))
-                .andExpect(jsonPath("$[2].code").value("FAT50"))
-                .andExpect(jsonPath("$[2].displayName").value("Fattore 50"));
-    }
-
-    // --- /index-members endpoint ---
-
-    @Test
-    void listIndexMembers_returns200() throws Exception {
-        StockRow stock = new StockRow(
-                "AAPL", "Apple", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN,
-                BigDecimal.ONE, BigDecimal.ONE, "US", "United States", "DE", "CA", "Common Stock", 1980);
-        when(indexMemberApiService.listAll()).thenReturn(List.of(
-                new IndexMemberRow(1L, new BigDecimal("5.5"), "Test Index", false, "", stock)
-        ));
-        mockMvc.perform(get("/index-members"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(1))
-                .andExpect(jsonPath("$[0].index").value("Test Index"))
-                .andExpect(jsonPath("$[0].stock.ticker").value("AAPL"));
-    }
-
-    @Test
-    void listIndexMembers_withCode_filters() throws Exception {
-        StockRow stock = new StockRow(
-                "MSFT", "Microsoft", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN,
-                BigDecimal.ONE, BigDecimal.ONE, "US", "United States", "WA", "WA", "Common Stock", 1986);
-        when(indexMemberApiService.listByIndexCode("FAT50")).thenReturn(List.of(
-                new IndexMemberRow(2L, new BigDecimal("3.25"), "Fattore 50", false, "", stock)
-        ));
-        mockMvc.perform(get("/index-members").param("code", "FAT50"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(2))
-                .andExpect(jsonPath("$[0].index").value("Fattore 50"))
-                .andExpect(jsonPath("$[0].stock.ticker").value("MSFT"));
     }
 }

--- a/springboot/src/test/java/com/fattorestreet/sec_api/controller/PublicControllerTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/controller/PublicControllerTest.java
@@ -1,0 +1,435 @@
+package com.fattorestreet.sec_api.controller;
+
+import com.fattorestreet.sec_api.index.IndexMemberApiService;
+import com.fattorestreet.sec_api.index.IndexMemberApiService.IndexMemberRow;
+import com.fattorestreet.sec_api.index.IndexMemberApiService.StockRow;
+import com.fattorestreet.sec_api.model.Asset;
+import com.fattorestreet.sec_api.model.CorporateAction;
+import com.fattorestreet.sec_api.model.CorporateAction.ActionType;
+import com.fattorestreet.sec_api.model.DailyPrice;
+import com.fattorestreet.sec_api.model.FilingSummary;
+import com.fattorestreet.sec_api.model.MarketIndex;
+import com.fattorestreet.sec_api.model.Quarter;
+import com.fattorestreet.sec_api.repository.AssetRepository;
+import com.fattorestreet.sec_api.repository.CorporateActionRepository;
+import com.fattorestreet.sec_api.repository.FilingSummaryRepository;
+import com.fattorestreet.sec_api.repository.MarketIndexRepository;
+import com.fattorestreet.sec_api.repository.QuarterRepository;
+import com.fattorestreet.sec_api.fundamentals.FinancialService;
+import com.fattorestreet.sec_api.repository.DailyPriceRepository;
+import org.junit.jupiter.api.Test;
+import com.fattorestreet.sec_api.config.SecurityConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PublicController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = "SECRET_KEY=test-jwt-signing-secret-32chars-min!") // pragma: allowlist secret
+class PublicControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean private AssetRepository assetRepository;
+    @MockitoBean private QuarterRepository quarterRepository;
+    @MockitoBean private FinancialService financialService;
+    @MockitoBean private DailyPriceRepository dailyPriceRepository;
+    @MockitoBean private CorporateActionRepository corporateActionRepository;
+    @MockitoBean private FilingSummaryRepository filingSummaryRepository;
+    @MockitoBean private MarketIndexRepository marketIndexRepository;
+    @MockitoBean private IndexMemberApiService indexMemberApiService;
+
+    private Asset buildAsset(Long cik) {
+        Asset a = new Asset();
+        a.setId(1L);
+        a.setCik(cik);
+        return a;
+    }
+
+    private Quarter buildQuarter(Asset asset, int year, int qtr, LocalDate end, Long revenue, Long netIncome) {
+        Quarter q = new Quarter();
+        q.setAsset(asset);
+        q.setYear(year);
+        q.setQuarter(qtr);
+        q.setPeriodStart(end.minusMonths(3));
+        q.setPeriodEnd(end);
+        q.setRevenues(revenue);
+        q.setNetIncomeLoss(netIncome);
+        q.setAssets(500L);
+        q.setLiabilities(300L);
+        q.setStockholdersEquity(200L);
+        q.setCashAndCashEquivalentsAtCarryingValue(80L);
+        q.setInventoryNet(40L);
+        q.setEarningsPerShareBasic(1.50);
+        return q;
+    }
+
+    // --- /quarters endpoint ---
+
+    @Test
+    void quarters_validTicker_returns200WithData() throws Exception {
+        Asset asset = buildAsset(320193L);
+        Quarter q = buildQuarter(asset, 2024, 4, LocalDate.of(2024, 12, 31), 100L, 25L);
+
+        when(assetRepository.findByListings_Ticker("AAPL")).thenReturn(asset);
+        when(quarterRepository.findByAsset(asset)).thenReturn(List.of(q));
+
+        mockMvc.perform(get("/quarters").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.cik").value("320193"))
+                .andExpect(jsonPath("$.quarters").isArray())
+                .andExpect(jsonPath("$.quarters[0].year").value(2024))
+                .andExpect(jsonPath("$.quarters[0].revenues").value(100));
+    }
+
+    @Test
+    void quarters_unknownTicker_returns404() throws Exception {
+        when(assetRepository.findByListings_Ticker("ZZZZ")).thenReturn(null);
+
+        mockMvc.perform(get("/quarters").param("ticker", "ZZZZ"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void quarters_invalidTickerFormat_throwsConstraintViolation() {
+        assertThrows(jakarta.servlet.ServletException.class, () ->
+                mockMvc.perform(get("/quarters").param("ticker", "aapl"))
+        );
+    }
+
+    @Test
+    void quarters_missingTicker_returns400() throws Exception {
+        mockMvc.perform(get("/quarters"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- /company-fact-sheet endpoint ---
+
+    @Test
+    void companyFactSheet_validTicker_returns200WithMetrics() throws Exception {
+        Asset asset = buildAsset(320193L);
+        Quarter q = buildQuarter(asset, 2024, 4, LocalDate.of(2024, 12, 31), 100L, 25L);
+
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put("ttmNetIncome", 78.0);
+        metrics.put("ttmRevenue", 355.0);
+        metrics.put("ttmOperatingCashFlow", 105.0);
+        metrics.put("ttmOperatingIncome", 118.0);
+        metrics.put("ttmGrossProfit", 177.0);
+        metrics.put("ttmNetIncomeYoY", 0.42);
+        metrics.put("ttmRevenueYoY", 0.12);
+        metrics.put("latestAssets", 500L);
+        metrics.put("latestLiabilities", 300L);
+        metrics.put("latestEquity", 200L);
+        metrics.put("latestInventory", 40L);
+        metrics.put("latestCash", 80L);
+        metrics.put("latestEps", 1.50);
+        metrics.put("netMargin", 0.2197);
+        metrics.put("grossMargin", 0.4986);
+        metrics.put("debtToAssets", 0.60);
+        metrics.put("cashToLiabilities", 0.2667);
+        metrics.put("roA", 0.156);
+        metrics.put("ocfToNetIncome", 1.346);
+
+        when(assetRepository.findByListings_Ticker("AAPL")).thenReturn(asset);
+        when(quarterRepository.findByAsset(asset)).thenReturn(List.of(q));
+        when(financialService.calculateMetrics(anyList())).thenReturn(metrics);
+
+        mockMvc.perform(get("/company-fact-sheet").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.cik").value("320193"))
+                .andExpect(jsonPath("$.ttmRevenue").exists())
+                .andExpect(jsonPath("$.ttmNetIncome").exists())
+                .andExpect(jsonPath("$.netMargin").exists())
+                .andExpect(jsonPath("$.latestQuarterEnd").value("2024-12-31"));
+    }
+
+    @Test
+    void companyFactSheet_unknownTicker_returns404() throws Exception {
+        when(assetRepository.findByListings_Ticker("ZZZZ")).thenReturn(null);
+
+        mockMvc.perform(get("/company-fact-sheet").param("ticker", "ZZZZ"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void companyFactSheet_emptyQuarters_returnsMinimalResponse() throws Exception {
+        Asset asset = buildAsset(320193L);
+
+        when(assetRepository.findByListings_Ticker("AAPL")).thenReturn(asset);
+        when(quarterRepository.findByAsset(asset)).thenReturn(Collections.emptyList());
+        when(financialService.calculateMetrics(anyList())).thenReturn(Collections.emptyMap());
+
+        mockMvc.perform(get("/company-fact-sheet").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.cik").value("320193"))
+                .andExpect(jsonPath("$.ttmRevenue").doesNotExist());
+    }
+
+    // --- /prices endpoint ---
+
+    @Test
+    void prices_validTicker_returns200WithData() throws Exception {
+        DailyPrice dp = new DailyPrice();
+        dp.setTicker("AAPL");
+        dp.setTradeDate(LocalDate.of(2025, 3, 15));
+        dp.setOpenPrice(172.5);
+        dp.setHighPrice(174.2);
+        dp.setLowPrice(171.8);
+        dp.setClosePrice(173.9);
+        dp.setAdjustedOpen(171.95);
+        dp.setAdjustedHigh(173.65);
+        dp.setAdjustedLow(171.25);
+        dp.setAdjustedClose(173.35);
+        dp.setVolume(45230L);
+
+        when(dailyPriceRepository.findByTickerOrderByTradeDateDesc("AAPL")).thenReturn(List.of(dp));
+
+        mockMvc.perform(get("/prices").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.prices").isArray())
+                .andExpect(jsonPath("$.prices[0].date").value("2025-03-15"))
+                .andExpect(jsonPath("$.prices[0].open").value(172.5))
+                .andExpect(jsonPath("$.prices[0].close").value(173.9))
+                .andExpect(jsonPath("$.prices[0].adjustedOpen").value(171.95))
+                .andExpect(jsonPath("$.prices[0].adjustedClose").value(173.35))
+                .andExpect(jsonPath("$.prices[0].volume").value(45230));
+    }
+
+    @Test
+    void prices_withDateRange_returns200() throws Exception {
+        when(dailyPriceRepository.findByTickerAndTradeDateBetweenOrderByTradeDateDesc(
+                org.mockito.ArgumentMatchers.eq("AAPL"),
+                org.mockito.ArgumentMatchers.any(LocalDate.class),
+                org.mockito.ArgumentMatchers.any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/prices")
+                        .param("ticker", "AAPL")
+                        .param("start", "2025-01-01")
+                        .param("end", "2025-06-30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.prices").isArray());
+    }
+
+    @Test
+    void prices_missingTicker_returns400() throws Exception {
+        mockMvc.perform(get("/prices"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- /dividends endpoint ---
+
+    @Test
+    void dividends_validTicker_returns200WithData() throws Exception {
+        CorporateAction d1 = new CorporateAction();
+        d1.setTicker("AAPL");
+        d1.setActionType(ActionType.DIVIDEND);
+        d1.setEffectiveDate(LocalDate.of(2025, 2, 10));
+        d1.setRatio(0.25);
+        d1.setRawDividend(0.25);
+        d1.setAdjustedDividend(0.25);
+        d1.setSourceType(CorporateAction.SourceType.SEC_EQUITY_XBRL);
+        d1.setFormType("8-K");
+        d1.setAccessionNumber("0000320193-25-000010");
+        d1.setRecordDate(LocalDate.of(2025, 2, 10));
+        d1.setPayDate(LocalDate.of(2025, 2, 13));
+        d1.setConfidenceScore(87.0);
+
+        CorporateAction d2 = new CorporateAction();
+        d2.setTicker("AAPL");
+        d2.setActionType(ActionType.DIVIDEND);
+        d2.setEffectiveDate(LocalDate.of(2025, 5, 12));
+        d2.setRatio(0.26);
+        d2.setRawDividend(0.065);
+        d2.setAdjustedDividend(0.26);
+
+        CorporateAction split = new CorporateAction();
+        split.setTicker("AAPL");
+        split.setActionType(ActionType.SPLIT);
+        split.setEffectiveDate(LocalDate.of(2020, 8, 31));
+        split.setRatio(0.25);
+
+        when(corporateActionRepository.findByTicker("AAPL")).thenReturn(List.of(d2, split, d1));
+
+        mockMvc.perform(get("/dividends").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.dividends").isArray())
+                .andExpect(jsonPath("$.dividends", hasSize(2)))
+                .andExpect(jsonPath("$.dividends[0].date").value("2025-02-10"))
+                .andExpect(jsonPath("$.dividends[0].rawValue").value(0.25))
+                .andExpect(jsonPath("$.dividends[0].adjustedValue").value(0.25))
+                .andExpect(jsonPath("$.dividends[0].value").value(0.25))
+                .andExpect(jsonPath("$.dividends[0].source").value("SEC_EQUITY_XBRL"))
+                .andExpect(jsonPath("$.dividends[0].formType").value("8-K"))
+                .andExpect(jsonPath("$.dividends[0].accessionNumber").value("0000320193-25-000010"))
+                .andExpect(jsonPath("$.dividends[0].recordDate").value("2025-02-10"))
+                .andExpect(jsonPath("$.dividends[0].payDate").value("2025-02-13"))
+                .andExpect(jsonPath("$.dividends[0].confidenceScore").value(87.0))
+                .andExpect(jsonPath("$.dividends[1].date").value("2025-05-12"))
+                .andExpect(jsonPath("$.dividends[1].rawValue").value(0.065))
+                .andExpect(jsonPath("$.dividends[1].adjustedValue").value(0.26))
+                .andExpect(jsonPath("$.dividends[1].value").value(0.26));
+    }
+
+    @Test
+    void dividends_missingTicker_returns400() throws Exception {
+        mockMvc.perform(get("/dividends"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- /splits endpoint ---
+
+    @Test
+    void splits_validTicker_returns200WithData() throws Exception {
+        CorporateAction s1 = new CorporateAction();
+        s1.setTicker("AAPL");
+        s1.setActionType(ActionType.SPLIT);
+        s1.setEffectiveDate(LocalDate.of(2014, 6, 9));
+        s1.setRatio(0.1428571429);
+        s1.setSourceType(CorporateAction.SourceType.SEC_EQUITY_XBRL);
+        s1.setFormType("8-K");
+        s1.setAccessionNumber("0000320193-14-000070");
+        s1.setConfidenceScore(90.0);
+
+        CorporateAction s2 = new CorporateAction();
+        s2.setTicker("AAPL");
+        s2.setActionType(ActionType.SPLIT);
+        s2.setEffectiveDate(LocalDate.of(2020, 8, 31));
+        s2.setRatio(0.25);
+        s2.setSourceType(CorporateAction.SourceType.SEC_EQUITY_XBRL);
+        s2.setFormType("8-K");
+        s2.setAccessionNumber("0000320193-20-000096");
+        s2.setConfidenceScore(93.0);
+
+        CorporateAction dividend = new CorporateAction();
+        dividend.setTicker("AAPL");
+        dividend.setActionType(ActionType.DIVIDEND);
+        dividend.setEffectiveDate(LocalDate.of(2025, 2, 10));
+        dividend.setRatio(0.25);
+
+        when(corporateActionRepository.findByTicker("AAPL")).thenReturn(List.of(dividend, s2, s1));
+
+        mockMvc.perform(get("/splits").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.splits").isArray())
+                .andExpect(jsonPath("$.splits", hasSize(2)))
+                .andExpect(jsonPath("$.splits[0].date").value("2014-06-09"))
+                .andExpect(jsonPath("$.splits[0].ratio").value(0.1428571429))
+                .andExpect(jsonPath("$.splits[0].value").value(0.1428571429))
+                .andExpect(jsonPath("$.splits[1].date").value("2020-08-31"))
+                .andExpect(jsonPath("$.splits[1].ratio").value(0.25))
+                .andExpect(jsonPath("$.splits[1].value").value(0.25));
+    }
+
+    @Test
+    void splits_missingTicker_returns400() throws Exception {
+        mockMvc.perform(get("/splits"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- /filing-summaries endpoint ---
+
+    @Test
+    void filingSummaries_validTicker_returns200() throws Exception {
+        FilingSummary fs = new FilingSummary();
+        fs.setTicker("AAPL");
+        fs.setFilingDate(java.time.LocalDate.of(2024, 10, 31));
+        fs.setAccessionNumber("0000320193-24-000123");
+        fs.setSummary("Apple reported strong revenue growth driven by iPhone sales.");
+
+        when(filingSummaryRepository.findByTickerOrderByFilingDateDesc("AAPL"))
+                .thenReturn(List.of(fs));
+
+        mockMvc.perform(get("/filing-summaries").param("ticker", "AAPL"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ticker").value("AAPL"))
+                .andExpect(jsonPath("$.summaries").isArray())
+                .andExpect(jsonPath("$.summaries[0].filingDate").value("2024-10-31"))
+                .andExpect(jsonPath("$.summaries[0].summary").value(containsString("strong revenue growth")));
+    }
+
+    @Test
+    void filingSummaries_missingTicker_returns400() throws Exception {
+        mockMvc.perform(get("/filing-summaries"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- /indexes endpoint ---
+
+    @Test
+    void listIndexes_returns200() throws Exception {
+        MarketIndex fat50 = new MarketIndex();
+        fat50.setCode("FAT50");
+        fat50.setDisplayName("Fattore 50");
+        MarketIndex fat100 = new MarketIndex();
+        fat100.setCode("FAT100");
+        fat100.setDisplayName("Fattore 100");
+        MarketIndex fat1000 = new MarketIndex();
+        fat1000.setCode("FAT1000");
+        fat1000.setDisplayName("Fattore 1000");
+        when(marketIndexRepository.findAll()).thenReturn(List.of(fat50, fat100, fat1000));
+
+        mockMvc.perform(get("/indexes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].code").value("FAT100"))
+                .andExpect(jsonPath("$[0].displayName").value("Fattore 100"))
+                .andExpect(jsonPath("$[1].code").value("FAT1000"))
+                .andExpect(jsonPath("$[1].displayName").value("Fattore 1000"))
+                .andExpect(jsonPath("$[2].code").value("FAT50"))
+                .andExpect(jsonPath("$[2].displayName").value("Fattore 50"));
+    }
+
+    // --- /index-members endpoint ---
+
+    @Test
+    void listIndexMembers_returns200() throws Exception {
+        StockRow stock = new StockRow(
+                "AAPL", "Apple", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN,
+                BigDecimal.ONE, BigDecimal.ONE, "US", "United States", "DE", "CA", "Common Stock", 1980);
+        when(indexMemberApiService.listAll()).thenReturn(List.of(
+                new IndexMemberRow(1L, new BigDecimal("5.5"), "Test Index", false, "", stock)
+        ));
+        mockMvc.perform(get("/index-members"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].index").value("Test Index"))
+                .andExpect(jsonPath("$[0].stock.ticker").value("AAPL"));
+    }
+
+    @Test
+    void listIndexMembers_withCode_filters() throws Exception {
+        StockRow stock = new StockRow(
+                "MSFT", "Microsoft", BigDecimal.ONE, BigDecimal.TEN, BigDecimal.TEN,
+                BigDecimal.ONE, BigDecimal.ONE, "US", "United States", "WA", "WA", "Common Stock", 1986);
+        when(indexMemberApiService.listByIndexCode("FAT50")).thenReturn(List.of(
+                new IndexMemberRow(2L, new BigDecimal("3.25"), "Fattore 50", false, "", stock)
+        ));
+        mockMvc.perform(get("/index-members").param("code", "FAT50"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(2))
+                .andExpect(jsonPath("$[0].index").value("Fattore 50"))
+                .andExpect(jsonPath("$[0].stock.ticker").value("MSFT"));
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationServiceTest.java
@@ -1,0 +1,270 @@
+package com.fattorestreet.sec_api.corporateaction;
+
+import com.fattorestreet.sec_api.corporateaction.CorporateActionValidationService.ValidationReport;
+import com.fattorestreet.sec_api.model.CorporateAction;
+import com.fattorestreet.sec_api.model.CorporateAction.ActionType;
+import com.fattorestreet.sec_api.model.CorporateAction.SourceType;
+import com.fattorestreet.sec_api.repository.CorporateActionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CorporateActionValidationServiceTest {
+
+    private static final String TICKER = "AAPL";
+    private static final LocalDate MIN_DATE = LocalDate.of(2024, 1, 1);
+
+    @Mock
+    private CorporateActionRepository corporateActionRepository;
+    @Mock
+    private HttpClient httpClient;
+
+    private CorporateActionValidationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CorporateActionValidationService(
+                corporateActionRepository, new ObjectMapper(), "http://django.test/portfolio/", httpClient);
+    }
+
+    /** Stubs the Django dividends and splits endpoints with the given JSON payloads. */
+    @SuppressWarnings("unchecked")
+    private void stubDjango(String dividendsJson, String splitsJson) throws Exception {
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenAnswer(invocation -> {
+                    HttpRequest request = invocation.getArgument(0);
+                    HttpResponse<String> response = mock(HttpResponse.class);
+                    when(response.statusCode()).thenReturn(200);
+                    when(response.body()).thenReturn(
+                            request.uri().toString().contains("asset-dividends") ? dividendsJson : splitsJson);
+                    return response;
+                });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubDjangoFailure(int statusCode) throws Exception {
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenAnswer(invocation -> {
+                    HttpResponse<String> response = mock(HttpResponse.class);
+                    when(response.statusCode()).thenReturn(statusCode);
+                    return response;
+                });
+    }
+
+    private static CorporateAction dividend(LocalDate date, Double adjusted, double ratio) {
+        CorporateAction a = new CorporateAction();
+        a.setTicker(TICKER);
+        a.setActionType(ActionType.DIVIDEND);
+        a.setEffectiveDate(date);
+        a.setRatio(ratio);
+        a.setAdjustedDividend(adjusted);
+        a.setSourceType(SourceType.SEC_EQUITY_XBRL);
+        return a;
+    }
+
+    private static CorporateAction split(LocalDate date, double ratio) {
+        CorporateAction a = new CorporateAction();
+        a.setTicker(TICKER);
+        a.setActionType(ActionType.SPLIT);
+        a.setEffectiveDate(date);
+        a.setRatio(ratio);
+        return a;
+    }
+
+    @Test
+    void matchingEventsProduceCleanReport() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2024, 2, 9), 0.24, 0.24)));
+        stubDjango("[{\"date\": \"2024-02-09\", \"amount\": 0.24}]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(1, report.secEventCount());
+        assertEquals(1, report.yfEventCount());
+        assertEquals(0, report.missingInSec());
+        assertEquals(0, report.extraInSec());
+        assertEquals(0, report.dateDrift());
+        assertEquals(0, report.amountDrift());
+        assertTrue(report.mismatchSamples().isEmpty());
+    }
+
+    @Test
+    void djangoOnlyEventCountsAsMissingInSec() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of());
+        stubDjango("[{\"date\": \"2024-02-09\", \"amount\": 0.24}]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(1, report.missingInSec());
+        assertEquals("missing_in_sec", report.mismatchSamples().get(0).get("category"));
+        assertEquals("high", report.mismatchSamples().get(0).get("severity"));
+    }
+
+    @Test
+    void secOnlyEventCountsAsExtraInSec() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2024, 2, 9), 0.24, 0.24)));
+        stubDjango("[]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(1, report.extraInSec());
+        assertEquals("extra_in_sec", report.mismatchSamples().get(0).get("category"));
+    }
+
+    @Test
+    void amountGapBeyondToleranceIsAmountDrift() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2024, 2, 9), 0.30, 0.30)));
+        stubDjango("[{\"date\": \"2024-02-09\", \"amount\": 0.24}]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(1, report.amountDrift());
+        assertEquals(0, report.missingInSec());
+        assertEquals("amount_drift", report.mismatchSamples().get(0).get("category"));
+    }
+
+    @Test
+    void dateGapWithinToleranceIsDateDrift() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2024, 2, 12), 0.24, 0.24)));
+        stubDjango("[{\"date\": \"2024-02-09\", \"amount\": 0.24}]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(1, report.dateDrift());
+        assertEquals(0, report.missingInSec());
+        assertEquals(0, report.extraInSec());
+    }
+
+    @Test
+    void minDateFiltersOldEventsOnBothSides() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2023, 11, 10), 0.24, 0.24)));
+        stubDjango("[{\"date\": \"2023-11-10\", \"amount\": 0.24}]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(0, report.secEventCount());
+        assertEquals(0, report.yfEventCount());
+    }
+
+    @Test
+    void djangoHttpErrorDegradesToEmptyReference() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2024, 2, 9), 0.24, 0.24)));
+        stubDjangoFailure(500);
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(0, report.yfEventCount());
+        assertEquals(1, report.extraInSec());
+    }
+
+    @Test
+    void yfinanceSplitMultiplierIsNormalizedToSecRatio() throws Exception {
+        // SEC stores 4:1 as 0.25; yfinance reports it as 4.0 — they must match after normalization.
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                split(LocalDate.of(2024, 6, 10), 0.25)));
+        stubDjango("[]", "[{\"date\": \"2024-06-10\", \"value\": 4.0}]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(0, report.missingInSec());
+        assertEquals(0, report.extraInSec());
+        assertEquals(0, report.amountDrift());
+    }
+
+    @Test
+    void dividendFallsBackToValueFieldWhenAmountMissing() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of(
+                dividend(LocalDate.of(2024, 2, 9), 0.24, 0.24)));
+        stubDjango("[{\"date\": \"2024-02-09\", \"value\": 0.24}]", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(1, report.yfEventCount());
+        assertEquals(0, report.missingInSec());
+    }
+
+    @Test
+    void interruptedFetchRestoresInterruptFlagAndDegrades() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of());
+        when(httpClient.send(any(HttpRequest.class), any()))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(0, report.yfEventCount());
+        assertTrue(Thread.interrupted(), "interrupt flag should be restored (and cleared here)");
+    }
+
+    @Test
+    void nonArrayDjangoPayloadIsTreatedAsFetchFailure() throws Exception {
+        when(corporateActionRepository.findByTicker(TICKER)).thenReturn(List.of());
+        stubDjango("{\"detail\": \"not a list\"}", "[]");
+
+        ValidationReport report = service.validateTicker(TICKER, MIN_DATE);
+
+        assertEquals(0, report.yfEventCount());
+    }
+
+    @Test
+    void summarizeBatchAggregatesCountsAndMismatchRate() throws Exception {
+        ValidationReport clean = new ValidationReport(TICKER, 2, 2, 0, 0, 0, 0, List.of());
+        ValidationReport dirty = new ValidationReport("MSFT", 1, 2, 1, 0, 0, 1,
+                List.of(Map.of("ticker", "MSFT", "category", "missing_in_sec")));
+
+        Map<String, Object> summary = service.summarizeBatch(List.of(clean, dirty));
+
+        assertEquals(2, summary.get("tickersValidated"));
+        assertEquals(3, summary.get("secEvents"));
+        assertEquals(4, summary.get("yfinanceEvents"));
+        assertEquals(1, summary.get("missingInSec"));
+        assertEquals(1, summary.get("amountDrift"));
+        // (missing 1 + dateDrift 0 + amountDrift 1) / 4 yf events
+        assertEquals(0.5, summary.get("mismatchRate"));
+        assertEquals(1, ((List<?>) summary.get("sampleMismatches")).size());
+    }
+
+    @Test
+    void summarizeBatchWithNoYfEventsHasZeroMismatchRate() {
+        ValidationReport empty = new ValidationReport(TICKER, 1, 0, 0, 1, 0, 0, List.of());
+
+        Map<String, Object> summary = service.summarizeBatch(List.of(empty));
+
+        assertEquals(0.0, summary.get("mismatchRate"));
+    }
+
+    @Test
+    void requestUrlsEncodeTickerAndTrimBaseSlash() throws Exception {
+        when(corporateActionRepository.findByTicker("BRK.B")).thenReturn(List.of());
+        stubDjango("[]", "[]");
+
+        service.validateTicker("BRK.B", MIN_DATE);
+
+        org.mockito.ArgumentCaptor<HttpRequest> captor = org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient, times(2)).send(captor.capture(), any());
+        assertEquals("http://django.test/portfolio/api/asset-dividends/?ticker=BRK.B",
+                captor.getAllValues().get(0).uri().toString());
+        assertEquals("http://django.test/portfolio/api/asset-splits/?ticker=BRK.B",
+                captor.getAllValues().get(1).uri().toString());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/EdgarFilingDiscoveryServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/EdgarFilingDiscoveryServiceTest.java
@@ -1,0 +1,205 @@
+package com.fattorestreet.sec_api.corporateaction;
+
+import com.fattorestreet.sec_api.client.WebService;
+import com.fattorestreet.sec_api.corporateaction.EdgarFilingDiscoveryService.FilingMeta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EdgarFilingDiscoveryServiceTest {
+
+    private static final long CIK = 320193L;
+
+    @Mock
+    private WebService webService;
+
+    private EdgarFilingDiscoveryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EdgarFilingDiscoveryService(webService, new ObjectMapper());
+    }
+
+    private static String recentSubmissions(String filesArray) {
+        return """
+                {
+                  "filings": {
+                    "recent": {
+                      "accessionNumber": ["0000320193-24-000123", "0000320193-24-000100"],
+                      "form": ["10-k", "8-K"],
+                      "primaryDocument": ["aapl-10k.htm", "aapl-8k.htm"],
+                      "filingDate": ["2024-11-01", "2024-08-01"]
+                    },
+                    "files": %s
+                  }
+                }
+                """.formatted(filesArray);
+    }
+
+    @Test
+    void discoversRecentFilingsSortedByDateDescWithNormalizedForms() {
+        when(webService.fetchSubmissions(CIK)).thenReturn(recentSubmissions("[]"));
+
+        List<FilingMeta> filings = service.discoverFilings(CIK);
+
+        assertEquals(2, filings.size());
+        assertEquals("0000320193-24-000123", filings.get(0).accessionNumber());
+        assertEquals("10-K", filings.get(0).formType());
+        assertEquals("aapl-10k.htm", filings.get(0).primaryDocument());
+        assertEquals(LocalDate.of(2024, 11, 1), filings.get(0).filingDate());
+        assertEquals("8-K", filings.get(1).formType());
+    }
+
+    @Test
+    void mergesArchiveBundlesAndDeduplicatesByAccession() {
+        when(webService.fetchSubmissions(CIK)).thenReturn(
+                recentSubmissions("[{\"name\": \"submissions-001.json\"}]"));
+        // The archive repeats an accession from recent (kept once) and adds an older one.
+        when(webService.fetchSubmissionsFile(CIK, "submissions-001.json")).thenReturn("""
+                {
+                  "filings": {
+                    "recent": {
+                      "accessionNumber": ["0000320193-24-000100", "0000320193-20-000050"],
+                      "form": ["8-K", "10-Q"],
+                      "primaryDocument": ["dup.htm", "aapl-10q.htm"],
+                      "filingDate": ["2024-08-01", "2020-05-01"]
+                    }
+                  }
+                }
+                """);
+
+        List<FilingMeta> filings = service.discoverFilings(CIK);
+
+        assertEquals(3, filings.size());
+        // First occurrence wins for the duplicated accession.
+        FilingMeta dup = filings.stream()
+                .filter(f -> f.accessionNumber().equals("0000320193-24-000100"))
+                .findFirst().orElseThrow();
+        assertEquals("aapl-8k.htm", dup.primaryDocument());
+        assertEquals("0000320193-20-000050", filings.get(2).accessionNumber());
+    }
+
+    @Test
+    void honorsMaxSubmissionFilesToScan() {
+        when(webService.fetchSubmissions(CIK)).thenReturn(recentSubmissions(
+                "[{\"name\": \"a.json\"}, {\"name\": \"b.json\"}, {\"name\": \"c.json\"}]"));
+        when(webService.fetchSubmissionsFile(eq(CIK), anyString())).thenReturn("{}");
+
+        service.discoverFilings(CIK, 2);
+
+        verify(webService).fetchSubmissionsFile(CIK, "a.json");
+        verify(webService).fetchSubmissionsFile(CIK, "b.json");
+        verify(webService, never()).fetchSubmissionsFile(CIK, "c.json");
+    }
+
+    @Test
+    void blankArchiveNamesAreSkippedWithoutConsumingScanBudget() {
+        when(webService.fetchSubmissions(CIK)).thenReturn(recentSubmissions(
+                "[{\"name\": \"\"}, {\"other\": 1}, {\"name\": \"real.json\"}]"));
+        when(webService.fetchSubmissionsFile(CIK, "real.json")).thenReturn("{}");
+
+        service.discoverFilings(CIK, 1);
+
+        verify(webService).fetchSubmissionsFile(CIK, "real.json");
+    }
+
+    @Test
+    void archiveFetchFailureKeepsOtherFilings() {
+        when(webService.fetchSubmissions(CIK)).thenReturn(recentSubmissions(
+                "[{\"name\": \"broken.json\"}]"));
+        when(webService.fetchSubmissionsFile(CIK, "broken.json"))
+                .thenThrow(new RuntimeException("unavailable"));
+
+        List<FilingMeta> filings = service.discoverFilings(CIK);
+
+        assertEquals(2, filings.size());
+    }
+
+    @Test
+    void malformedRecentPayloadYieldsEmptyList() {
+        when(webService.fetchSubmissions(CIK)).thenReturn("this is not json{{");
+
+        assertTrue(service.discoverFilings(CIK).isEmpty());
+    }
+
+    @Test
+    void nullRecentPayloadYieldsEmptyList() {
+        when(webService.fetchSubmissions(CIK)).thenReturn(null);
+
+        assertTrue(service.discoverFilings(CIK).isEmpty());
+    }
+
+    @Test
+    void rowsMissingAccessionOrPrimaryDocumentAreSkipped() {
+        when(webService.fetchSubmissions(CIK)).thenReturn("""
+                {
+                  "filings": {
+                    "recent": {
+                      "accessionNumber": ["", "0000320193-24-000200", "0000320193-24-000300"],
+                      "form": ["8-K", "8-K", "8-K"],
+                      "primaryDocument": ["a.htm", "", "c.htm"],
+                      "filingDate": ["2024-01-01", "2024-02-01", "2024-03-01"]
+                    }
+                  }
+                }
+                """);
+
+        List<FilingMeta> filings = service.discoverFilings(CIK);
+
+        assertEquals(1, filings.size());
+        assertEquals("0000320193-24-000300", filings.get(0).accessionNumber());
+    }
+
+    @Test
+    void unparseableFilingDatesSortLast() {
+        when(webService.fetchSubmissions(CIK)).thenReturn("""
+                {
+                  "filings": {
+                    "recent": {
+                      "accessionNumber": ["acc-no-date", "acc-with-date"],
+                      "form": ["8-K", "8-K"],
+                      "primaryDocument": ["a.htm", "b.htm"],
+                      "filingDate": ["not-a-date", "2024-03-01"]
+                    }
+                  }
+                }
+                """);
+
+        List<FilingMeta> filings = service.discoverFilings(CIK);
+
+        assertEquals("acc-with-date", filings.get(0).accessionNumber());
+        assertNull(filings.get(1).filingDate());
+    }
+
+    @Test
+    void parsesFilingsArrayShape() {
+        when(webService.fetchSubmissions(CIK)).thenReturn("""
+                {
+                  "filings": [
+                    {
+                      "accessionNumber": "acc-array-1",
+                      "form": "10-q",
+                      "primaryDocument": "doc.htm",
+                      "filingDate": "2023-06-30"
+                    }
+                  ]
+                }
+                """);
+
+        List<FilingMeta> filings = service.discoverFilings(CIK);
+
+        assertEquals(1, filings.size());
+        assertEquals("10-Q", filings.get(0).formType());
+        assertEquals(LocalDate.of(2023, 6, 30), filings.get(0).filingDate());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/support/EquitySplitDetectorTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/support/EquitySplitDetectorTest.java
@@ -1,0 +1,241 @@
+package com.fattorestreet.sec_api.corporateaction.support;
+
+import com.fattorestreet.sec_api.corporateaction.CorporateActionFilingDateService;
+import com.fattorestreet.sec_api.corporateaction.CorporateActionFilingDateService.SplitDateCandidate;
+import com.fattorestreet.sec_api.corporateaction.EquityCorporateActionService.SplitDetectionStats;
+import com.fattorestreet.sec_api.model.CorporateAction;
+import com.fattorestreet.sec_api.model.CorporateAction.ActionType;
+import com.fattorestreet.sec_api.repository.CorporateActionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EquitySplitDetectorTest {
+
+    private static final String TICKER = "AAPL";
+    private static final long CIK = 320193L;
+
+    @Mock
+    private CorporateActionFilingDateService corporateActionFilingDateService;
+    @Mock
+    private CorporateActionRepository corporateActionRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private EquitySplitDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        detector = new EquitySplitDetector(corporateActionFilingDateService, corporateActionRepository);
+    }
+
+    private JsonNode facts(String sharesEntries) {
+        return objectMapper.readTree("""
+                {
+                  "facts": {
+                    "dei": {
+                      "EntityCommonStockSharesOutstanding": {
+                        "units": {
+                          "shares": %s
+                        }
+                      }
+                    }
+                  }
+                }
+                """.formatted(sharesEntries));
+    }
+
+    private static String sharesEntry(String end, long val, String form) {
+        return "{\"end\": \"%s\", \"val\": %d, \"form\": \"%s\"}".formatted(end, val, form);
+    }
+
+    @Test
+    void detectsForwardSplitWithFallbackDate() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-06-30", 200_000_000L, "10-Q")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+        when(corporateActionRepository.existsByTickerAndActionTypeAndEffectiveDate(
+                eq(TICKER), eq(ActionType.SPLIT), any())).thenReturn(false);
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        ArgumentCaptor<CorporateAction> captor = ArgumentCaptor.forClass(CorporateAction.class);
+        verify(corporateActionRepository).save(captor.capture());
+        CorporateAction saved = captor.getValue();
+        assertEquals(TICKER, saved.getTicker());
+        assertEquals(ActionType.SPLIT, saved.getActionType());
+        assertEquals(0.5, saved.getRatio());
+        // No SEC candidate: falls back to the shares-entry date where the jump was observed.
+        assertEquals(LocalDate.of(2020, 6, 30), saved.getEffectiveDate());
+        assertEquals(CorporateAction.SourceType.SEC_EQUITY_XBRL, saved.getSourceType());
+        assertEquals(1, stats.created());
+    }
+
+    @Test
+    void prefersSecSplitDateCandidateInsideWindow() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-09-30", 400_000_000L, "10-Q")));
+        SplitDateCandidate candidate = new SplitDateCandidate(
+                LocalDate.of(2020, 8, 31), LocalDate.of(2020, 7, 31), "acc-1", 90);
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of(candidate));
+        when(corporateActionRepository.existsByTickerAndActionTypeAndEffectiveDate(
+                TICKER, ActionType.SPLIT, LocalDate.of(2020, 8, 31))).thenReturn(false);
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        ArgumentCaptor<CorporateAction> captor = ArgumentCaptor.forClass(CorporateAction.class);
+        verify(corporateActionRepository).save(captor.capture());
+        assertEquals(LocalDate.of(2020, 8, 31), captor.getValue().getEffectiveDate());
+        assertEquals(0.25, captor.getValue().getRatio());
+        assertEquals(1, stats.created());
+    }
+
+    @Test
+    void skipsWhenSplitAlreadyPersisted() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-06-30", 200_000_000L, "10-Q")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+        when(corporateActionRepository.existsByTickerAndActionTypeAndEffectiveDate(
+                eq(TICKER), eq(ActionType.SPLIT), any())).thenReturn(true);
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        verify(corporateActionRepository, never()).save(any());
+        assertEquals(0, stats.created());
+    }
+
+    @Test
+    void noSplitWhenSharesStayFlat() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-06-30", 101_000_000L, "10-Q")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        verify(corporateActionRepository, never()).save(any());
+        assertEquals(0, stats.created());
+        assertEquals(2, stats.sharesFactsParsed());
+    }
+
+    @Test
+    void missingSharesFactsReturnsZeroStats() {
+        JsonNode root = objectMapper.readTree("{\"facts\": {}}");
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        assertEquals(0, stats.sharesFactsParsed());
+        assertEquals(0, stats.created());
+        verifyNoInteractions(corporateActionFilingDateService);
+    }
+
+    @Test
+    void ignoresIrrelevantForms() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "S-1"),
+                sharesEntry("2020-06-30", 200_000_000L, "S-1")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        assertEquals(0, stats.sharesFactsParsed());
+        verify(corporateActionRepository, never()).save(any());
+    }
+
+    @Test
+    void extendedRatioRequiresSecDateConfirmation() {
+        // 3:2 split (x1.5) is an "extended" ratio: skipped without a matching SEC candidate.
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-06-30", 150_000_000L, "10-Q")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        verify(corporateActionRepository, never()).save(any());
+        assertEquals(0, stats.created());
+    }
+
+    @Test
+    void extendedRatioPersistedWhenSecCandidateMatches() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-06-30", 150_000_000L, "10-Q")));
+        SplitDateCandidate candidate = new SplitDateCandidate(
+                LocalDate.of(2020, 6, 15), LocalDate.of(2020, 5, 20), "acc-2", 80);
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of(candidate));
+        when(corporateActionRepository.existsByTickerAndActionTypeAndEffectiveDate(
+                TICKER, ActionType.SPLIT, LocalDate.of(2020, 6, 15))).thenReturn(false);
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        ArgumentCaptor<CorporateAction> captor = ArgumentCaptor.forClass(CorporateAction.class);
+        verify(corporateActionRepository).save(captor.capture());
+        assertEquals(1.0 / 1.5, captor.getValue().getRatio(), 1e-9);
+        assertEquals(1, stats.created());
+    }
+
+    @Test
+    void skipsSharesPairsWithHugeGaps() {
+        // > 400 days between observations: a doubling is not credible split evidence.
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2018-03-31", 100_000_000L, "10-K"),
+                sharesEntry("2020-06-30", 200_000_000L, "10-K")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        verify(corporateActionRepository, never()).save(any());
+        assertEquals(0, stats.created());
+    }
+
+    @Test
+    void detectsReverseSplit() {
+        JsonNode root = facts("[%s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-06-30", 25_000_000L, "10-Q")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(CIK)).thenReturn(List.of());
+        when(corporateActionRepository.existsByTickerAndActionTypeAndEffectiveDate(
+                eq(TICKER), eq(ActionType.SPLIT), any())).thenReturn(false);
+
+        detector.detectSplits(TICKER, CIK, root);
+
+        ArgumentCaptor<CorporateAction> captor = ArgumentCaptor.forClass(CorporateAction.class);
+        verify(corporateActionRepository).save(captor.capture());
+        assertEquals(4.0, captor.getValue().getRatio(), 1e-9);
+    }
+
+    @Test
+    void duplicateDatesKeepLargestSharesValue() {
+        // Two rows for the same end date (original + amendment): the larger value wins,
+        // so no bogus 2:1 "split" between them is detected.
+        JsonNode root = facts("[%s, %s, %s]".formatted(
+                sharesEntry("2020-03-31", 100_000_000L, "10-Q"),
+                sharesEntry("2020-03-31", 200_000_000L, "10-Q/A"),
+                sharesEntry("2020-06-30", 200_000_000L, "10-Q")));
+        when(corporateActionFilingDateService.fetchSplitEffectiveDates(anyLong())).thenReturn(List.of());
+
+        SplitDetectionStats stats = detector.detectSplits(TICKER, CIK, root);
+
+        verify(corporateActionRepository, never()).save(any());
+        assertEquals(0, stats.created());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/support/EtfActionPersisterTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/support/EtfActionPersisterTest.java
@@ -1,0 +1,96 @@
+package com.fattorestreet.sec_api.corporateaction.support;
+
+import com.fattorestreet.sec_api.corporateaction.support.EtfActionPersister.PersistResult;
+import com.fattorestreet.sec_api.corporateaction.support.EtfDateExtractor.EtfDateSignals;
+import com.fattorestreet.sec_api.model.CorporateAction;
+import com.fattorestreet.sec_api.model.CorporateAction.ActionType;
+import com.fattorestreet.sec_api.model.CorporateAction.SourceType;
+import com.fattorestreet.sec_api.model.Listing;
+import com.fattorestreet.sec_api.repository.CorporateActionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EtfActionPersisterTest {
+
+    private static final LocalDate EX_DATE = LocalDate.of(2025, 3, 20);
+
+    @Mock
+    private CorporateActionRepository corporateActionRepository;
+
+    @InjectMocks
+    private EtfActionPersister persister;
+
+    private Listing listing;
+    private EtfDateSignals signals;
+
+    @BeforeEach
+    void setUp() {
+        listing = new Listing();
+        listing.setTicker("VOO");
+        listing.setSecSeriesId("S000002277");
+        listing.setSecClassContractId("C000005780");
+        signals = new EtfDateSignals(
+                EX_DATE,
+                LocalDate.of(2025, 3, 21),
+                LocalDate.of(2025, 3, 25),
+                85,
+                "record+1bd",
+                "derived",
+                "explicit",
+                "explicit");
+    }
+
+    @Test
+    void savesNewDividendWithAllFields() {
+        when(corporateActionRepository.findByTickerAndActionTypeAndEffectiveDateAndRatioAndSourceType(
+                "VOO", ActionType.DIVIDEND, EX_DATE, 1.7181, SourceType.SEC_ETF_FILING))
+                .thenReturn(Optional.empty());
+
+        PersistResult result = persister.persistDividend(
+                "VOO", listing, "N-CSR", "acc-123", EX_DATE, 1.7181, signals);
+
+        assertEquals(PersistResult.SAVED, result);
+        ArgumentCaptor<CorporateAction> captor = ArgumentCaptor.forClass(CorporateAction.class);
+        verify(corporateActionRepository).save(captor.capture());
+        CorporateAction saved = captor.getValue();
+        assertEquals("VOO", saved.getTicker());
+        assertEquals(ActionType.DIVIDEND, saved.getActionType());
+        assertEquals(EX_DATE, saved.getEffectiveDate());
+        assertEquals(1.7181, saved.getRatio());
+        assertEquals(1.7181, saved.getRawDividend());
+        assertEquals(1.7181, saved.getAdjustedDividend());
+        assertEquals(SourceType.SEC_ETF_FILING, saved.getSourceType());
+        assertEquals("N-CSR", saved.getFormType());
+        assertEquals("acc-123", saved.getAccessionNumber());
+        assertEquals(LocalDate.of(2025, 3, 21), saved.getRecordDate());
+        assertEquals(LocalDate.of(2025, 3, 25), saved.getPayDate());
+        assertEquals(85.0, saved.getConfidenceScore());
+        assertEquals("S000002277", saved.getSecSeriesId());
+        assertEquals("C000005780", saved.getSecClassContractId());
+    }
+
+    @Test
+    void duplicateDividendIsNotSavedAgain() {
+        when(corporateActionRepository.findByTickerAndActionTypeAndEffectiveDateAndRatioAndSourceType(
+                "VOO", ActionType.DIVIDEND, EX_DATE, 1.7181, SourceType.SEC_ETF_FILING))
+                .thenReturn(Optional.of(new CorporateAction()));
+
+        PersistResult result = persister.persistDividend(
+                "VOO", listing, "N-CSR", "acc-123", EX_DATE, 1.7181, signals);
+
+        assertEquals(PersistResult.DUPLICATE, result);
+        verify(corporateActionRepository, never()).save(any());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/fundamentals/EdgarServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/fundamentals/EdgarServiceTest.java
@@ -1,17 +1,27 @@
 package com.fattorestreet.sec_api.fundamentals;
 
 import com.fattorestreet.sec_api.client.WebService;
+import com.fattorestreet.sec_api.model.Asset;
 import com.fattorestreet.sec_api.model.Quarter;
 import com.fattorestreet.sec_api.repository.AssetRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EdgarServiceTest {
@@ -119,5 +129,221 @@ class EdgarServiceTest {
         callDeriveBalanceSheetFields(q);
 
         assertEquals(-300L, q.getStockholdersEquity());
+    }
+
+    // --- updateFinancials (companyfacts parsing) ---
+
+    private static Asset asset(long cik) {
+        Asset a = new Asset();
+        a.setId(1L);
+        a.setCik(cik);
+        return a;
+    }
+
+    private List<Quarter> runUpdateFinancials(String companyFactsJson) throws Exception {
+        Asset apple = asset(320193L);
+        when(webService.fetchFinancials(320193L)).thenReturn(companyFactsJson);
+
+        edgarService.updateFinancials(apple);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Quarter>> captor = ArgumentCaptor.forClass(List.class);
+        verify(quarterService).updateAssetQuarters(eq(apple), captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    void updateFinancials_buildsQuarterFromThreeMonthFacts() throws Exception {
+        List<Quarter> quarters = runUpdateFinancials("""
+                {
+                  "facts": {
+                    "us-gaap": {
+                      "Revenues": {
+                        "units": {
+                          "USD": [
+                            {"start": "2024-01-01", "end": "2024-03-31", "val": 1000,
+                             "fy": 2024, "fp": "Q1", "form": "10-Q"}
+                          ]
+                        }
+                      },
+                      "NetIncomeLoss": {
+                        "units": {
+                          "USD": [
+                            {"start": "2024-01-01", "end": "2024-03-31", "val": 250,
+                             "fy": 2024, "fp": "Q1", "form": "10-Q"}
+                          ]
+                        }
+                      },
+                      "Assets": {
+                        "units": {
+                          "USD": [
+                            {"end": "2024-03-31", "val": 5000, "fy": 2024, "fp": "Q1", "form": "10-Q"}
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+        assertEquals(1, quarters.size());
+        Quarter q = quarters.get(0);
+        assertEquals(2024, q.getYear());
+        assertEquals(1, q.getQuarter());
+        assertEquals(1000L, q.getRevenues());
+        assertEquals(250L, q.getNetIncomeLoss());
+        // The instant Assets fact lands in its own period key (end|end), so this quarter
+        // only carries the flow fields.
+        assertNull(q.getAssets());
+    }
+
+    @Test
+    void updateFinancials_derivesQuarterFromYtdDifference() throws Exception {
+        // Q2 revenue reported only as a 6-month YTD figure: derived as YTD6 - Q1.
+        List<Quarter> quarters = runUpdateFinancials("""
+                {
+                  "facts": {
+                    "us-gaap": {
+                      "Revenues": {
+                        "units": {
+                          "USD": [
+                            {"start": "2024-01-01", "end": "2024-03-31", "val": 1000,
+                             "fy": 2024, "fp": "Q1", "form": "10-Q"},
+                            {"start": "2024-01-01", "end": "2024-06-30", "val": 2200,
+                             "fy": 2024, "fp": "Q2", "form": "10-Q"}
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+        assertEquals(2, quarters.size());
+        Quarter q2 = quarters.stream()
+                .filter(q -> q.getPeriodEnd().toString().equals("2024-06-30"))
+                .findFirst().orElseThrow();
+        assertEquals(1200L, q2.getRevenues());
+        assertEquals("2024-04-01", q2.getPeriodStart().toString());
+    }
+
+    @Test
+    void updateFinancials_skipsShortPeriods() throws Exception {
+        List<Quarter> quarters = runUpdateFinancials("""
+                {
+                  "facts": {
+                    "us-gaap": {
+                      "Revenues": {
+                        "units": {
+                          "USD": [
+                            {"start": "2024-03-01", "end": "2024-03-31", "val": 300,
+                             "fy": 2024, "fp": "Q1", "form": "8-K"}
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+        assertTrue(quarters.isEmpty(), "a one-month flow period is not a quarter");
+    }
+
+    @Test
+    void updateFinancials_missingFactsYieldsNoQuarters() throws Exception {
+        assertTrue(runUpdateFinancials("{}").isEmpty());
+    }
+
+    @Test
+    void updateFinancials_fallbackRevenueTagIsUsed() throws Exception {
+        List<Quarter> quarters = runUpdateFinancials("""
+                {
+                  "facts": {
+                    "us-gaap": {
+                      "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                        "units": {
+                          "USD": [
+                            {"start": "2024-01-01", "end": "2024-03-31", "val": 900,
+                             "fy": 2024, "fp": "Q1", "form": "10-Q"}
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+
+        assertEquals(1, quarters.size());
+        assertEquals(900L, quarters.get(0).getRevenues());
+    }
+
+    // --- syncFramesFull (XBRL frames sync) ---
+
+    @Test
+    void syncFramesFull_collectsFramesAndDerivesMissingQuarterFromAnnual() throws Exception {
+        Asset apple = asset(320193L);
+        when(assetRepository.findByIsFund(false)).thenReturn(List.of(apple));
+        when(assetRepository.countByIsFund(true)).thenReturn(7L);
+        // Default: every frame request returns an empty payload.
+        lenient().when(webService.fetchXbrlFrames(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("{}");
+
+        // Q1-Q3 2024 net income frames; Q4 comes only from the annual total.
+        when(webService.fetchXbrlFrames("us-gaap", "NetIncomeLoss", "USD", "CY2024Q1"))
+                .thenReturn(frame("2024-01-01", "2024-03-31", 100, 2024, "Q1"));
+        when(webService.fetchXbrlFrames("us-gaap", "NetIncomeLoss", "USD", "CY2024Q2"))
+                .thenReturn(frame("2024-04-01", "2024-06-30", 200, 2024, "Q2"));
+        when(webService.fetchXbrlFrames("us-gaap", "NetIncomeLoss", "USD", "CY2024Q3"))
+                .thenReturn(frame("2024-07-01", "2024-09-30", 300, 2024, "Q3"));
+        when(webService.fetchXbrlFrames("us-gaap", "NetIncomeLoss", "USD", "CY2024"))
+                .thenReturn(frame("2024-01-01", "2024-12-31", 1000, 2024, "FY"));
+
+        var result = edgarService.syncFramesFull();
+
+        assertEquals(1, result.get("equitiesProcessed"));
+        assertEquals(7L, result.get("fundsSkipped"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<Quarter>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(quarterService).batchUpsertQuarters(eq(2024), eq(1), captor.capture());
+        assertEquals(100L, captor.getValue().iterator().next().getNetIncomeLoss());
+
+        verify(quarterService).batchUpsertQuarters(eq(2024), eq(4), captor.capture());
+        Quarter q4 = captor.getValue().iterator().next();
+        assertEquals(400L, q4.getNetIncomeLoss(), "Q4 must be derived as annual - (Q1+Q2+Q3)");
+        assertEquals("2024-12-31", q4.getPeriodEnd().toString());
+    }
+
+    @Test
+    void syncFramesFull_ignoresFramesForUnknownCiksAndNonQuarterPeriods() throws Exception {
+        Asset apple = asset(320193L);
+        when(assetRepository.findByIsFund(false)).thenReturn(List.of(apple));
+        when(assetRepository.countByIsFund(true)).thenReturn(0L);
+        lenient().when(webService.fetchXbrlFrames(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("{}");
+
+        // Unknown CIK plus a 6-month "quarter": both must be dropped.
+        when(webService.fetchXbrlFrames("us-gaap", "Revenues", "USD", "CY2024Q1"))
+                .thenReturn("""
+                        {"data": [
+                          {"cik": 999999, "start": "2024-01-01", "end": "2024-03-31", "val": 5,
+                           "fy": 2024, "fp": "Q1"},
+                          {"cik": 320193, "start": "2024-01-01", "end": "2024-06-30", "val": 5,
+                           "fy": 2024, "fp": "Q1"}
+                        ]}
+                        """);
+
+        edgarService.syncFramesFull();
+
+        verify(quarterService, org.mockito.Mockito.never())
+                .batchUpsertQuarters(any(), any(), any());
+    }
+
+    private static String frame(String start, String end, long val, int fy, String fp) {
+        return """
+                {"data": [
+                  {"cik": 320193, "start": "%s", "end": "%s", "val": %d, "fy": %d, "fp": "%s"}
+                ]}
+                """.formatted(start, end, val, fy, fp);
     }
 }

--- a/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexMemberApiServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexMemberApiServiceTest.java
@@ -1,0 +1,169 @@
+package com.fattorestreet.sec_api.index;
+
+import com.fattorestreet.sec_api.index.IndexMemberApiService.IndexMemberRow;
+import com.fattorestreet.sec_api.model.IndexMember;
+import com.fattorestreet.sec_api.model.Listing;
+import com.fattorestreet.sec_api.model.ListingIndexMetrics;
+import com.fattorestreet.sec_api.model.MarketIndex;
+import com.fattorestreet.sec_api.repository.IndexMemberRepository;
+import com.fattorestreet.sec_api.repository.ListingIndexMetricsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Year;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IndexMemberApiServiceTest {
+
+    private static final int CURRENT_YEAR = Year.now().getValue();
+
+    @Mock
+    private IndexMemberRepository indexMemberRepository;
+    @Mock
+    private ListingIndexMetricsRepository metricsRepository;
+
+    @InjectMocks
+    private IndexMemberApiService service;
+
+    private static Listing listing(long id, String ticker, String title) {
+        Listing l = new Listing();
+        l.setId(id);
+        l.setTicker(ticker);
+        l.setTitle(title);
+        return l;
+    }
+
+    private static IndexMember member(long id, Listing listing, String indexName, BigDecimal percent) {
+        MarketIndex index = new MarketIndex();
+        index.setDisplayName(indexName);
+        IndexMember im = new IndexMember();
+        im.setId(id);
+        im.setListing(listing);
+        im.setMarketIndex(index);
+        im.setPercent(percent);
+        im.setOutlier(false);
+        return im;
+    }
+
+    private static ListingIndexMetrics metrics(Listing listing) {
+        ListingIndexMetrics m = new ListingIndexMetrics();
+        m.setListing(listing);
+        m.setYear(CURRENT_YEAR);
+        m.setMarketCap(new BigDecimal("3000"));
+        m.setVolume(new BigDecimal("55"));
+        m.setVolumeUsd(new BigDecimal("9000"));
+        m.setFreeFloat(new BigDecimal("0.98"));
+        m.setFreeFloatMarketCap(new BigDecimal("2940"));
+        m.setCountryIncorp("US");
+        m.setCountryHq("US");
+        m.setStateIncorp("DE");
+        m.setStateHq("CA");
+        m.setSecurityType("Common Stock");
+        m.setYearIpo(1980);
+        return m;
+    }
+
+    @Test
+    void listAll_joinsCurrentYearMetricsByListing() {
+        Listing aapl = listing(1L, "AAPL", "Apple Inc.");
+        when(indexMemberRepository.findAllWithListingAndAsset()).thenReturn(List.of(
+                member(10L, aapl, "Fattore 50", new BigDecimal("6.5"))));
+        when(metricsRepository.findAllByYear(CURRENT_YEAR)).thenReturn(List.of(metrics(aapl)));
+
+        List<IndexMemberRow> rows = service.listAll();
+
+        assertEquals(1, rows.size());
+        IndexMemberRow row = rows.get(0);
+        assertEquals(10L, row.id());
+        assertEquals("Fattore 50", row.index());
+        assertEquals(new BigDecimal("6.5"), row.percent());
+        assertEquals("AAPL", row.stock().ticker());
+        assertEquals("Apple Inc.", row.stock().name());
+        assertEquals(new BigDecimal("3000"), row.stock().marketCap());
+        assertEquals("DE", row.stock().stateIncorp());
+        assertEquals(1980, row.stock().yearIPO());
+    }
+
+    @Test
+    void listAll_memberWithoutMetricsGetsZeroDefaults() {
+        Listing nvda = listing(2L, "NVDA", "NVIDIA");
+        when(indexMemberRepository.findAllWithListingAndAsset()).thenReturn(List.of(
+                member(11L, nvda, "Fattore 100", new BigDecimal("4.0"))));
+        when(metricsRepository.findAllByYear(CURRENT_YEAR)).thenReturn(List.of());
+
+        List<IndexMemberRow> rows = service.listAll();
+
+        assertEquals(BigDecimal.ZERO, rows.get(0).stock().marketCap());
+        assertEquals("United States", rows.get(0).stock().countryIncorp());
+        assertEquals("Common Stock", rows.get(0).stock().securityType());
+        assertEquals(0, rows.get(0).stock().yearIPO());
+        assertNull(rows.get(0).stock().stateIncorp());
+    }
+
+    @Test
+    void listAll_nullMetricFieldsFallBackToDefaults() {
+        Listing tsla = listing(3L, "TSLA", "Tesla");
+        ListingIndexMetrics sparse = new ListingIndexMetrics();
+        sparse.setListing(tsla);
+        sparse.setYear(CURRENT_YEAR);
+        when(indexMemberRepository.findAllWithListingAndAsset()).thenReturn(List.of(
+                member(12L, tsla, "Fattore 50", BigDecimal.ONE)));
+        when(metricsRepository.findAllByYear(CURRENT_YEAR)).thenReturn(List.of(sparse));
+
+        List<IndexMemberRow> rows = service.listAll();
+
+        assertEquals(BigDecimal.ZERO, rows.get(0).stock().marketCap());
+        assertEquals("United States", rows.get(0).stock().countryHQ());
+        assertEquals(0, rows.get(0).stock().yearIPO());
+    }
+
+    @Test
+    void listByIndexCode_filtersMembersWithoutListing() {
+        Listing msft = listing(4L, "MSFT", "Microsoft");
+        IndexMember orphan = new IndexMember();
+        orphan.setId(13L);
+        orphan.setListing(null);
+        when(indexMemberRepository.findByMarketIndex_CodeOrderByPercentDesc("FAT50"))
+                .thenReturn(List.of(member(14L, msft, "Fattore 50", BigDecimal.TEN), orphan));
+        when(metricsRepository.findAllByYear(CURRENT_YEAR)).thenReturn(List.of());
+
+        List<IndexMemberRow> rows = service.listByIndexCode("FAT50");
+
+        assertEquals(1, rows.size());
+        assertEquals("MSFT", rows.get(0).stock().ticker());
+    }
+
+    @Test
+    void listByIndexCode_unknownCodeReturnsEmpty() {
+        when(indexMemberRepository.findByMarketIndex_CodeOrderByPercentDesc("NOPE")).thenReturn(List.of());
+        when(metricsRepository.findAllByYear(CURRENT_YEAR)).thenReturn(List.of());
+
+        assertTrue(service.listByIndexCode("NOPE").isEmpty());
+    }
+
+    @Test
+    void nullNotesAndMissingIndexNameBecomeEmptyStrings() {
+        Listing amzn = listing(5L, "AMZN", "Amazon");
+        IndexMember im = new IndexMember();
+        im.setId(15L);
+        im.setListing(amzn);
+        im.setMarketIndex(null);
+        im.setNotes(null);
+        im.setPercent(BigDecimal.ONE);
+        when(indexMemberRepository.findAllWithListingAndAsset()).thenReturn(List.of(im));
+        when(metricsRepository.findAllByYear(CURRENT_YEAR)).thenReturn(List.of());
+
+        List<IndexMemberRow> rows = service.listAll();
+
+        assertEquals("", rows.get(0).index());
+        assertEquals("", rows.get(0).notes());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexMetricsRefreshServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexMetricsRefreshServiceTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.math.BigDecimal;
@@ -38,7 +36,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class IndexMetricsRefreshServiceTest {
 
     private static final int YEAR = 2026;
@@ -525,7 +522,8 @@ class IndexMetricsRefreshServiceTest {
             String t = "T" + i;
             Listing l = listing(t, asset(1000L + i, false));
             listings.add(l);
-            when(dailyPriceRepository.findTopByTickerOrderByTradeDateDesc(t))
+            // lenient: the abort under test stops the loop at 25, leaving the last stubs unused
+            org.mockito.Mockito.lenient().when(dailyPriceRepository.findTopByTickerOrderByTradeDateDesc(t))
                     .thenReturn(Optional.of(price(t, 10.0, 100L)));
         }
         when(listingRepository.findAll()).thenReturn(listings);

--- a/springboot/src/test/java/com/fattorestreet/sec_api/index/IwbHoldingsTickerSetTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/index/IwbHoldingsTickerSetTest.java
@@ -1,0 +1,47 @@
+package com.fattorestreet.sec_api.index;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IwbHoldingsTickerSetTest {
+
+    @Test
+    void loadsEquityTickersFromClasspathCsv() throws IOException {
+        IwbHoldingsTickerSet tickerSet = new IwbHoldingsTickerSet(new DefaultResourceLoader());
+
+        Set<String> tickers = tickerSet.tickers();
+        assertFalse(tickers.isEmpty(), "bundled IWB_holdings.csv should yield tickers");
+        assertEquals(tickers.size(), tickerSet.equityRows().size(),
+                "rows and deduplicated ticker set should agree");
+        assertTrue(tickers.stream().allMatch(t -> t.equals(t.toUpperCase())),
+                "tickers are uppercase symbols");
+    }
+
+    @Test
+    void equityRowsCarryPositiveWeights() throws IOException {
+        IwbHoldingsTickerSet tickerSet = new IwbHoldingsTickerSet(new DefaultResourceLoader());
+
+        assertTrue(tickerSet.equityRows().stream()
+                        .allMatch(r -> r.weightPercent() != null && r.weightPercent().signum() >= 0),
+                "every equity row should have a non-negative weight");
+    }
+
+    @Test
+    void missingResourceYieldsEmptySetWithoutThrowing() throws IOException {
+        DefaultResourceLoader missingEverything = new DefaultResourceLoader() {
+            @Override
+            public org.springframework.core.io.Resource getResource(String location) {
+                return super.getResource("classpath:/data/does-not-exist.csv");
+            }
+        };
+        IwbHoldingsTickerSet tickerSet = new IwbHoldingsTickerSet(missingEverything);
+
+        assertTrue(tickerSet.tickers().isEmpty());
+        assertTrue(tickerSet.equityRows().isEmpty());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/marketdata/IexHistServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/marketdata/IexHistServiceTest.java
@@ -1,0 +1,241 @@
+package com.fattorestreet.sec_api.marketdata;
+
+import com.fattorestreet.sec_api.model.DailyPrice;
+import com.fattorestreet.sec_api.repository.DailyPriceRepository;
+import com.fattorestreet.sec_api.testsupport.PcapTestData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Flow;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IexHistServiceTest {
+
+    private static final DateTimeFormatter KEY_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    @Mock
+    private DailyPriceRepository dailyPriceRepository;
+    @Mock
+    private HttpClient httpClient;
+
+    private IexHistService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IexHistService(dailyPriceRepository, new ObjectMapper(), httpClient);
+    }
+
+    /** Most recent date before today that the service considers a trading day. */
+    private static LocalDate latestTradingDay() {
+        LocalDate date = LocalDate.now().minusDays(1);
+        while (!isTradingDay(date)) {
+            date = date.minusDays(1);
+        }
+        return date;
+    }
+
+    // Mirrors IexHistService.isTradingDay so the test stays date-independent.
+    private static boolean isTradingDay(LocalDate date) {
+        DayOfWeek dow = date.getDayOfWeek();
+        if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) return false;
+        if (Set.of(MonthDay.of(1, 1), MonthDay.of(6, 19), MonthDay.of(7, 4), MonthDay.of(12, 25))
+                .contains(MonthDay.from(date))) return false;
+        int nth = (date.getDayOfMonth() - 1) / 7 + 1;
+        if (date.getMonthValue() == 1 && dow == DayOfWeek.MONDAY && nth == 3) return false;
+        if (date.getMonthValue() == 2 && dow == DayOfWeek.MONDAY && nth == 3) return false;
+        if (date.getMonthValue() == 5 && dow == DayOfWeek.MONDAY && date.getDayOfMonth() > 24) return false;
+        if (date.getMonthValue() == 9 && dow == DayOfWeek.MONDAY && nth == 1) return false;
+        if (date.getMonthValue() == 11 && dow == DayOfWeek.THURSDAY && nth == 4) return false;
+        return true;
+    }
+
+    private static String histIndexJson(LocalDate date) {
+        return """
+                {
+                  "%s": [
+                    {"feed": "DEEP", "link": "https://example.test/deep.pcap.gz", "size": "1048576"},
+                    {"feed": "TOPS", "link": "https://example.test/tops.pcap.gz", "size": "2097152"}
+                  ]
+                }
+                """.formatted(date.format(KEY_FMT));
+    }
+
+    private static byte[] gzip(byte[] bytes) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+            gz.write(bytes);
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Stubs the HttpClient: the HIST index URL answers with JSON, the TOPS download URL streams
+     * the given bytes through the service's real ofFile BodyHandler so its temp file gets written.
+     */
+    private void stubHttp(String indexJson, byte[] downloadBytes) throws Exception {
+        when(httpClient.send(any(HttpRequest.class), any()))
+                .thenAnswer(invocation -> {
+                    HttpRequest request = invocation.getArgument(0);
+                    if (request.uri().toString().contains("iextrading.com/api/1.0/hist")) {
+                        HttpResponse<String> response = mock(HttpResponse.class);
+                        when(response.statusCode()).thenReturn(200);
+                        when(response.body()).thenReturn(indexJson);
+                        return response;
+                    }
+                    HttpResponse.BodyHandler<Object> handler = invocation.getArgument(1);
+                    Object body = feedBodyHandler(handler, downloadBytes);
+                    HttpResponse<Object> response = mock(HttpResponse.class);
+                    lenient().when(response.statusCode()).thenReturn(200);
+                    lenient().when(response.body()).thenReturn(body);
+                    return response;
+                });
+    }
+
+    private static <T> T feedBodyHandler(HttpResponse.BodyHandler<T> handler, byte[] bytes) {
+        HttpResponse.BodySubscriber<T> subscriber = handler.apply(new HttpResponse.ResponseInfo() {
+            @Override public int statusCode() { return 200; }
+            @Override public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (a, b) -> true); }
+            @Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+        });
+        subscriber.onSubscribe(new Flow.Subscription() {
+            @Override public void request(long n) { }
+            @Override public void cancel() { }
+        });
+        subscriber.onNext(List.of(ByteBuffer.wrap(bytes)));
+        subscriber.onComplete();
+        return subscriber.getBody().toCompletableFuture().join();
+    }
+
+    @Test
+    void loadHistData_aggregatesTradesIntoOhlcvAndSaves() throws Exception {
+        LocalDate day = latestTradingDay();
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(
+                        PcapTestData.tradeReport(100L, "AAPL", 10, 172.50),
+                        PcapTestData.tradeReport(200L, "AAPL", 20, 174.00),
+                        PcapTestData.tradeReport(300L, "AAPL", 30, 171.00),
+                        PcapTestData.tradeReport(400L, "AAPL", 40, 173.25),
+                        PcapTestData.tradeReport(250L, "MSFT", 5, 410.00)));
+        stubHttp(histIndexJson(day), gzip(capture));
+        when(dailyPriceRepository.existsByTradeDate(day)).thenReturn(false);
+
+        Map<String, Object> result = service.loadHistData(1);
+
+        assertEquals(1, result.get("processed"));
+        assertEquals(0, result.get("errors"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<DailyPrice>> captor = ArgumentCaptor.forClass(List.class);
+        verify(dailyPriceRepository).saveAll(captor.capture());
+        List<DailyPrice> saved = captor.getValue();
+        assertEquals(2, saved.size());
+
+        DailyPrice aapl = saved.stream().filter(p -> p.getTicker().equals("AAPL")).findFirst().orElseThrow();
+        assertEquals(day, aapl.getTradeDate());
+        assertEquals(172.50, aapl.getOpenPrice());   // earliest timestamp
+        assertEquals(174.00, aapl.getHighPrice());   // max price
+        assertEquals(171.00, aapl.getLowPrice());    // min price
+        assertEquals(173.25, aapl.getClosePrice());  // latest timestamp
+        assertEquals(100L, aapl.getVolume());        // 10+20+30+40
+
+        DailyPrice msft = saved.stream().filter(p -> p.getTicker().equals("MSFT")).findFirst().orElseThrow();
+        assertEquals(410.00, msft.getOpenPrice());
+        assertEquals(410.00, msft.getClosePrice());
+        assertEquals(5L, msft.getVolume());
+    }
+
+    @Test
+    void loadHistData_skipsDatesAlreadyInDatabase() throws Exception {
+        LocalDate day = latestTradingDay();
+        stubHttp(histIndexJson(day), new byte[0]);
+        when(dailyPriceRepository.existsByTradeDate(day)).thenReturn(true);
+
+        Map<String, Object> result = service.loadHistData(1);
+
+        assertEquals(0, result.get("processed"));
+        assertEquals(1, result.get("skipped"));
+        verify(dailyPriceRepository, never()).saveAll(any());
+        // Only the index fetch; no pcap download.
+        verify(httpClient, times(1)).send(any(), any());
+    }
+
+    @Test
+    void loadHistData_reportsDatesWithoutTopsFeed() throws Exception {
+        LocalDate day = latestTradingDay();
+        String indexWithoutTops = """
+                {
+                  "%s": [
+                    {"feed": "DEEP", "link": "https://example.test/deep.pcap.gz", "size": "1048576"}
+                  ]
+                }
+                """.formatted(day.format(KEY_FMT));
+        stubHttp(indexWithoutTops, new byte[0]);
+        when(dailyPriceRepository.existsByTradeDate(day)).thenReturn(false);
+
+        Map<String, Object> result = service.loadHistData(1);
+
+        assertEquals(0, result.get("processed"));
+        assertEquals(1, result.get("notAvailable"));
+    }
+
+    @Test
+    void loadHistData_nonTradingDaysAreNeverRequested() throws Exception {
+        // Index only lists days the exchange published; an empty index means no dates qualify.
+        stubHttp("{}", new byte[0]);
+
+        Map<String, Object> result = service.loadHistData(3);
+
+        assertEquals(0, result.get("processed"));
+        assertEquals(0, result.get("skipped"));
+        assertEquals(0, result.get("notAvailable"));
+        verify(dailyPriceRepository, never()).existsByTradeDate(any());
+    }
+
+    @Test
+    void loadHistData_indexHttpErrorThrows() throws Exception {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(503);
+        when(httpClient.send(any(HttpRequest.class), any())).thenAnswer(invocation -> response);
+
+        IOException e = assertThrows(IOException.class, () -> service.loadHistData(1));
+        assertTrue(e.getMessage().contains("503"));
+    }
+
+    @Test
+    void loadHistData_corruptDownloadCountsAsErrorAndContinues() throws Exception {
+        LocalDate day = latestTradingDay();
+        // Not gzip data: parseGzip fails, the day is recorded as an error, no save happens.
+        stubHttp(histIndexJson(day), new byte[]{1, 2, 3, 4});
+        when(dailyPriceRepository.existsByTradeDate(day)).thenReturn(false);
+
+        Map<String, Object> result = service.loadHistData(1);
+
+        assertEquals(0, result.get("processed"));
+        assertEquals(1, result.get("errors"));
+        verify(dailyPriceRepository, never()).saveAll(any());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/repository/AssetRepositoryTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/repository/AssetRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.fattorestreet.sec_api.repository;
+
+import com.fattorestreet.sec_api.model.Asset;
+import com.fattorestreet.sec_api.model.Listing;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class AssetRepositoryTest {
+
+    @Autowired
+    private AssetRepository repository;
+    @Autowired
+    private TestEntityManager em;
+
+    @BeforeEach
+    void seed() {
+        asset(320193L, false, "AAPL");
+        asset(789019L, false, "MSFT");
+        asset(102909L, true, "VOO");
+        em.flush();
+        em.clear();
+    }
+
+    private void asset(long cik, boolean isFund, String ticker) {
+        Asset a = new Asset();
+        a.setCik(cik);
+        a.setIsFund(isFund);
+        em.persist(a);
+        Listing l = new Listing();
+        l.setTicker(ticker);
+        l.setTitle(ticker + " title");
+        l.setAsset(a);
+        em.persist(l);
+    }
+
+    @Test
+    void findByTickersIn_excludesFunds() {
+        List<Asset> assets = repository.findByTickersIn(List.of("AAPL", "MSFT", "VOO"));
+
+        assertEquals(2, assets.size());
+        assertTrue(assets.stream().noneMatch(Asset::getIsFund));
+    }
+
+    @Test
+    void findByListingsTicker() {
+        Asset asset = repository.findByListings_Ticker("AAPL");
+
+        assertNotNull(asset);
+        assertEquals(320193L, asset.getCik());
+        assertNull(repository.findByListings_Ticker("ZZZZ"));
+    }
+
+    @Test
+    void findAllWithListings_fetchJoinsListings() {
+        List<Asset> assets = repository.findAllWithListings();
+
+        assertEquals(3, assets.size());
+        for (Asset a : assets) {
+            assertTrue(Hibernate.isInitialized(a.getListings()), "listings must be fetch-joined");
+        }
+    }
+
+    @Test
+    void findByCikAndCounts() {
+        assertTrue(repository.findByCik(320193L).isPresent());
+        assertTrue(repository.findByCik(1L).isEmpty());
+        assertEquals(1, repository.countByIsFund(true));
+        assertEquals(2, repository.countByIsFund(false));
+        assertEquals(1, repository.findByIsFund(true).size());
+    }
+
+    @Test
+    void cikIsUnique() {
+        Asset dup = new Asset();
+        dup.setCik(320193L);
+
+        // Identity id generation inserts on persist, so the violation surfaces there already.
+        assertThrows(RuntimeException.class, () -> {
+            em.persist(dup);
+            em.flush();
+        });
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/repository/CorporateActionRepositoryTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/repository/CorporateActionRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.fattorestreet.sec_api.repository;
+
+import com.fattorestreet.sec_api.model.CorporateAction;
+import com.fattorestreet.sec_api.model.CorporateAction.ActionType;
+import com.fattorestreet.sec_api.model.CorporateAction.SourceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class CorporateActionRepositoryTest {
+
+    private static final LocalDate SPLIT_DATE = LocalDate.of(2020, 8, 31);
+    private static final LocalDate DIV_DATE = LocalDate.of(2025, 2, 10);
+
+    @Autowired
+    private CorporateActionRepository repository;
+    @Autowired
+    private TestEntityManager em;
+
+    @BeforeEach
+    void seed() {
+        action("AAPL", ActionType.SPLIT, SPLIT_DATE, 0.25, SourceType.SEC_EQUITY_XBRL);
+        action("AAPL", ActionType.DIVIDEND, DIV_DATE, 0.25, SourceType.SEC_EQUITY_XBRL);
+        action("VOO", ActionType.DIVIDEND, DIV_DATE, 1.72, SourceType.SEC_ETF_FILING);
+        em.flush();
+        em.clear();
+    }
+
+    private void action(String ticker, ActionType type, LocalDate date, double ratio, SourceType source) {
+        CorporateAction a = new CorporateAction();
+        a.setTicker(ticker);
+        a.setActionType(type);
+        a.setEffectiveDate(date);
+        a.setRatio(ratio);
+        a.setSourceType(source);
+        em.persist(a);
+    }
+
+    @Test
+    void findDistinctTickers() {
+        List<String> tickers = repository.findDistinctTickers();
+
+        assertEquals(2, tickers.size());
+        assertTrue(tickers.containsAll(List.of("AAPL", "VOO")));
+    }
+
+    @Test
+    void existsByTickerAndActionTypeAndEffectiveDate() {
+        assertTrue(repository.existsByTickerAndActionTypeAndEffectiveDate("AAPL", ActionType.SPLIT, SPLIT_DATE));
+        assertFalse(repository.existsByTickerAndActionTypeAndEffectiveDate("AAPL", ActionType.DIVIDEND, SPLIT_DATE));
+    }
+
+    @Test
+    void findByTickerAndActionTypeAndEffectiveDateAndRatioAndSourceType_matchesExactRow() {
+        assertTrue(repository.findByTickerAndActionTypeAndEffectiveDateAndRatioAndSourceType(
+                "VOO", ActionType.DIVIDEND, DIV_DATE, 1.72, SourceType.SEC_ETF_FILING).isPresent());
+        assertTrue(repository.findByTickerAndActionTypeAndEffectiveDateAndRatioAndSourceType(
+                "VOO", ActionType.DIVIDEND, DIV_DATE, 1.72, SourceType.SEC_EQUITY_XBRL).isEmpty());
+        assertTrue(repository.findByTickerAndActionTypeAndEffectiveDateAndRatioAndSourceType(
+                "VOO", ActionType.DIVIDEND, DIV_DATE, 1.73, SourceType.SEC_ETF_FILING).isEmpty());
+    }
+
+    @Test
+    void findByTickerOrderByEffectiveDateDesc() {
+        List<CorporateAction> actions = repository.findByTickerOrderByEffectiveDateDesc("AAPL");
+
+        assertEquals(2, actions.size());
+        assertEquals(DIV_DATE, actions.get(0).getEffectiveDate());
+        assertEquals(SPLIT_DATE, actions.get(1).getEffectiveDate());
+    }
+
+    @Test
+    void uniqueConstraintAllowsSameDateDifferentRatio() {
+        // (ticker, action_type, effective_date, ratio) is unique — a different ratio is a new row.
+        action("AAPL", ActionType.DIVIDEND, DIV_DATE, 0.26, SourceType.SEC_EQUITY_XBRL);
+        em.flush();
+
+        assertEquals(2, repository.findAllByTickerAndActionTypeAndEffectiveDate(
+                "AAPL", ActionType.DIVIDEND, DIV_DATE).size());
+    }
+
+    @Test
+    void uniqueConstraintRejectsExactDuplicate() {
+        // Identity id generation inserts on persist, so the violation surfaces there already.
+        assertThrows(RuntimeException.class, () -> {
+            action("AAPL", ActionType.DIVIDEND, DIV_DATE, 0.25, SourceType.SEC_EQUITY_XBRL);
+            em.flush();
+        });
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/repository/DailyPriceRepositoryTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/repository/DailyPriceRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.fattorestreet.sec_api.repository;
+
+import com.fattorestreet.sec_api.model.DailyPrice;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class DailyPriceRepositoryTest {
+
+    private static final LocalDate MONDAY = LocalDate.of(2025, 3, 10);
+    private static final LocalDate TUESDAY = LocalDate.of(2025, 3, 11);
+    private static final LocalDate WEDNESDAY = LocalDate.of(2025, 3, 12);
+
+    @Autowired
+    private DailyPriceRepository repository;
+    @Autowired
+    private TestEntityManager em;
+
+    @BeforeEach
+    void seed() {
+        price("AAPL", MONDAY, 170.0, 169.5);
+        price("AAPL", TUESDAY, 171.0, null);
+        price("MSFT", MONDAY, 410.0, 409.0);
+        em.flush();
+        em.clear();
+    }
+
+    private void price(String ticker, LocalDate date, double close, Double adjustedClose) {
+        DailyPrice dp = new DailyPrice();
+        dp.setTicker(ticker);
+        dp.setTradeDate(date);
+        dp.setClosePrice(close);
+        dp.setAdjustedClose(adjustedClose);
+        em.persist(dp);
+    }
+
+    @Test
+    void findDistinctTickers() {
+        List<String> tickers = repository.findDistinctTickers();
+
+        assertEquals(2, tickers.size());
+        assertTrue(tickers.containsAll(List.of("AAPL", "MSFT")));
+    }
+
+    @Test
+    void findTickersWithUnadjustedPrices_onlyNullAdjustedClose() {
+        assertEquals(List.of("AAPL"), repository.findTickersWithUnadjustedPrices());
+    }
+
+    @Test
+    void existsByTickerAndAdjustedCloseIsNull() {
+        assertTrue(repository.existsByTickerAndAdjustedCloseIsNull("AAPL"));
+        assertFalse(repository.existsByTickerAndAdjustedCloseIsNull("MSFT"));
+    }
+
+    @Test
+    void findTopByTickerAndTradeDateLessThanEqual_picksLatestOnOrBefore() {
+        Optional<DailyPrice> exact = repository
+                .findTopByTickerAndTradeDateLessThanEqualOrderByTradeDateDesc("AAPL", TUESDAY);
+        assertEquals(TUESDAY, exact.orElseThrow().getTradeDate());
+
+        Optional<DailyPrice> later = repository
+                .findTopByTickerAndTradeDateLessThanEqualOrderByTradeDateDesc("AAPL", WEDNESDAY);
+        assertEquals(TUESDAY, later.orElseThrow().getTradeDate());
+
+        Optional<DailyPrice> tooEarly = repository
+                .findTopByTickerAndTradeDateLessThanEqualOrderByTradeDateDesc("AAPL", MONDAY.minusDays(1));
+        assertTrue(tooEarly.isEmpty());
+    }
+
+    @Test
+    void findByTickerAndTradeDateBetween_ordersDescending() {
+        List<DailyPrice> range = repository.findByTickerAndTradeDateBetweenOrderByTradeDateDesc(
+                "AAPL", MONDAY, WEDNESDAY);
+
+        assertEquals(2, range.size());
+        assertEquals(TUESDAY, range.get(0).getTradeDate());
+        assertEquals(MONDAY, range.get(1).getTradeDate());
+    }
+
+    @Test
+    void existsByTradeDate() {
+        assertTrue(repository.existsByTradeDate(MONDAY));
+        assertFalse(repository.existsByTradeDate(WEDNESDAY));
+    }
+
+    @Test
+    void uniqueConstraintRejectsDuplicateTickerDate() {
+        price("AAPL", MONDAY, 999.0, null);
+
+        assertThrows(RuntimeException.class, em::flush,
+                "duplicate (ticker, trade_date) must violate the unique constraint");
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/repository/IndexMemberRepositoryTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/repository/IndexMemberRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.fattorestreet.sec_api.repository;
+
+import com.fattorestreet.sec_api.model.Asset;
+import com.fattorestreet.sec_api.model.IndexMember;
+import com.fattorestreet.sec_api.model.Listing;
+import com.fattorestreet.sec_api.model.MarketIndex;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class IndexMemberRepositoryTest {
+
+    @Autowired
+    private IndexMemberRepository repository;
+    @Autowired
+    private TestEntityManager em;
+
+    private MarketIndex fat50;
+    private MarketIndex fat100;
+
+    @BeforeEach
+    void seed() {
+        fat50 = index("FAT50", "Fattore 50");
+        fat100 = index("FAT100", "Fattore 100");
+        member(fat50, listing("AAPL", "Apple Inc.", 320193L), "8.5");
+        member(fat50, listing("MSFT", "Microsoft", 789019L), "7.25");
+        member(fat100, listing("ORPH", "No Asset Co", null), "1.0");
+        em.flush();
+        em.clear();
+    }
+
+    private MarketIndex index(String code, String name) {
+        MarketIndex mi = new MarketIndex();
+        mi.setCode(code);
+        mi.setDisplayName(name);
+        return em.persist(mi);
+    }
+
+    private Listing listing(String ticker, String title, Long cik) {
+        Listing l = new Listing();
+        l.setTicker(ticker);
+        l.setTitle(title);
+        if (cik != null) {
+            Asset a = new Asset();
+            a.setCik(cik);
+            l.setAsset(em.persist(a));
+        }
+        return em.persist(l);
+    }
+
+    private void member(MarketIndex mi, Listing l, String percent) {
+        IndexMember im = new IndexMember();
+        im.setMarketIndex(mi);
+        im.setListing(l);
+        im.setPercent(new BigDecimal(percent));
+        im.setOutlier(false);
+        em.persist(im);
+    }
+
+    @Test
+    void findAllWithListingAndAsset_fetchJoinsAssociations() {
+        List<IndexMember> members = repository.findAllWithListingAndAsset();
+
+        assertEquals(3, members.size());
+        for (IndexMember im : members) {
+            assertTrue(Hibernate.isInitialized(im.getListing()), "listing must be fetch-joined");
+            assertTrue(Hibernate.isInitialized(im.getMarketIndex()), "marketIndex must be fetch-joined");
+        }
+        // LEFT JOIN FETCH keeps members whose listing has no asset.
+        assertTrue(members.stream().anyMatch(im -> im.getListing().getTicker().equals("ORPH")));
+    }
+
+    @Test
+    void findByMarketIndexCode_ordersByPercentDesc() {
+        List<IndexMember> members = repository.findByMarketIndex_CodeOrderByPercentDesc("FAT50");
+
+        assertEquals(2, members.size());
+        assertEquals(0, members.get(0).getPercent().compareTo(new BigDecimal("8.5")));
+        assertEquals(0, members.get(1).getPercent().compareTo(new BigDecimal("7.25")));
+    }
+
+    @Test
+    void findByMarketIndexCodeAndListingTicker() {
+        assertTrue(repository.findByMarketIndex_CodeAndListing_Ticker("FAT50", "AAPL").isPresent());
+        assertTrue(repository.findByMarketIndex_CodeAndListing_Ticker("FAT100", "AAPL").isEmpty());
+    }
+
+    @Test
+    void deleteByMarketIndexCode_removesOnlyThatIndex() {
+        repository.deleteByMarketIndex_Code("FAT50");
+        em.flush();
+        em.clear();
+
+        assertTrue(repository.findByMarketIndex_CodeOrderByPercentDesc("FAT50").isEmpty());
+        assertEquals(1, repository.findByMarketIndex_CodeOrderByPercentDesc("FAT100").size());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/repository/ListingIndexMetricsRepositoryTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/repository/ListingIndexMetricsRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.fattorestreet.sec_api.repository;
+
+import com.fattorestreet.sec_api.model.Asset;
+import com.fattorestreet.sec_api.model.Listing;
+import com.fattorestreet.sec_api.model.ListingIndexMetrics;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ListingIndexMetricsRepositoryTest {
+
+    @Autowired
+    private ListingIndexMetricsRepository repository;
+    @Autowired
+    private TestEntityManager em;
+
+    private Listing aapl;
+
+    @BeforeEach
+    void seed() {
+        aapl = listing("AAPL", "Apple Inc.", 320193L);
+        Listing msft = listing("MSFT", "Microsoft", 789019L);
+        metrics(aapl, 2026, "3000");
+        metrics(aapl, 2025, "2800");
+        metrics(msft, 2026, "2900");
+        em.flush();
+        em.clear();
+    }
+
+    private Listing listing(String ticker, String title, long cik) {
+        Asset a = new Asset();
+        a.setCik(cik);
+        em.persist(a);
+        Listing l = new Listing();
+        l.setTicker(ticker);
+        l.setTitle(title);
+        l.setAsset(a);
+        return em.persist(l);
+    }
+
+    private void metrics(Listing l, int year, String marketCap) {
+        ListingIndexMetrics m = new ListingIndexMetrics();
+        m.setListing(l);
+        m.setYear(year);
+        m.setMarketCap(new BigDecimal(marketCap));
+        em.persist(m);
+    }
+
+    @Test
+    void findAllWithListingAndAssetByYear_filtersYearAndFetchJoins() {
+        List<ListingIndexMetrics> rows = repository.findAllWithListingAndAssetByYear(2026);
+
+        assertEquals(2, rows.size());
+        for (ListingIndexMetrics m : rows) {
+            assertEquals(2026, m.getYear());
+            assertTrue(Hibernate.isInitialized(m.getListing()), "listing must be fetch-joined");
+            assertTrue(Hibernate.isInitialized(m.getListing().getAsset()), "asset must be fetch-joined");
+        }
+    }
+
+    @Test
+    void findAllByYear_returnsOnlyThatYear() {
+        assertEquals(1, repository.findAllByYear(2025).size());
+        assertTrue(repository.findAllByYear(2020).isEmpty());
+    }
+
+    @Test
+    void findByListingAndYear() {
+        Listing managedAapl = em.find(Listing.class, aapl.getId());
+
+        assertTrue(repository.findByListingAndYear(managedAapl, 2026).isPresent());
+        assertTrue(repository.findByListingAndYear(managedAapl, 2019).isEmpty());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/testsupport/PcapTestData.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/testsupport/PcapTestData.java
@@ -1,0 +1,114 @@
+package com.fattorestreet.sec_api.testsupport;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Builds classic-pcap byte streams carrying IEX TOPS messages for PcapParser tests,
+ * so no binary fixtures need to be committed.
+ */
+public final class PcapTestData {
+
+    private static final int PCAP_MAGIC_LE = 0xA1B2C3D4;
+    public static final byte TRADE_REPORT_TYPE = 0x54;
+    public static final byte QUOTE_UPDATE_TYPE = 0x51;
+
+    private PcapTestData() {
+    }
+
+    /** A full capture: global header plus one UDP packet per call containing the given messages. */
+    public static byte[] pcap(byte[]... packets) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteBuffer global = ByteBuffer.allocate(24).order(ByteOrder.LITTLE_ENDIAN);
+        global.putInt(PCAP_MAGIC_LE);
+        global.putShort((short) 2).putShort((short) 4); // version 2.4
+        global.putInt(0).putInt(0);                     // thiszone, sigfigs
+        global.putInt(65535);                           // snaplen
+        global.putInt(1);                               // linktype: Ethernet
+        out.writeBytes(global.array());
+        for (byte[] packet : packets) {
+            ByteBuffer record = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN);
+            record.putInt(0).putInt(0);        // ts_sec, ts_usec
+            record.putInt(packet.length);      // incl_len
+            record.putInt(packet.length);      // orig_len
+            out.writeBytes(record.array());
+            out.writeBytes(packet);
+        }
+        return out.toByteArray();
+    }
+
+    /** Ethernet/IPv4/UDP packet wrapping an IEX transport segment with the given messages. */
+    public static byte[] udpPacket(byte[]... messages) {
+        return framedPacket(0x0800, (byte) 17, messages);
+    }
+
+    /** Same framing but a non-IPv4 ethertype; the parser must skip the whole packet. */
+    public static byte[] nonIpv4Packet(byte[]... messages) {
+        return framedPacket(0x86DD, (byte) 17, messages);
+    }
+
+    private static byte[] framedPacket(int ethType, byte ipProto, byte[]... messages) {
+        int messagesLen = 0;
+        for (byte[] m : messages) {
+            messagesLen += 2 + m.length;
+        }
+        int iexLen = 40 + messagesLen;
+        ByteBuffer buf = ByteBuffer.allocate(14 + 20 + 8 + iexLen).order(ByteOrder.LITTLE_ENDIAN);
+        // Ethernet: dst + src MACs, then big-endian ethertype
+        buf.put(new byte[12]);
+        buf.put((byte) (ethType >> 8)).put((byte) ethType);
+        // IPv4: version 4 / IHL 5, protocol at byte 9
+        int ipv4Start = buf.position();
+        buf.put(new byte[20]);
+        buf.put(ipv4Start, (byte) 0x45);
+        buf.put(ipv4Start + 9, ipProto);
+        // UDP header (ports/length/checksum unused by the parser)
+        buf.put(new byte[8]);
+        // IEX transport header: message count is a little-endian short at offset 14
+        int iexStart = buf.position();
+        buf.put(new byte[40]);
+        buf.putShort(iexStart + 14, (short) messages.length);
+        for (byte[] m : messages) {
+            buf.putShort((short) m.length);
+            buf.put(m);
+        }
+        return buf.array();
+    }
+
+    /** IEX TOPS Trade Report message (type 0x54), 38 bytes. */
+    public static byte[] tradeReport(long timestamp, String symbol, int size, double price) {
+        ByteBuffer buf = ByteBuffer.allocate(38).order(ByteOrder.LITTLE_ENDIAN);
+        buf.put(TRADE_REPORT_TYPE);
+        buf.put((byte) 0); // sale condition flags
+        buf.putLong(timestamp);
+        byte[] symbolBytes = String.format("%-8s", symbol).getBytes(StandardCharsets.US_ASCII);
+        buf.put(symbolBytes, 0, 8);
+        buf.putInt(size);
+        buf.putLong(Math.round(price * 10_000.0));
+        return buf.array();
+    }
+
+    /** A non-trade message of the same length; the parser must ignore it. */
+    public static byte[] quoteUpdate() {
+        ByteBuffer buf = ByteBuffer.allocate(38).order(ByteOrder.LITTLE_ENDIAN);
+        buf.put(QUOTE_UPDATE_TYPE);
+        return buf.array();
+    }
+
+    public static void writeGzip(Path file, byte[] content) {
+        try (OutputStream fos = Files.newOutputStream(file);
+             GZIPOutputStream gz = new GZIPOutputStream(fos)) {
+            gz.write(content);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/testsupport/TestJwtTokens.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/testsupport/TestJwtTokens.java
@@ -19,12 +19,16 @@ public final class TestJwtTokens {
     }
 
     public static String accessToken(String hs256Secret, long djangoUserId) {
+        return accessToken(hs256Secret, djangoUserId, new Date(System.currentTimeMillis() + 3_600_000L));
+    }
+
+    public static String accessToken(String hs256Secret, long djangoUserId, Date expirationTime) {
         try {
             byte[] secretBytes = hs256Secret.getBytes(StandardCharsets.UTF_8);
             JWSSigner signer = new MACSigner(secretBytes);
             JWTClaimsSet claims = new JWTClaimsSet.Builder()
                     .claim("user_id", djangoUserId)
-                    .expirationTime(new Date(System.currentTimeMillis() + 3_600_000L))
+                    .expirationTime(expirationTime)
                     .issueTime(new Date())
                     .jwtID(UUID.randomUUID().toString())
                     .build();

--- a/springboot/src/test/java/com/fattorestreet/sec_api/util/PcapParserTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/util/PcapParserTest.java
@@ -1,0 +1,155 @@
+package com.fattorestreet.sec_api.util;
+
+import com.fattorestreet.sec_api.testsupport.PcapTestData;
+import com.fattorestreet.sec_api.util.PcapParser.TradeReport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PcapParserTest {
+
+    private static List<TradeReport> parse(byte[] capture) throws IOException {
+        List<TradeReport> trades = new ArrayList<>();
+        PcapParser.parse(new ByteArrayInputStream(capture), trades::add);
+        return trades;
+    }
+
+    @Test
+    void parsesSingleTradeReport() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(PcapTestData.tradeReport(1_000L, "AAPL", 100, 172.53)));
+
+        List<TradeReport> trades = parse(capture);
+
+        assertEquals(1, trades.size());
+        TradeReport tr = trades.get(0);
+        assertEquals("AAPL", tr.symbol());
+        assertEquals(1_000L, tr.timestamp());
+        assertEquals(100, tr.size());
+        assertEquals(172.53, tr.price());
+    }
+
+    @Test
+    void returnsTradeCount() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(
+                        PcapTestData.tradeReport(1L, "AAPL", 100, 10.0),
+                        PcapTestData.tradeReport(2L, "MSFT", 200, 20.0)));
+
+        long count = PcapParser.parse(new ByteArrayInputStream(capture), tr -> { });
+
+        assertEquals(2, count);
+    }
+
+    @Test
+    void parsesTradesAcrossMultiplePackets() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(PcapTestData.tradeReport(1L, "AAPL", 100, 10.0)),
+                PcapTestData.udpPacket(PcapTestData.tradeReport(2L, "MSFT", 200, 20.0)),
+                PcapTestData.udpPacket(PcapTestData.tradeReport(3L, "AAPL", 300, 10.5)));
+
+        List<TradeReport> trades = parse(capture);
+
+        assertEquals(3, trades.size());
+        assertEquals(List.of("AAPL", "MSFT", "AAPL"),
+                trades.stream().map(TradeReport::symbol).toList());
+    }
+
+    @Test
+    void skipsNonTradeMessages() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(
+                        PcapTestData.quoteUpdate(),
+                        PcapTestData.tradeReport(1L, "NVDA", 50, 900.25),
+                        PcapTestData.quoteUpdate()));
+
+        List<TradeReport> trades = parse(capture);
+
+        assertEquals(1, trades.size());
+        assertEquals("NVDA", trades.get(0).symbol());
+    }
+
+    @Test
+    void skipsNonIpv4Packets() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.nonIpv4Packet(PcapTestData.tradeReport(1L, "AAPL", 100, 10.0)),
+                PcapTestData.udpPacket(PcapTestData.tradeReport(2L, "MSFT", 200, 20.0)));
+
+        List<TradeReport> trades = parse(capture);
+
+        assertEquals(1, trades.size());
+        assertEquals("MSFT", trades.get(0).symbol());
+    }
+
+    @Test
+    void dropsTradesWithNonPositivePriceOrSize() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(
+                        PcapTestData.tradeReport(1L, "AAPL", 0, 10.0),
+                        PcapTestData.tradeReport(2L, "MSFT", 100, 0.0),
+                        PcapTestData.tradeReport(3L, "NVDA", 100, 10.0)));
+
+        List<TradeReport> trades = parse(capture);
+
+        assertEquals(1, trades.size());
+        assertEquals("NVDA", trades.get(0).symbol());
+    }
+
+    @Test
+    void emptyCaptureYieldsNoTrades() throws IOException {
+        List<TradeReport> trades = parse(PcapTestData.pcap());
+        assertTrue(trades.isEmpty());
+    }
+
+    @Test
+    void unknownMagicNumberThrows() {
+        byte[] garbage = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+        IOException e = assertThrows(IOException.class, () -> parse(garbage));
+        assertTrue(e.getMessage().contains("Unknown capture format"));
+    }
+
+    @Test
+    void truncatedPacketPayloadThrowsEof() {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(PcapTestData.tradeReport(1L, "AAPL", 100, 10.0)));
+        byte[] truncated = Arrays.copyOf(capture, capture.length - 10);
+
+        assertThrows(EOFException.class, () -> parse(truncated));
+    }
+
+    @Test
+    void parseGzip_readsGzippedCapture(@TempDir Path tempDir) throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(
+                        PcapTestData.tradeReport(1L, "AAPL", 100, 172.53),
+                        PcapTestData.tradeReport(2L, "AAPL", 50, 172.60)));
+        Path gz = tempDir.resolve("tops.pcap.gz");
+        PcapTestData.writeGzip(gz, capture);
+
+        List<TradeReport> trades = new ArrayList<>();
+        long count = PcapParser.parseGzip(gz.toFile(), trades::add);
+
+        assertEquals(2, count);
+        assertEquals(2, trades.size());
+        assertEquals(172.60, trades.get(1).price());
+    }
+
+    @Test
+    void symbolsArePaddedAsciiAndTrimmed() throws IOException {
+        byte[] capture = PcapTestData.pcap(
+                PcapTestData.udpPacket(PcapTestData.tradeReport(1L, "F", 10, 12.0)));
+
+        List<TradeReport> trades = parse(capture);
+
+        assertEquals("F", trades.get(0).symbol());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/util/SecDateParsingUtilsTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/util/SecDateParsingUtilsTest.java
@@ -1,0 +1,178 @@
+package com.fattorestreet.sec_api.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SecDateParsingUtilsTest {
+
+    // --- parseIsoDate ---
+
+    @Test
+    void parseIsoDate_valid() {
+        assertEquals(LocalDate.of(2024, 3, 15), SecDateParsingUtils.parseIsoDate("2024-03-15"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "garbage", "2024-02-30", "03/15/2024"})
+    void parseIsoDate_invalidReturnsNull(String input) {
+        assertNull(SecDateParsingUtils.parseIsoDate(input));
+    }
+
+    // --- parseUsDate ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "'January 5, 2024', 2024-01-05",
+            "'Jan 5, 2024', 2024-01-05",
+            "'Jan. 5, 2024', 2024-01-05",
+            "'Sept. 30, 2023', 2023-09-30",
+            "'February 29 2024', 2024-02-29",
+            "'December 31, 1999', 1999-12-31",
+            "'may 12, 2025', 2025-05-12",
+    })
+    void parseUsDate_valid(String input, LocalDate expected) {
+        assertEquals(expected, SecDateParsingUtils.parseUsDate(input));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "Febtember 5, 2024", "2024-01-05"})
+    void parseUsDate_invalidReturnsNull(String input) {
+        assertNull(SecDateParsingUtils.parseUsDate(input));
+    }
+
+    @Test
+    void parseUsDate_smartResolvesOutOfRangeDay() {
+        // ofPattern defaults to ResolverStyle.SMART: Feb 30 clamps to the month's last day
+        assertEquals(LocalDate.of(2024, 2, 29), SecDateParsingUtils.parseUsDate("February 30, 2024"));
+    }
+
+    // --- numeric formats ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "3/15/2024, 2024-03-15",
+            "12/1/2024, 2024-12-01",
+            "1/5/2024, 2024-01-05",
+    })
+    void parseSlashDate_valid(String input, LocalDate expected) {
+        assertEquals(expected, SecDateParsingUtils.parseSlashDate(input));
+    }
+
+    @Test
+    void parseSlashDate_invalidReturnsNull() {
+        assertNull(SecDateParsingUtils.parseSlashDate("not a date"));
+        // SMART resolution clamps out-of-range days rather than rejecting them
+        assertEquals(LocalDate.of(2024, 2, 29), SecDateParsingUtils.parseSlashDate("2/30/2024"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // 'uu' maps every two-digit year onto 2000-2099
+            "3/15/24, 2024-03-15",
+            "1/5/99, 2099-01-05",
+            "12/31/00, 2000-12-31",
+    })
+    void parseSlashShortYearDate_valid(String input, LocalDate expected) {
+        assertEquals(expected, SecDateParsingUtils.parseSlashShortYearDate(input));
+    }
+
+    @Test
+    void parseYearSlashDate_valid() {
+        assertEquals(LocalDate.of(2024, 3, 15), SecDateParsingUtils.parseYearSlashDate("2024/3/15"));
+        assertNull(SecDateParsingUtils.parseYearSlashDate("15/3/2024"));
+    }
+
+    @Test
+    void parseDashDate_valid() {
+        assertEquals(LocalDate.of(2024, 3, 15), SecDateParsingUtils.parseDashDate("3-15-2024"));
+        assertNull(SecDateParsingUtils.parseDashDate("2024-03-15"));
+    }
+
+    // --- parseAnyDate dispatch ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "2024-03-15, 2024-03-15",
+            "2024/3/15, 2024-03-15",
+            "'March 15, 2024', 2024-03-15",
+            "3/15/2024, 2024-03-15",
+            "3/15/24, 2024-03-15",
+            "3-15-2024, 2024-03-15",
+    })
+    void parseAnyDate_dispatchesAcrossFormats(String input, LocalDate expected) {
+        assertEquals(expected, SecDateParsingUtils.parseAnyDate(input));
+    }
+
+    @Test
+    void parseAnyDate_unparseableReturnsNull() {
+        assertNull(SecDateParsingUtils.parseAnyDate("on or about the record date"));
+    }
+
+    // --- extractAllDates ---
+
+    @Test
+    void extractAllDates_findsMultipleFormatsInText() {
+        String text = "Record date 2024-03-15, payable on April 1, 2024; declared 3/1/2024.";
+        List<LocalDate> dates = SecDateParsingUtils.extractAllDates(text);
+        assertTrue(dates.contains(LocalDate.of(2024, 3, 15)));
+        assertTrue(dates.contains(LocalDate.of(2024, 4, 1)));
+        assertTrue(dates.contains(LocalDate.of(2024, 3, 1)));
+    }
+
+    @Test
+    void extractAllDates_isoIsStrictButSlashSmartResolves() {
+        // ISO parsing is strict (2024-02-30 dropped); slash parsing SMART-clamps to Feb 29
+        List<LocalDate> dates = SecDateParsingUtils.extractAllDates("due 2024-02-30 or 2/30/2024");
+        assertEquals(List.of(LocalDate.of(2024, 2, 29)), dates);
+    }
+
+    @Test
+    void extractAllDates_emptyTextReturnsEmpty() {
+        assertTrue(SecDateParsingUtils.extractAllDates("").isEmpty());
+    }
+
+    @Test
+    void extractAllDates_fullYearSlashDateDoesNotAlsoMatchAsShortYear() {
+        // "3/15/2024" must not additionally be read as the short-year date "3/15/20"
+        assertEquals(List.of(LocalDate.of(2024, 3, 15)),
+                SecDateParsingUtils.extractAllDates("payable 3/15/2024 to holders"));
+    }
+
+    @Test
+    void extractAllDates_shortYearDateStillMatches() {
+        assertEquals(List.of(LocalDate.of(2024, 3, 15)),
+                SecDateParsingUtils.extractAllDates("payable 3/15/24 to holders"));
+    }
+
+    // --- previousBusinessDay ---
+
+    @ParameterizedTest
+    @CsvSource({
+            // Tuesday -> Monday
+            "2024-03-12, 2024-03-11",
+            // Monday -> previous Friday
+            "2024-03-11, 2024-03-08",
+            // Sunday -> Friday
+            "2024-03-10, 2024-03-08",
+            // Saturday -> Friday
+            "2024-03-09, 2024-03-08",
+    })
+    void previousBusinessDay_skipsWeekends(LocalDate input, LocalDate expected) {
+        assertEquals(expected, SecDateParsingUtils.previousBusinessDay(input));
+    }
+
+    @Test
+    void previousBusinessDay_nullReturnsNull() {
+        assertNull(SecDateParsingUtils.previousBusinessDay(null));
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/util/SecNumberUtilsTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/util/SecNumberUtilsTest.java
@@ -1,0 +1,64 @@
+package com.fattorestreet.sec_api.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SecNumberUtilsTest {
+
+    // --- round4 ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.123456, 0.1235",
+            "0.12344, 0.1234",
+            "0.00005, 0.0001",
+            "1.0, 1.0",
+            "0.0, 0.0",
+            "-0.123456, -0.1235",
+    })
+    void round4_roundsHalfUpToFourDecimals(double input, double expected) {
+        assertEquals(expected, SecNumberUtils.round4(input));
+    }
+
+    // --- parsePositiveDouble ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "0.25, 0.25",
+            "4, 4.0",
+            "1e2, 100.0",
+    })
+    void parsePositiveDouble_valid(String input, double expected) {
+        assertEquals(expected, SecNumberUtils.parsePositiveDouble(input));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"0", "-1.5", "abc", "1,000", " "})
+    void parsePositiveDouble_invalidOrNonPositiveReturnsNull(String input) {
+        assertNull(SecNumberUtils.parsePositiveDouble(input));
+    }
+
+    // --- roughlyEqual ---
+
+    @Test
+    void roughlyEqual_withinEpsilon() {
+        assertTrue(SecNumberUtils.roughlyEqual(0.25, 0.2501, 0.001));
+        assertTrue(SecNumberUtils.roughlyEqual(0.25, 0.2509, 0.001));
+    }
+
+    @Test
+    void roughlyEqual_outsideEpsilon() {
+        assertFalse(SecNumberUtils.roughlyEqual(0.25, 0.2512, 0.001));
+    }
+
+    @Test
+    void roughlyEqual_nullLeftIsFalse() {
+        assertFalse(SecNumberUtils.roughlyEqual(null, 0.25, 0.001));
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/util/SecTextUtilsTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/util/SecTextUtilsTest.java
@@ -1,0 +1,87 @@
+package com.fattorestreet.sec_api.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SecTextUtilsTest {
+
+    // --- notBlank ---
+
+    @Test
+    void notBlank_trueForText() {
+        assertTrue(SecTextUtils.notBlank("x"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "\n"})
+    void notBlank_falseForBlank(String input) {
+        assertFalse(SecTextUtils.notBlank(input));
+    }
+
+    // --- normalizeText ---
+
+    @ParameterizedTest
+    @CsvSource({
+            "'Vanguard S&P 500 ETF', 'vanguard s p 500 etf'",
+            "'  MiXeD   Case  ', 'mixed case'",
+            "'already normal', 'already normal'",
+    })
+    void normalizeText_lowercasesAndStripsPunctuation(String input, String expected) {
+        assertEquals(expected, SecTextUtils.normalizeText(input));
+    }
+
+    @Test
+    void normalizeText_nullReturnsEmpty() {
+        assertEquals("", SecTextUtils.normalizeText(null));
+    }
+
+    // --- containsToken ---
+
+    @Test
+    void containsToken_matchesSubstring() {
+        assertTrue(SecTextUtils.containsToken("vanguard 500 index fund", "500 index"));
+        assertFalse(SecTextUtils.containsToken("vanguard 500 index fund", "growth"));
+    }
+
+    @Test
+    void containsToken_blankArgumentsAreFalse() {
+        assertFalse(SecTextUtils.containsToken(null, "x"));
+        assertFalse(SecTextUtils.containsToken("x", null));
+        assertFalse(SecTextUtils.containsToken("", "x"));
+        assertFalse(SecTextUtils.containsToken("x", " "));
+    }
+
+    // --- normalizeDateExtractionText ---
+
+    @Test
+    void normalizeDateExtractionText_stripsTagsAndEntities() {
+        String html = "<div>Record&nbsp;date:</div><p>March 15, 2024 &amp; beyond</p>";
+        assertEquals("Record date:\nMarch 15, 2024 & beyond",
+                SecTextUtils.normalizeDateExtractionText(html));
+    }
+
+    @Test
+    void normalizeDateExtractionText_dropsStyleAndScriptBlocks() {
+        String html = "<style>td { color: red; }</style>before<script>alert(1)</script>after";
+        assertEquals("before after", SecTextUtils.normalizeDateExtractionText(html));
+    }
+
+    @Test
+    void normalizeDateExtractionText_collapsesWhitespaceAndNewlines() {
+        String html = "a<br/>b</tr>\n\n\nc\t\td";
+        assertEquals("a\nb\nc d", SecTextUtils.normalizeDateExtractionText(html));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    void normalizeDateExtractionText_blankReturnsEmpty(String input) {
+        assertEquals("", SecTextUtils.normalizeDateExtractionText(input));
+    }
+}

--- a/springboot/src/test/resources/application-test.properties
+++ b/springboot/src/test/resources/application-test.properties
@@ -1,8 +1,21 @@
 spring.flyway.enabled=false
 spring.datasource.url=jdbc:h2:mem:testdb;NON_KEYWORDS=YEAR
+# @DataJpaTest must keep this datasource (its replacement embedded DB would lose NON_KEYWORDS=YEAR)
+spring.test.database.replace=none
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
-# Must match MainControllerTest SECRET_KEY; Spring JWT verification for integration-style tests
-SECRET_KEY=test-jwt-signing-secret-32chars-min! # pragma: allowlist secret
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Must match the controller tests' SECRET_KEY; Spring JWT verification for integration-style tests
+# (a mid-line # is part of a .properties value, so the allowlist pragma gets its own line)
+# pragma: allowlist nextline secret
+SECRET_KEY=test-jwt-signing-secret-32chars-min!
+
+# Pin env-sensitive keys so a stray .env import can never reach real services from tests
+llm.server.url=http://localhost:1/llm-disabled-in-tests
+sec.contact-email=test@example.com
+DJANGO_PORTFOLIO_BASE_URL=http://localhost:1/django-disabled-in-tests
+app.run-mode=server


### PR DESCRIPTION
## Summary
- Break the 1000-line `MainControllerTest` into focused test classes (`AdminControllerTest`, `PublicControllerTest`, plus service/repository/util suites) so each package's behavior is covered where it lives
- Add tests for previously untested areas: security config, index services, IEX HIST ingestion, PCAP parsing, SEC date/number/text utils, and JPA repositories (via `@DataJpaTest`)
- Enforce the new baseline with a JaCoCo 76% line-coverage gate wired into `mvn test`
- Production fixes made for testability and bugs the new tests exposed:
  - `CorporateActionValidationService` / `IexHistService`: package-private constructors accepting an injectable `HttpClient`
  - `EdgarFilingDiscoveryService`: guard against null/blank submission JSON
  - `SecDateParsingUtils`: digit boundaries on the short-year slash pattern (so `3/15/2024` can't half-match as `3/15/20`), case-insensitive US date parsing, `Sept` → `Sep` normalization
- Run Surefire from `target/` so tests never resolve the real `springboot/.env`

## Test plan
- [x] `mvn test` — 465 tests, 0 failures, BUILD SUCCESS
- [x] JaCoCo coverage check (76% line minimum) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)