### PR TITLE
fix stale docs: CI section, deploy/ paths, full app lists

### DIFF
--- a/.claude/rules/auto-update-tests.md
+++ b/.claude/rules/auto-update-tests.md
@@ -19,7 +19,7 @@ After making code changes to application logic, check whether tests need updatin
 - Follow the patterns in the existing test files -- do not introduce new testing libraries
 - For Django: use `@patch()` for external APIs, `BaseAPITestCase` for setup, test both auth and unauth paths
 - For Spring Boot: use `@ExtendWith(MockitoExtension.class)` for services, `@WebMvcTest` + `@MockitoBean` for controllers
-- For React: use `renderWithProviders` from `testutils.tsx`, `screen.findByText` for async, `userEvent` for interactions (v13 API -- no `.setup()`)
+- For React: use `renderWithProviders` from `testutils.tsx`, `screen.findByText` for async, `userEvent` for interactions (direct API -- no `.setup()`, matching existing tests)
 - Only add/modify tests for the changed code -- do not rewrite unrelated tests
 - Run the relevant test suite after changes to verify nothing is broken
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ mvn test -Dtest=MainControllerTest#testGetQuarters  # Specific method
 mvn clean test                                   # Clean + test
 ```
 
+### CI
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint + build + tests, Django tests, Spring Boot tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+
 ## Architecture
 
 ### Request Flow

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 This repository contains the source code for a comprehensive web application featuring:
 
-- **Finance**: Stock tracking, historical data, and market indexes—Django for the main portfolio API, plus a **Spring Boot** service for SEC EDGAR filings, quarterly fundamentals, and related market data.
-- **Social**: Restaurant reviews and recommendation engine.
-- **AI**: An investing chatbot assistant; optional **local AI** tooling lives under `llm/` (see [llm/README.md](llm/README.md)).
+- **Finance**: Stock tracking, historical data, and market indexes—Django for the main portfolio API, plus a **Spring Boot** service for SEC EDGAR filings, quarterly fundamentals, corporate actions, FRED economic data, and daily prices.
+- **Social**: Restaurant reviews and recommendations, a blog, and media recommendations (books, movies, shows, music, podcasts, games, websites).
+- **AI**: An investing chatbot assistant (Google Gemini) and LLM-summarized 10-K filings; optional **local AI** tooling lives under `llm/` (see [llm/README.md](llm/README.md)).
 
 ---
 
@@ -17,7 +17,7 @@ We have organized the documentation to help you get started quickly:
 - **[🚀 Getting Started](docs/GETTING_STARTED.md)**: Setup guide for local development and staging.
 - **[🏗 Architecture](docs/ARCHITECTURE.md)**: High-level system design, tech stack, data flow, and development practices.
 - **[📖 API Reference](docs/API_REFERENCE.md)**: Django and Spring Boot HTTP endpoints.
-- **[☁️ Deployment](docs/DEPLOYMENT.md)**: Infrastructure guide (Docker, Kubernetes, cloud).
+- **[☁️ Deployment](docs/DEPLOYMENT.md)**: Infrastructure guide (Docker Compose on AWS EC2, GHCR images, SSM-driven deploys).
 
 **CI**: Pull requests and pushes to `main` run [GitHub Actions](.github/workflows/ci.yml) (React lint/build/tests, Django tests, Spring Boot tests, detect-secrets). See [Getting Started](docs/GETTING_STARTED.md) (Testing and CI sections) for local equivalents.
 
@@ -29,12 +29,12 @@ Service-specific detail: [django/README.md](django/README.md), [springboot/READM
 
 | Directory | Description |
 |-----------|-------------|
-| **[`django/`](django/)** | **Primary API**. Django REST Framework—auth, portfolio, chatbot, restaurants. |
-| **[`springboot/`](springboot/)** | **SEC microservice**. Spring Boot—EDGAR data, quarterly financials, corporate actions, index membership, daily prices (IEX ingest). |
+| **[`django/`](django/)** | **Primary API**. Django REST Framework—auth, portfolio, chatbot, restaurants, changeflow (changelog + feedback), blog, entertainment. |
+| **[`springboot/`](springboot/)** | **SEC microservice**. Spring Boot—EDGAR data, quarterly financials, corporate actions, index membership, daily prices (IEX ingest), FRED economic data. |
 | **[`react-app/`](react-app/)** | **Frontend**. React, TypeScript, Vite. |
 | **[`llm/`](llm/)** | **Local AI**. llama.cpp, optional SD/TTS helpers (not required for the web app). |
 | **[`nginx/`](nginx/)** | Reverse proxy configuration for composed deployments. |
-| **[`kubernetes/`](kubernetes/)** | Kubernetes manifests and related DevOps assets. |
+| **[`deploy/`](deploy/)** | Docker Compose stacks, build/deploy scripts, and the automated-deploy runbook ([DEPLOY.md](deploy/DEPLOY.md)). |
 | **[`docs/`](docs/)** | Project documentation. |
 
 ---
@@ -43,7 +43,7 @@ Service-specific detail: [django/README.md](django/README.md), [springboot/READM
 
 For full details, see [Getting Started](docs/GETTING_STARTED.md). Typical local ports: Django **8000**, Spring Boot **8080**, Vite **5173**.
 
-**Django (primary API)** — requires [uv](https://docs.astral.sh/uv/) (`brew install uv`):
+**Django (primary API)** — requires [uv](https://docs.astral.sh/uv/) (`brew install uv`). Create `django/.env` with at least `SECRET_KEY` and `DATABASE` (e.g. `DATABASE=sqlite` for a quick start; see [Getting Started](docs/GETTING_STARTED.md) for the full list):
 
 ```bash
 cd django

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,13 +52,16 @@ graph TD
     - **`users/`**: Authentication, user profiles, and JWT handling.
     - **`chatbot/`**: Logic for the AI investing assistant.
     - **`restaurants/`**: Restaurant review system.
+    - **`changeflow/`**: Changelog and feedback tickets.
+    - **`blog/`**: Blog posts with categories and tags.
+    - **`entertainment/`**: Media recommendations (books, movies, shows, music, podcasts, games, websites).
 - **`react-app/`**: Frontend source code.
     - **`src/components/`**: Reusable UI components.
     - **`src/pages/`**: Main application views.
-    - **`src/store/`**: Redux state slices.
+    - **`src/reducers/`**: Redux state slices (store setup in `src/store.ts`).
 - **`springboot/`**: Spring Boot `sec-api` service (SEC EDGAR data, IEX-derived daily prices, and market index membership under `/index-members` and `/admin/indexes/*`).
-- **`kubernetes/`**: Scripts and configs for K8s deployment.
-- **`aws/`**: AWS specific configuration files.
+- **`deploy/`**: Docker Compose stacks and build/deploy scripts (see [Deployment](DEPLOYMENT.md)).
+- **`nginx/`**: Reverse proxy configuration.
 
 ## 🔄 Data Flow
 


### PR DESCRIPTION
## Summary
- Add a CI section to CLAUDE.md documenting what `ci.yml` and `docker-build.yml` run, so future Claude Code sessions know what must pass before merge
- Fix README and docs/ARCHITECTURE.md references to a nonexistent `kubernetes/` (and `aws/`) directory; infra actually lives in `deploy/` (Docker Compose on EC2, GHCR images, SSM-driven deploys)
- Complete the Django app lists (changeflow, blog, entertainment were missing) and fix `src/store/` → `src/reducers/`
- Add the required `django/.env` (`SECRET_KEY`, `DATABASE`) to the README quick start, which otherwise fails on a clean checkout
- Correct the userEvent version note in `.claude/rules/auto-update-tests.md` (package is v14; tests use the direct API, no `.setup()`)

## Test plan
- Docs-only change, no runtime surface
- Verified each claim against the codebase: `pom.xml` versions, `INSTALLED_APPS`, `react-app/src/` layout, workflow files, and `.pre-commit-config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)