### PR TITLE
move fred-data endpoint from django to springboot

### DIFF
--- a/.claude/plans/curried-wibbling-squid.md
+++ b/.claude/plans/curried-wibbling-squid.md
@@ -1,0 +1,62 @@
+# Move fred-data endpoint from Django to Spring Boot
+
+## Context
+
+The `/portfolio/api/fred-data/` endpoint (FRED economic observations powering the Economic Indicators page) currently lives in Django: `FredDataRetrieveView` (`django/portfolio/views.py:201`) loops over requested series and calls `get_fred_data` (`django/portfolio/helper.py:166`), which hits `https://api.stlouisfed.org/fred/series/observations` and caches results in Redis for 24h. Spring Boot is the service that already owns external market data (SEC, IEX), so FRED belongs there. This change ports the endpoint to Spring Boot, points React at it, and removes the Django implementation. FRED is a preferred commercially-free source per `.claude/rules/data-licensing-commercial-free.md`; data stays cache-only (never persisted), so no licensing concerns.
+
+## API contract (Spring Boot)
+
+`POST /fred-data` (public, no auth) — mirrors the Django shape but with camelCase request keys per Spring Boot conventions:
+
+- Request body: `[{ "seriesId": "CPIAUCSL", "computeYoy": true }, ...]` (`computeYoy` defaults to false)
+- Behavior: for each item, fetch FRED observations (`units=pc1` when `computeYoy`), drop FRED's `"."` missing-value markers, sort by date
+- Response: `{ "<seriesId>": [{ "date": "1962-01-02", "value": 4.06 }, ...], ... }` (unchanged from Django, so charts need no changes)
+
+## Spring Boot changes (`springboot/`)
+
+1. **`src/main/resources/application.properties`** — add `fred.api-key=${FRED_API_KEY:}`.
+2. **New `economic/FredService.java`** (`com.fattorestreet.sec_api.economic`):
+   - Constructor injection: `@Value("${fred.api-key}")` plus a package-visible constructor accepting a `RestTemplate` for tests (same pattern as `client/WebService.java`). Do NOT reuse `WebService` — it is SEC-specific (User-Agent, throttling, retries).
+   - `public record FredObservation(LocalDate date, double value)` — Boot serializes `LocalDate` as `"yyyy-MM-dd"` by default.
+   - `getSeries(String seriesId, boolean computeYoy)`: check an in-memory TTL cache (`ConcurrentHashMap` keyed `seriesId|computeYoy`, 24h TTL, matching Django's Redis TTL — springboot has no Redis; restart-clearing is acceptable), else GET the FRED observations URL with `series_id`, `api_key`, `file_type=json`, and `units=pc1` when yoy; parse JSON with Jackson, skip observations whose `value` is not numeric (FRED uses `"."` for missing), sort ascending by date, cache, return.
+3. **`controller/PublicController.java`** — add `POST /fred-data`: accepts `List<FredSeriesItem>` (record with `@NotBlank @Pattern(regexp = "^[A-Z][A-Z0-9]{0,30}$") String seriesId`, `Boolean computeYoy` treated as false when null), builds a `LinkedHashMap<String, List<FredObservation>>`, returns 200. Controller stays thin; service does the work.
+4. **`config/SecurityConfig.java`** — add `"/fred-data"` to the explicit `permitAll` request-matcher list. (CORS in `WebConfig` already covers `/**` with POST.)
+5. **Tests** (per springboot-tests skill):
+   - `src/test/java/.../economic/FredServiceTest.java` — Mockito with injected mock `RestTemplate`: happy path, `"."` values dropped, `units=pc1` sent only when yoy, cache hit avoids second HTTP call.
+   - `controller/PublicControllerTest.java` — add `@MockitoBean FredService` cases: 200 with mapped body, 400 on invalid `seriesId`.
+
+## React changes (`react-app/`)
+
+1. **`src/functions/api/springbootApi.ts`** — add `getFredData` query: `builder.query<Record<string, IFredObservation[]>, { seriesId: string; computeYoy?: boolean }[]>` with `url: "fred-data"`, `method: "POST"`, `data: seriesList`. Export `useGetFredDataQuery`.
+2. **`src/interfaces.ts`** — move `IFredObservation` here (from `djangoApi.ts:63`), since springbootApi imports its types from `interfaces.ts`.
+3. **`src/functions/api/djangoApi.ts`** — remove `getFredData` endpoint, `IFredObservation`, and the `useGetFredDataQuery` export.
+4. **`src/functions/api/index.ts`** — re-export `useGetFredDataQuery` from the springboot block instead of the django block (component import path stays `../functions/api`, so `EconomicIndicators.tsx` only changes its arg shape).
+5. **`src/pages/EconomicIndicators.tsx`** — change `seriesList` entries from `{ series_id, compute_yoy }` to `{ seriesId, computeYoy }`.
+6. **`__tests__/mocks/handlers.ts`** — move the `fred-data/` mock from `http.post(portfolioApiBaseUrl.concat("fred-data/"), ...)` to `http.post(import.meta.env.VITE_APP_SPRINGBOOT_URL.concat("fred-data"), ...)` (same response payload; matches the pattern of the other springboot handlers). The existing `EconomicIndicators` test in `__tests__/render.test.tsx` should then pass unchanged.
+
+## Django changes (`django/`)
+
+Remove the FRED implementation entirely:
+
+1. `portfolio/views.py` — delete `FredDataRetrieveView` and the `FredSeriesItemSerializer` / `get_fred_data` imports.
+2. `portfolio/serializers.py` — delete `FredSeriesItemSerializer`.
+3. `portfolio/urls.py` — delete the `api/fred-data/` path (watch the trailing comma on the previous entry).
+4. `portfolio/helper.py` — delete `get_fred_data` (requests/pandas are still used by other helpers; keep imports that remain in use).
+5. Tests — delete `FredDataTests` from `tests/test_helper.py` (and its `get_fred_data` import) and `FredDataTest` from `tests/test_portfolio.py`.
+
+## Docs & env plumbing
+
+- **`CLAUDE.md`** — move `FRED_API_KEY` from the Django env-vars list to the Spring Boot list; drop "FRED economic data" from the `portfolio/` app description; add `economic/` to the Spring Boot package tree.
+- **`docs/API_REFERENCE.md:37`** — remove the Django `fred-data` row; add `POST /fred-data` to the Spring Boot section (method, path, body, response shape, note it was previously `/portfolio/api/fred-data/`).
+- **`django/README.md`** — remove FRED mentions (lines 12, 19, 39) and `FRED_API_KEY` if listed.
+- **`springboot/README.md`** — add FRED economic data to features, `FRED_API_KEY` to the env-vars table, and a short usage example.
+- **`react-app/README.md`** — line 36/65: Economic Indicators now consumes the Spring Boot API; remove "FRED data" from the Django endpoint list.
+- **`deploy/docker-compose.dev.yml`** — add `FRED_API_KEY` to the springboot service env (dev placeholder with a comment, same style as `GOOGLE_API_KEY` in the django block).
+- **`deploy/run.sh`** — production config comes from the single shared `fattorestreet/env` secret exported to both containers, so no launch-command change is needed; add `"FRED_API_KEY"` to the example secret JSON comment so the key is documented.
+
+## Verification
+
+1. `cd springboot && mvn test` — new FredService/PublicController tests plus existing suite green.
+2. `cd django && uv run python manage.py test` — suite green after removals.
+3. `cd react-app && npm run lint && npx vitest --run && npm run build`.
+4. End-to-end: start Spring Boot with a real `FRED_API_KEY` in `springboot/.env` (`mvn spring-boot:run`), then `curl -X POST http://localhost:8080/fred-data -H 'Content-Type: application/json' -d '[{"seriesId":"UNRATE"},{"seriesId":"CPIAUCSL","computeYoy":true}]'` and confirm sorted `{date, value}` arrays; repeat the call to confirm the cached second response is fast. Then `npm run dev` in react-app and load `/economic-indicators` to confirm all charts render (webapp-testing skill if a browser check is wanted).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Django mounts each app under its own prefix (`users/`, `portfolio/`, `restaurant
 - Spring Boot admin endpoints require `Authorization: Bearer` with a Django SimpleJWT access token; JWT signing uses the same `SECRET_KEY` as Django, and only `user_id` claim `1` is allowed for `/admin/**`
 
 ### Django Apps
-- `portfolio/` — Asset & account CRUD, yfinance price data, FRED economic data, quarterly financials
+- `portfolio/` — Asset & account CRUD, yfinance price data, quarterly financials
 - `users/` — Registration, JWT tokens
 - `chatbot/` — Boglehead AI advisor (Google Gemini)
 - `restaurants/` — Restaurant reviews/recommendations
@@ -90,6 +90,7 @@ com.fattorestreet.sec_api/
   listing/           Assets, listings, ETF identity enrichment
   filing/            10-K MD&A fetch + LLM summarization
   marketdata/        Daily prices, IEX HIST binary ingest
+  economic/          FRED economic data client + in-memory cache
   index/             Index membership, metrics refresh
   repository/        Spring Data JPA repositories
   model/             JPA entities
@@ -137,7 +138,7 @@ Additional conventions:
 - `POSTGRES_PASSWORD` — required when `DATABASE=postgresDocker`
 - `REDIS_URL` — cache backend, required when `DEBUG=False`
 - `GOOGLE_API_KEY` — Gemini key for the chatbot app
-- `FINNHUB_API_KEY`, `FRED_API_KEY` — portfolio quotes and FRED economic data
+- `FINNHUB_API_KEY` — portfolio quotes
 - `SEC_CONTACT_EMAIL` — email for SEC API User-Agent header (required by SEC)
 - `DJANGO_FORCE_SCRIPT_NAME` — set to `/django` when served behind the nginx prefix
 
@@ -147,6 +148,7 @@ Additional conventions:
 - `LLM_SERVER_URL` — llama.cpp server (default `http://localhost:8081`)
 - `DJANGO_PORTFOLIO_BASE_URL` — Django base URL for validation calls
 - `SEC_CONTACT_EMAIL` — email for SEC API User-Agent header (required by SEC)
+- `FRED_API_KEY` — FRED key for the public `POST /fred-data` economic data endpoint
 
 ### React (`.env.*` per mode)
 - `VITE_APP_DJANGO_URL` — Django base URL (`http://127.0.0.1:8000/` in dev, `https://fattorestreet.com/django/` in production)

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -60,6 +60,8 @@ services:
       DJANGO_PORTFOLIO_BASE_URL: http://django:8000
       # llama.cpp runs on the host, not in compose
       LLM_SERVER_URL: http://host.docker.internal:8081
+      # /fred-data reads this at request time; a dummy breaks only economic indicators
+      FRED_API_KEY: dev-dummy-fred-api-key  # pragma: allowlist secret
     depends_on: [postgres]
     restart: unless-stopped
 

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -29,7 +29,8 @@ sudo docker network create --driver bridge dockerNet
 #     "DB_URL": "jdbc:postgresql://postgres:5432/springboot",
 #     "SEC_CONTACT_EMAIL": "johnefattore@gmail.com",
 #     "LLM_SERVER_URL": "http://localhost:8081",
-#     "SHOW_JPA_SQL": "false"
+#     "SHOW_JPA_SQL": "false",
+#     "FRED_API_KEY": "<fred-api-key>"
 #   }'
 #
 # Requires: EC2 instance role with secretsmanager:GetSecretValue on the secret,

--- a/django/README.md
+++ b/django/README.md
@@ -9,14 +9,13 @@ Django 5 + Django REST Framework backend providing portfolio management, market 
 - django-redis (caching layer, Redis-backed in production)
 - SimpleJWT (authentication)
 - yfinance (market data)
-- FRED API (macroeconomic data)
 - Google Generative AI (chatbot)
 
 ## Apps
 
 | App | Purpose |
 |-----|---------|
-| `portfolio` | Asset & account CRUD, yfinance adjusted-close prices/dividends/splits/info, FRED data, quarterly financials |
+| `portfolio` | Asset & account CRUD, yfinance adjusted-close prices/dividends/splits/info, quarterly financials |
 | `users` | User registration, JWT token management |
 | `chatbot` | Boglehead AI financial advisor (Google Gemini) |
 | `restaurants` | Restaurant reviews and recommendations |
@@ -36,7 +35,7 @@ DROP TABLE IF EXISTS indexes_stock CASCADE;
 
 ## Background Jobs & Caching
 
-Django runs no task queue. External-data helpers in `portfolio/helper.py` (FRED, yfinance, Finnhub) fetch lazily on the first request and cache the result in Redis (24h TTL for FRED/yfinance, 60s for quotes).
+Django runs no task queue. External-data helpers in `portfolio/helper.py` (yfinance, Finnhub) fetch lazily on the first request and cache the result in Redis (24h TTL for yfinance, 60s for quotes). FRED economic data is served by the Spring Boot service (`POST /fred-data`), not Django.
 
 The IEX HIST daily price ingest is scheduled outside Django: an EventBridge Scheduler cron launches a one-shot Fargate task running Spring Boot in `hist-load` mode (see `springboot/deploy/terraform/`). Other Spring Boot admin jobs (price adjustments, corporate actions, etc.) are run manually.
 

--- a/django/portfolio/helper.py
+++ b/django/portfolio/helper.py
@@ -163,36 +163,6 @@ def get_yfinance_data(tickers: list[str]) -> dict:
         financials[ticker] = financial_data
     return financials
 
-def get_fred_data(series_id: str, compute_yoy: bool = False) -> list[dict]:
-    cache_key = f"FRED_{series_id}_{compute_yoy}"
-    cached_data = cache.get(cache_key)
-    if cached_data:
-        return cached_data
-    
-    api_key = env("FRED_API_KEY")
-    url = f"https://api.stlouisfed.org/fred/series/observations"
-    params = {
-        "series_id": series_id,
-        "api_key": api_key,
-        "file_type": "json",
-    }
-    if compute_yoy:
-        params["units"] = "pc1"
-
-    response = requests.get(url, params=params)
-    response.raise_for_status()
-    data = response.json()["observations"]
-    df = pd.DataFrame(data)
-    df["date"] = pd.to_datetime(df["date"]).dt.date
-    df["value"] = pd.to_numeric(df["value"], errors="coerce")
-    df = df.drop(columns=["realtime_start", "realtime_end"])
-    df = df.sort_values("date").reset_index(drop=True)
-
-    df = df.dropna(subset=["value"])
-    output = df.to_dict(orient="records")
-    cache.set(cache_key, output, timeout=60 * 60 * 24)
-    return output
-
 _nyse_calendar = None
 
 def _get_nyse_calendar():

--- a/django/portfolio/serializers.py
+++ b/django/portfolio/serializers.py
@@ -24,10 +24,6 @@ class SymbolQuerySerializer(serializers.Serializer):
     symbol = serializers.CharField(validators=[TICKER_REGEX])
 
 
-class FredSeriesItemSerializer(serializers.Serializer):
-    series_id = serializers.CharField()
-    compute_yoy = serializers.BooleanField(default=False)
-
 class AccountSerializer(serializers.ModelSerializer):
     user = serializers.PrimaryKeyRelatedField(read_only=True)
 

--- a/django/portfolio/urls.py
+++ b/django/portfolio/urls.py
@@ -11,6 +11,5 @@ urlpatterns = [
     path('api/asset-dividends/', views.AssetHistoricalDividendsRetrieveView.as_view(), name='asset-dividends'),
     path('api/asset-splits/', views.AssetHistoricalSplitsRetrieveView.as_view(), name='asset-splits'),
     path('api/quote/', views.QuoteRetrieveView.as_view(), name='quote'),
-    path('api/quarterly-data/', views.QuarterlyDataRetrieveView.as_view(), name='quarterly-data'),
-    path('api/fred-data/', views.FredDataRetrieveView.as_view(), name='fred-data')
+    path('api/quarterly-data/', views.QuarterlyDataRetrieveView.as_view(), name='quarterly-data')
 ]

--- a/django/portfolio/views.py
+++ b/django/portfolio/views.py
@@ -2,7 +2,7 @@ from rest_framework import generics, serializers
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, AllowAny
-from .serializers import AssetSerializer, AccountSerializer, FredSeriesItemSerializer, TickerQuerySerializer, SymbolQuerySerializer
+from .serializers import AssetSerializer, AccountSerializer, TickerQuerySerializer, SymbolQuerySerializer
 from .permissions import IsOwner
 from .models import Asset, Account
 import logging
@@ -10,7 +10,6 @@ import environ
 from .helper import (
     get_realtime_price,
     get_yfinance_data,
-    get_fred_data,
     percent_change,
     get_historical_prices,
     get_market_reference_dates,
@@ -196,17 +195,4 @@ class QuarterlyDataRetrieveView(APIView):
         except Exception as e:
             logger.exception("Error fetching quarterly data for %s", ticker)
             raise serializers.ValidationError({"ticker": str(e)})
-        return Response(data)
-
-class FredDataRetrieveView(APIView):
-    authentication_classes = []
-    permission_classes = [AllowAny]
-    def post(self, request):
-        serializer = FredSeriesItemSerializer(data=request.data, many=True)
-        serializer.is_valid(raise_exception=True)
-        data = {}
-        for item in serializer.validated_data:
-            output = get_fred_data(item["series_id"], item["compute_yoy"])
-            data[item["series_id"]] = output
-
         return Response(data)

--- a/django/tests/test_helper.py
+++ b/django/tests/test_helper.py
@@ -9,7 +9,6 @@ import pandas as pd
 from portfolio.helper import (
     QuoteFetchError,
     _partition_cached,
-    get_fred_data,
     get_historical_dividends,
     get_historical_prices,
     get_historical_splits,
@@ -244,49 +243,6 @@ class YfinanceDataTests(LocMemCacheTestCase):
 
         self.assertEqual(result["short_name"], "AAPL")
         self.assertEqual(result["type"], "N/A")
-
-
-@patch("portfolio.helper.env", MagicMock(return_value="test-key"))
-class FredDataTests(LocMemCacheTestCase):
-    """Tests for the FRED observations helper."""
-
-    FRED_PAYLOAD = {
-        "observations": [
-            {"date": "2023-02-01", "realtime_start": "x", "realtime_end": "x", "value": "3.4"},
-            {"date": "2023-01-01", "realtime_start": "x", "realtime_end": "x", "value": "3.5"},
-            {"date": "2023-03-01", "realtime_start": "x", "realtime_end": "x", "value": "."},
-        ]
-    }
-
-    @patch("portfolio.helper.requests.get")
-    def test_parses_sorts_and_drops_missing_values(self, mock_get):
-        mock_get.return_value.json.return_value = self.FRED_PAYLOAD
-
-        result = get_fred_data("UNRATE")
-
-        # "." (FRED's missing marker) is coerced to NaN and dropped
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0], {"date": date(2023, 1, 1), "value": 3.5})
-        self.assertEqual(result[1], {"date": date(2023, 2, 1), "value": 3.4})
-
-    @patch("portfolio.helper.requests.get")
-    def test_compute_yoy_requests_percent_change_units(self, mock_get):
-        mock_get.return_value.json.return_value = self.FRED_PAYLOAD
-
-        get_fred_data("CPIAUCSL", compute_yoy=True)
-        self.assertEqual(mock_get.call_args.kwargs["params"]["units"], "pc1")
-
-        get_fred_data("CPIAUCSL", compute_yoy=False)
-        self.assertNotIn("units", mock_get.call_args.kwargs["params"])
-
-    @patch("portfolio.helper.requests.get")
-    def test_second_call_served_from_cache(self, mock_get):
-        mock_get.return_value.json.return_value = self.FRED_PAYLOAD
-
-        get_fred_data("UNRATE")
-        get_fred_data("UNRATE")
-
-        mock_get.assert_called_once()
 
 
 class MarketCalendarTests(TestCase):

--- a/django/tests/test_portfolio.py
+++ b/django/tests/test_portfolio.py
@@ -287,29 +287,6 @@ class QuoteTest(BaseAPITestCase):
         self.assertEqual(response.status_code, 400)
 
 
-class FredDataTest(BaseAPITestCase):
-    """Tests for the FRED data endpoint (public, calls FRED API)."""
-
-    def setUp(self):
-        super().setUp()
-        self.url = reverse('fred-data')
-        patch("portfolio.views.get_fred_data", return_value=[
-            {"date": "2023-01-01", "value": 3.5},
-            {"date": "2023-02-01", "value": 3.4},
-        ]).start()
-        self.addCleanup(patch.stopall)
-
-    def test_fred_data(self):
-        data = [{"series_id": "UNRATE", "compute_yoy": False}]
-        response = self.client.post(self.url, data, format='json')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("UNRATE", response.data)
-
-    def test_fred_data_empty_body(self):
-        response = self.client.post(self.url, [], format='json')
-        self.assertEqual(response.status_code, 200)
-
-
 class QuarterlyDataTest(BaseAPITestCase):
     """Tests for the quarterly-data endpoint (public, calls yfinance)."""
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -34,7 +34,6 @@ Management of financial assets and retrieving market data.
 | `GET` | `/portfolio/api/asset-dividends/` | Get historical dividend events per ticker from yfinance. |
 | `GET` | `/portfolio/api/asset-splits/` | Get historical split events per ticker from yfinance. |
 | `GET` | `/portfolio/api/quote/` | Get the latest price quote. |
-| `GET` | `/portfolio/api/fred-data/` | Fetch economic data from Federal Reserve API. |
 
 ## 🍽 Restaurants (Reviews)
 
@@ -92,6 +91,14 @@ Public blog posts (no authentication required).
 | `POST` | `/admin/indexes/rebuild-fattore-50` | `Authorization: Bearer` (Django JWT) | **Legacy alias** for `POST /admin/indexes/rebuild?code=FAT50`. Response uses singular `rebuild` instead of `rebuilds`. |
 | `POST` | `/admin/indexes/rebuild-fattore-100` | `Authorization: Bearer` (Django JWT) | **Legacy alias** for `POST /admin/indexes/rebuild?code=FAT100`. Response uses singular `rebuild` instead of `rebuilds`. |
 | `POST` | `/admin/indexes/rebuild-fattore-1000` | `Authorization: Bearer` (Django JWT) | **Legacy alias** for `POST /admin/indexes/rebuild?code=FAT1000`. Response uses singular `rebuild` instead of `rebuilds`. |
+
+## 📈 FRED Economic Data
+
+Economic observation series from the Federal Reserve Bank of St. Louis (FRED). Previously served by Django at `/portfolio/api/fred-data/`; now handled entirely by Spring Boot. Requires `FRED_API_KEY` on the Spring Boot service. Responses are cached in memory for 24h per series/units combination; nothing is persisted.
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `POST` | `/fred-data` | None | Fetch one or more FRED observation series. Request body: JSON array of `{ "seriesId": "UNRATE", "computeYoy": false }` (`computeYoy: true` requests year-over-year percent change, FRED `units=pc1`). Response: object keyed by series id, each value an ascending-date array of `{ "date": "YYYY-MM-DD", "value": number }` with FRED's `"."` missing markers dropped. |
 
 ## 📄 SEC Financial Data
 

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -33,7 +33,7 @@ SPA built with [React 18](https://react.dev/) + [TypeScript](https://www.typescr
 | `/iex-prices/:ticker` | IexPricesView | IEX daily adjusted OHLCV prices plus side-by-side adjusted price, dividend, and split comparisons vs YFinance |
 | `/react-admin/success-bar` | AdminSuccessBar | Per-ticker corporate-action success overview comparing Spring Boot vs YFinance price/dividend alignment using persisted manual ticker list |
 | `/visualizer` | Visualizer | Chart comparison tool |
-| `/economic-indicators` | EconomicIndicators | FRED macroeconomic data charts with chart-level latest readings (date + value) |
+| `/economic-indicators` | EconomicIndicators | FRED macroeconomic data charts (served by Spring Boot `POST /fred-data`) with chart-level latest readings (date + value) |
 | `/chatbot` | Chatbot | Boglehead AI financial advisor |
 | `/restaurants` | Restaurants | Restaurant reviews and map |
 | `/entertainment` | Entertainment | Music and media |
@@ -62,8 +62,8 @@ SPA built with [React 18](https://react.dev/) + [TypeScript](https://www.typescr
 
 All API calls go through RTK Query API slices using a custom `axiosBaseQuery`. Endpoints are split across two backends:
 
-- **Django** (`VITE_APP_DJANGO_URL`): React derives per-app API bases (`/users/api/`, `/portfolio/api/`, `/restaurants/api/`, `/chatbot/api/`, `/changeflow/api/`, `/blog/api/`) from this single base; endpoints include assets, accounts, quotes, asset-prices, asset-dividends, asset-splits, FRED data, quarterly data, asset-info, tickets, and blog
-- **Spring Boot** (`VITE_APP_SPRINGBOOT_URL`): SEC EDGAR fact sheets, quarters, IEX prices, dividends, splits, filing summaries, indexes (`/indexes`, `/index-members` with nested `stock` including `stateHQ` / `stateIncorp`), IWB reference weights (`/iwb-reference-holdings`)
+- **Django** (`VITE_APP_DJANGO_URL`): React derives per-app API bases (`/users/api/`, `/portfolio/api/`, `/restaurants/api/`, `/chatbot/api/`, `/changeflow/api/`, `/blog/api/`) from this single base; endpoints include assets, accounts, quotes, asset-prices, asset-dividends, asset-splits, quarterly data, asset-info, tickets, and blog
+- **Spring Boot** (`VITE_APP_SPRINGBOOT_URL`): SEC EDGAR fact sheets, quarters, IEX prices, dividends, splits, filing summaries, indexes (`/indexes`, `/index-members` with nested `stock` including `stateHQ` / `stateIncorp`), IWB reference weights (`/iwb-reference-holdings`), FRED economic data (`POST /fred-data`)
 
 The `transformResponse` functions handle snake_case → camelCase conversion.
 

--- a/react-app/__tests__/mocks/handlers.ts
+++ b/react-app/__tests__/mocks/handlers.ts
@@ -216,7 +216,7 @@ export const handlers = [
   ),
 
   http.post(
-    portfolioApiBaseUrl.concat("fred-data/"),
+    import.meta.env.VITE_APP_SPRINGBOOT_URL.concat("fred-data"),
     () => {
       return Response.json(
         {

--- a/react-app/src/functions/api/djangoApi.ts
+++ b/react-app/src/functions/api/djangoApi.ts
@@ -60,11 +60,6 @@ interface IQuoteResponse {
   percent_change_daily: number;
 }
 
-interface IFredObservation {
-  date: string;
-  value: number;
-}
-
 interface ITicketPayload {
   title: string;
   description: string;
@@ -476,14 +471,6 @@ export const djangoApi = createApi({
         withAuth: false,
       }),
     }),
-    getFredData: builder.query<Record<string, IFredObservation[]>, { series_id: string; compute_yoy?: boolean }[]>({
-      query: (seriesList) => ({
-        url: "portfolio/api/fred-data/",
-        method: "POST",
-        data: seriesList,
-        withAuth: false,
-      }),
-    }),
     getQuote: builder.query<IQuoteResponse, string>({
       query: (ticker) => ({
         url: "portfolio/api/quote/",
@@ -515,7 +502,6 @@ export const {
   useGetBlogPostQuery,
   useDeleteAssetMutation,
   usePatchAssetMutation,
-  useGetFredDataQuery,
   useGetQuoteQuery,
   useLazyGetQuoteQuery,
   useCreateAccountMutation,

--- a/react-app/src/functions/api/index.ts
+++ b/react-app/src/functions/api/index.ts
@@ -13,7 +13,6 @@ export {
   useGetBlogPostQuery,
   useDeleteAssetMutation,
   usePatchAssetMutation,
-  useGetFredDataQuery,
   useGetQuoteQuery,
   useCreateAccountMutation,
   usePostTicketMutation,
@@ -43,5 +42,6 @@ export {
   useGetIndexesQuery,
   useGetIndexMembersQuery,
   useGetIwbReferenceHoldingsQuery,
+  useGetFredDataQuery,
 } from "./springbootApi";
 

--- a/react-app/src/functions/api/springbootApi.ts
+++ b/react-app/src/functions/api/springbootApi.ts
@@ -1,6 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import type {
   IFilingSummary,
+  IFredObservation,
   IIexDividendsResponse,
   IIexPricesResponse,
   IIexSplitsResponse,
@@ -87,6 +88,14 @@ export const springbootApi = createApi({
       query: () => ({
         url: "iwb-reference-holdings",
         method: "GET",
+      }),
+    }),
+    getFredData: builder.query<Record<string, IFredObservation[]>, { seriesId: string; computeYoy?: boolean }[]>({
+      query: (seriesList) => ({
+        url: "fred-data",
+        method: "POST",
+        data: seriesList,
+        withAuth: false,
       }),
     }),
 
@@ -198,6 +207,7 @@ export const {
   useGetIndexesQuery,
   useGetIndexMembersQuery,
   useGetIwbReferenceHoldingsQuery,
+  useGetFredDataQuery,
   useAdminAssetLoadMutation,
   useAdminSyncFramesMutation,
   useAdminLoadHistMutation,

--- a/react-app/src/interfaces.ts
+++ b/react-app/src/interfaces.ts
@@ -166,6 +166,11 @@ export interface IIexPricesResponse {
     prices: IIexPrice[];
 }
 
+export interface IFredObservation {
+    date: string;
+    value: number;
+}
+
 export interface IDividendRow {
     date: string;
     value: number;

--- a/react-app/src/pages/EconomicIndicators.tsx
+++ b/react-app/src/pages/EconomicIndicators.tsx
@@ -36,37 +36,37 @@ export default function EconomicIndicators() {
 
   const seriesList = [
     // Interest Rates & Yield Curve
-    { series_id: "DGS2", compute_yoy: false },
-    { series_id: "DGS10", compute_yoy: false },
-    { series_id: "DGS30", compute_yoy: false },
-    { series_id: "T10Y2Y", compute_yoy: false },
-    { series_id: "FEDFUNDS", compute_yoy: false },
+    { seriesId: "DGS2", computeYoy: false },
+    { seriesId: "DGS10", computeYoy: false },
+    { seriesId: "DGS30", computeYoy: false },
+    { seriesId: "T10Y2Y", computeYoy: false },
+    { seriesId: "FEDFUNDS", computeYoy: false },
     // Inflation
-    { series_id: "CPIAUCSL", compute_yoy: true },
-    { series_id: "PCEPILFE", compute_yoy: true },
-    { series_id: "T10YIE", compute_yoy: false },
+    { seriesId: "CPIAUCSL", computeYoy: true },
+    { seriesId: "PCEPILFE", computeYoy: true },
+    { seriesId: "T10YIE", computeYoy: false },
     // Labor Market
-    { series_id: "UNRATE", compute_yoy: false },
-    { series_id: "ICSA", compute_yoy: false },
-    { series_id: "PAYEMS", compute_yoy: true },
+    { seriesId: "UNRATE", computeYoy: false },
+    { seriesId: "ICSA", computeYoy: false },
+    { seriesId: "PAYEMS", computeYoy: true },
     // Economic Growth & Consumer
-    { series_id: "GDP", compute_yoy: true },
-    { series_id: "INDPRO", compute_yoy: true },
-    { series_id: "RSAFS", compute_yoy: true },
-    { series_id: "UMCSENT", compute_yoy: false },
+    { seriesId: "GDP", computeYoy: true },
+    { seriesId: "INDPRO", computeYoy: true },
+    { seriesId: "RSAFS", computeYoy: true },
+    { seriesId: "UMCSENT", computeYoy: false },
     // Housing
-    { series_id: "MORTGAGE30US", compute_yoy: false },
-    { series_id: "MORTGAGE15US", compute_yoy: false },
-    { series_id: "CSUSHPINSA", compute_yoy: true },
-    { series_id: "HOUST", compute_yoy: false },
+    { seriesId: "MORTGAGE30US", computeYoy: false },
+    { seriesId: "MORTGAGE15US", computeYoy: false },
+    { seriesId: "CSUSHPINSA", computeYoy: true },
+    { seriesId: "HOUST", computeYoy: false },
     // Financial Markets
-    { series_id: "SP500", compute_yoy: false },
-    { series_id: "VIXCLS", compute_yoy: false },
-    { series_id: "BAMLH0A0HYM2", compute_yoy: false },
+    { seriesId: "SP500", computeYoy: false },
+    { seriesId: "VIXCLS", computeYoy: false },
+    { seriesId: "BAMLH0A0HYM2", computeYoy: false },
     // Monetary Policy
-    { series_id: "DTWEXBGS", compute_yoy: true },
-    { series_id: "M2SL", compute_yoy: true },
-    { series_id: "WALCL", compute_yoy: true },
+    { seriesId: "DTWEXBGS", computeYoy: true },
+    { seriesId: "M2SL", computeYoy: true },
+    { seriesId: "WALCL", computeYoy: true },
   ];
 
   const { data, isLoading, error } = useGetFredDataQuery(seriesList);

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -16,11 +16,12 @@ A Spring Boot 3.4 microservice providing SEC EDGAR financial data for all public
 - Derives dividend ex-dates from SEC 8-K record-date disclosures and settlement-regime logic (pre-2024-05-28 T+2, post-cutover T+1)
 - Applies cumulative backward price adjustment factors for split/dividend-adjusted OHLCV (decoupled from IEX load — runs as a separate process)
 - Fetches 10-K filings from SEC EDGAR, extracts the MD&A section, and generates ~500 word summaries via a local LLM (llama.cpp server)
+- Serves FRED (Federal Reserve Economic Data) observation series via public `POST /fred-data` (per-series optional year-over-year `pc1` units, 24h in-memory cache; powers the Economic Indicators page)
 - **Market indexes (Spring-only — Django does not serve these routes):** `MarketIndex` (one row per index: `code` + `display_name`), `Listing` + `ListingIndexMetrics` (one row per listing per **calendar year**; IEX daily prices + SEC companyfacts for shares/float), and `IndexMember` rows (FK to `MarketIndex`). Public `GET /index-members` (no auth for now), `GET /iwb-reference-holdings` (bundled IWB CSV tickers + fund weights for UI benchmark), plus admin `POST /admin/indexes/refresh-stocks` and `POST /admin/indexes/rebuild` (`Authorization: Bearer` Django JWT for user id `1`, optional `code`, optional `year`). **Fattore 50** / **Fattore 100** / **Fattore 1000** are Russell-style (float-adjusted cap rank) top-50 / top-100 / top-1000 proxies (`FAT50` / `FAT100` / `FAT1000`), not official FTSE Russell products; run `refresh-stocks` first (or pass `refreshMetrics=true`) so metrics exist for the target year. Legacy paths `rebuild-fattore-50` / `rebuild-fattore-100` / `rebuild-fattore-1000` remain as aliases.
 
 ## Java package layout
 
-Application code under `com.fattorestreet.sec_api`: `client` (SEC HTTP / `WebService`), `index`, `corporateaction` and `corporateaction.support`, `fundamentals`, `listing`, `filing`, `marketdata`, plus shared `controller`, `repository`, `model`, `config`, and `util`. The `index` package holds index membership listing, SEC facts parsing, and metrics refresh. Tests mirror those package names under `src/test/java`.
+Application code under `com.fattorestreet.sec_api`: `client` (SEC HTTP / `WebService`), `index`, `corporateaction` and `corporateaction.support`, `economic` (FRED client/cache), `fundamentals`, `listing`, `filing`, `marketdata`, plus shared `controller`, `repository`, `model`, `config`, and `util`. The `index` package holds index membership listing, SEC facts parsing, and metrics refresh. Tests mirror those package names under `src/test/java`.
 
 ## Stack
 
@@ -78,6 +79,7 @@ Before adding or changing any external data source:
 | `SEC_HTTP_RETRY_MAX_ATTEMPTS` | `3` | Max attempts for transient SEC failures (429/5xx/timeout) |
 | `SEC_HTTP_RETRY_BASE_BACKOFF_MS` | `1000` | Base backoff for SEC retries; multiplied by attempt |
 | `SEC_HTTP_MIN_INTERVAL_MS` | `250` | Minimum delay between SEC requests to reduce throttling |
+| `FRED_API_KEY` | (empty) | FRED API key for the public `POST /fred-data` economic data endpoint |
 
 ### Run Locally
 
@@ -261,6 +263,19 @@ curl "http://localhost:8080/filing-summaries?ticker=AAPL"
 ```
 
 Already-summarized filings (by accession number) are skipped on re-runs.
+
+### FRED Economic Data
+
+Public endpoint (no auth) returning FRED observation series, keyed by series id. Requires `FRED_API_KEY`. Each item may set `computeYoy: true` to request year-over-year percent change (`units=pc1`). Responses are cached in memory for 24 hours per series/units combination; nothing is persisted.
+
+```bash
+curl -X POST http://localhost:8080/fred-data \
+  -H 'Content-Type: application/json' \
+  -d '[{"seriesId": "UNRATE"}, {"seriesId": "CPIAUCSL", "computeYoy": true}]'
+# => {"UNRATE": [{"date": "1948-01-01", "value": 3.4}, ...], "CPIAUCSL": [...]}
+```
+
+FRED data is provided by the Federal Reserve Bank of St. Louis (https://fred.stlouisfed.org/docs/api/fred/) and is served to the UI without persistence.
 
 ### Run Tests
 

--- a/springboot/src/main/java/com/fattorestreet/sec_api/config/SecurityConfig.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/config/SecurityConfig.java
@@ -81,7 +81,8 @@ public class SecurityConfig {
                                 "/filing-summaries",
                                 "/index-members",
                                 "/indexes",
-                                "/iwb-reference-holdings"
+                                "/iwb-reference-holdings",
+                                "/fred-data"
                         ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().permitAll())

--- a/springboot/src/main/java/com/fattorestreet/sec_api/controller/PublicController.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/controller/PublicController.java
@@ -11,16 +11,21 @@ import com.fattorestreet.sec_api.repository.CorporateActionRepository;
 import com.fattorestreet.sec_api.repository.FilingSummaryRepository;
 import com.fattorestreet.sec_api.repository.MarketIndexRepository;
 import com.fattorestreet.sec_api.repository.QuarterRepository;
+import com.fattorestreet.sec_api.economic.FredService;
+import com.fattorestreet.sec_api.economic.FredService.FredObservation;
 import com.fattorestreet.sec_api.fundamentals.FinancialService;
 import com.fattorestreet.sec_api.index.IndexMemberApiService;
 import com.fattorestreet.sec_api.index.IndexMemberApiService.IndexMemberRow;
 import com.fattorestreet.sec_api.repository.DailyPriceRepository;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,6 +49,7 @@ public class PublicController {
     private final FilingSummaryRepository filingSummaryRepository;
     private final MarketIndexRepository marketIndexRepository;
     private final IndexMemberApiService indexMemberApiService;
+    private final FredService fredService;
 
     public PublicController(
             AssetRepository assetRepository,
@@ -53,7 +59,8 @@ public class PublicController {
             CorporateActionRepository corporateActionRepository,
             FilingSummaryRepository filingSummaryRepository,
             MarketIndexRepository marketIndexRepository,
-            IndexMemberApiService indexMemberApiService
+            IndexMemberApiService indexMemberApiService,
+            FredService fredService
     ) {
         this.assetRepository = assetRepository;
         this.quarterRepository = quarterRepository;
@@ -63,9 +70,25 @@ public class PublicController {
         this.filingSummaryRepository = filingSummaryRepository;
         this.marketIndexRepository = marketIndexRepository;
         this.indexMemberApiService = indexMemberApiService;
+        this.fredService = fredService;
     }
 
     public record MarketIndexRow(String code, String displayName) {
+    }
+
+    public record FredSeriesItem(
+            @NotBlank @Size(max = 30) @Pattern(regexp = "^[A-Z][A-Z0-9]*$", message = "Invalid series id format") String seriesId,
+            Boolean computeYoy
+    ) {
+    }
+
+    @PostMapping("/fred-data")
+    public ResponseEntity<?> fredData(@RequestBody List<@Valid FredSeriesItem> series) {
+        Map<String, List<FredObservation>> response = new LinkedHashMap<>();
+        for (FredSeriesItem item : series) {
+            response.put(item.seriesId(), fredService.getSeries(item.seriesId(), Boolean.TRUE.equals(item.computeYoy())));
+        }
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/quarters")

--- a/springboot/src/main/java/com/fattorestreet/sec_api/economic/FredService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/economic/FredService.java
@@ -1,0 +1,81 @@
+package com.fattorestreet.sec_api.economic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class FredService {
+
+    private static final String OBSERVATIONS_URL = "https://api.stlouisfed.org/fred/series/observations";
+    private static final long CACHE_TTL_MS = 24 * 60 * 60 * 1000L;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String apiKey;
+    private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    public record FredObservation(LocalDate date, double value) {
+    }
+
+    private record CacheEntry(List<FredObservation> observations, long expiresAtEpochMs) {
+    }
+
+    @Autowired
+    public FredService(@Value("${fred.api-key}") String apiKey) {
+        this(new RestTemplate(), apiKey);
+    }
+
+    FredService(RestTemplate restTemplate, String apiKey) {
+        this.restTemplate = restTemplate;
+        this.apiKey = apiKey;
+    }
+
+    public List<FredObservation> getSeries(String seriesId, boolean computeYoy) {
+        String cacheKey = seriesId + "|" + computeYoy;
+        CacheEntry cached = cache.get(cacheKey);
+        if (cached != null && cached.expiresAtEpochMs() > System.currentTimeMillis()) {
+            return cached.observations();
+        }
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(OBSERVATIONS_URL)
+                .queryParam("series_id", seriesId)
+                .queryParam("api_key", apiKey)
+                .queryParam("file_type", "json");
+        if (computeYoy) {
+            builder.queryParam("units", "pc1");
+        }
+        String body = restTemplate.getForObject(builder.toUriString(), String.class);
+
+        List<FredObservation> observations = parseObservations(body);
+        cache.put(cacheKey, new CacheEntry(observations, System.currentTimeMillis() + CACHE_TTL_MS));
+        return observations;
+    }
+
+    private List<FredObservation> parseObservations(String body) {
+        JsonNode root = objectMapper.readTree(body);
+        List<FredObservation> result = new ArrayList<>();
+        for (JsonNode observation : root.path("observations")) {
+            double value;
+            try {
+                value = Double.parseDouble(observation.path("value").asText());
+            } catch (NumberFormatException e) {
+                continue; // FRED marks missing values with "."
+            }
+            result.add(new FredObservation(LocalDate.parse(observation.path("date").asText()), value));
+        }
+        result.sort(Comparator.comparing(FredObservation::date));
+        return result;
+    }
+}

--- a/springboot/src/main/resources/application.properties
+++ b/springboot/src/main/resources/application.properties
@@ -33,3 +33,5 @@ sec.http.retry-max-attempts=${SEC_HTTP_RETRY_MAX_ATTEMPTS:3}
 sec.http.retry-base-backoff-ms=${SEC_HTTP_RETRY_BASE_BACKOFF_MS:1000}
 sec.http.min-interval-ms=${SEC_HTTP_MIN_INTERVAL_MS:250}
 sec.contact-email=${SEC_CONTACT_EMAIL:}
+# FRED (Federal Reserve Economic Data) API key for the /fred-data endpoint.
+fred.api-key=${FRED_API_KEY:}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/controller/PublicControllerTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/controller/PublicControllerTest.java
@@ -1,5 +1,7 @@
 package com.fattorestreet.sec_api.controller;
 
+import com.fattorestreet.sec_api.economic.FredService;
+import com.fattorestreet.sec_api.economic.FredService.FredObservation;
 import com.fattorestreet.sec_api.index.IndexMemberApiService;
 import com.fattorestreet.sec_api.index.IndexMemberApiService.IndexMemberRow;
 import com.fattorestreet.sec_api.index.IndexMemberApiService.StockRow;
@@ -22,6 +24,7 @@ import com.fattorestreet.sec_api.config.SecurityConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +37,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PublicController.class)
@@ -52,6 +56,7 @@ class PublicControllerTest {
     @MockitoBean private FilingSummaryRepository filingSummaryRepository;
     @MockitoBean private MarketIndexRepository marketIndexRepository;
     @MockitoBean private IndexMemberApiService indexMemberApiService;
+    @MockitoBean private FredService fredService;
 
     private Asset buildAsset(Long cik) {
         Asset a = new Asset();
@@ -431,5 +436,38 @@ class PublicControllerTest {
                 .andExpect(jsonPath("$[0].id").value(2))
                 .andExpect(jsonPath("$[0].index").value("Fattore 50"))
                 .andExpect(jsonPath("$[0].stock.ticker").value("MSFT"));
+    }
+
+    // --- /fred-data endpoint ---
+
+    @Test
+    void fredData_returnsObservationsKeyedBySeriesId() throws Exception {
+        when(fredService.getSeries("UNRATE", false)).thenReturn(List.of(
+                new FredObservation(LocalDate.of(2024, 1, 1), 3.7),
+                new FredObservation(LocalDate.of(2024, 2, 1), 3.9)));
+        when(fredService.getSeries("CPIAUCSL", true)).thenReturn(List.of(
+                new FredObservation(LocalDate.of(2024, 1, 1), 3.1)));
+
+        mockMvc.perform(post("/fred-data")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[{\"seriesId\":\"UNRATE\"},{\"seriesId\":\"CPIAUCSL\",\"computeYoy\":true}]"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.UNRATE", hasSize(2)))
+                .andExpect(jsonPath("$.UNRATE[0].date").value("2024-01-01"))
+                .andExpect(jsonPath("$.UNRATE[0].value").value(3.7))
+                .andExpect(jsonPath("$.CPIAUCSL[0].value").value(3.1));
+
+        verify(fredService).getSeries("UNRATE", false);
+        verify(fredService).getSeries("CPIAUCSL", true);
+    }
+
+    @Test
+    void fredData_invalidSeriesIdFormat_throwsConstraintViolation() {
+        assertThrows(jakarta.servlet.ServletException.class, () ->
+                mockMvc.perform(post("/fred-data")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[{\"seriesId\":\"bad id\"}]"))
+        );
+        verifyNoInteractions(fredService);
     }
 }

--- a/springboot/src/test/java/com/fattorestreet/sec_api/economic/FredServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/economic/FredServiceTest.java
@@ -1,0 +1,84 @@
+package com.fattorestreet.sec_api.economic;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FredServiceTest {
+
+    private static final String PAYLOAD = """
+            {"observations": [
+              {"realtime_start": "2026-01-01", "realtime_end": "2026-01-01", "date": "2024-02-01", "value": "3.9"},
+              {"realtime_start": "2026-01-01", "realtime_end": "2026-01-01", "date": "2024-01-01", "value": "3.7"},
+              {"realtime_start": "2026-01-01", "realtime_end": "2026-01-01", "date": "2024-03-01", "value": "."}
+            ]}
+            """;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private FredService fredService;
+
+    @BeforeEach
+    void setUp() {
+        fredService = new FredService(restTemplate, "test-key");
+    }
+
+    @Test
+    void getSeries_parsesSortsAndDropsMissingValues() {
+        when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(PAYLOAD);
+
+        List<FredService.FredObservation> result = fredService.getSeries("UNRATE", false);
+
+        // FRED's "." missing marker is dropped, remaining observations sorted ascending by date
+        assertEquals(2, result.size());
+        assertEquals(LocalDate.of(2024, 1, 1), result.get(0).date());
+        assertEquals(3.7, result.get(0).value());
+        assertEquals(LocalDate.of(2024, 2, 1), result.get(1).date());
+        assertEquals(3.9, result.get(1).value());
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(restTemplate).getForObject(urlCaptor.capture(), eq(String.class));
+        String url = urlCaptor.getValue();
+        assertTrue(url.contains("series_id=UNRATE"));
+        assertTrue(url.contains("api_key=test-key"));
+        assertTrue(url.contains("file_type=json"));
+        assertFalse(url.contains("units=pc1"));
+    }
+
+    @Test
+    void getSeries_computeYoyRequestsPc1Units() {
+        when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(PAYLOAD);
+
+        fredService.getSeries("CPIAUCSL", true);
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(restTemplate).getForObject(urlCaptor.capture(), eq(String.class));
+        assertTrue(urlCaptor.getValue().contains("units=pc1"));
+    }
+
+    @Test
+    void getSeries_cachesResultsPerSeriesAndUnits() {
+        when(restTemplate.getForObject(anyString(), eq(String.class))).thenReturn(PAYLOAD);
+
+        fredService.getSeries("UNRATE", false);
+        fredService.getSeries("UNRATE", false);
+        verify(restTemplate, times(1)).getForObject(anyString(), eq(String.class));
+
+        fredService.getSeries("UNRATE", true);
+        verify(restTemplate, times(2)).getForObject(anyString(), eq(String.class));
+    }
+}


### PR DESCRIPTION
## Summary
- Spring Boot now owns FRED economic data alongside its other external market data (SEC, IEX): new public `POST /fred-data` backed by `economic/FredService` — 24h in-memory cache per series/units, `units=pc1` for YoY series, FRED's `"."` missing markers dropped, response shape unchanged (`{seriesId: [{date, value}]}`)
- React's `getFredData` moves from `djangoApi` to `springbootApi` (camelCase request keys per Spring conventions); the Economic Indicators page and MSW mocks follow
- Django's `FredDataRetrieveView`, `FredSeriesItemSerializer`, `get_fred_data` helper, URL, and tests are removed; `FRED_API_KEY` moves to the Spring Boot environment (docs, dev compose, and the run.sh secret example updated)
- FRED remains a commercially-free source; data is cache-only, never persisted

## Test plan
- `mvn test` — 470 tests pass, including new `FredServiceTest` (parsing/sorting/missing-marker/caching/pc1) and `PublicControllerTest` fred-data cases
- `uv run python manage.py test` — 110 tests pass after removals
- `npm run lint`, `npx vitest --run` (143 tests), `npm run build` — all green
- Live wiring check: booted Spring Boot locally and POSTed to `/fred-data`; request routed unauthenticated through security to the FRED API (rejected only for the dummy dev key)
- Remaining: production needs `FRED_API_KEY` present in the shared `fattorestreet/env` secret (already there if Django prod used it); verify `/economic-indicators` renders after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)