### PR TITLE
fix pgadmin4 startup: password from secrets manager + persistent volume

### DIFF
--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -33,10 +33,10 @@ sudo docker network create --driver bridge dockerNet
 #    and IMDSv2 hop limit >= 2)
 cp .env.example .env
 
-# 3. Stateful infra (postgres, redis, pgadmin4). POSTGRES_PASSWORD is only read
-# on FIRST-TIME init of an empty /mnt/ebs/postgres-data volume -- see the
-# comments in docker-compose.infra.yml for the fetch-from-secret recipe.
-# PGADMIN_DEFAULT_PASSWORD seeds the pgadmin admin account on first run only.
+# 3. Stateful infra (postgres, redis, pgadmin4). POSTGRES_PASSWORD and
+# PGADMIN_DEFAULT_PASSWORD are only read on FIRST-TIME init of their empty
+# /mnt/ebs volumes -- see the comments in docker-compose.infra.yml for the
+# fetch-from-secret recipes (pgadmin's volume must be owned by uid 5050).
 sudo docker compose -f docker-compose.infra.yml up -d
 
 # 4. App services

--- a/deploy/docker-compose.infra.yml
+++ b/deploy/docker-compose.infra.yml
@@ -41,12 +41,20 @@ services:
     networks: [dockerNet]
     restart: unless-stopped
 
-  # PGADMIN_DEFAULT_PASSWORD seeds the admin account on first run only
-  # (persisted thereafter). Supply the real value via the host env -- do NOT
-  # hardcode it here.
+  # PGADMIN_DEFAULT_PASSWORD seeds the admin account ONLY on first run (empty
+  # /mnt/ebs/pgadmin-data, which pgadmin's uid 5050 must own); the image
+  # hard-fails at startup if it's empty then. Persisted in the volume
+  # thereafter, when the env is ignored -- same lifecycle as POSTGRES_PASSWORD
+  # above. FRESH VOLUME ONLY, fetch it from the secret on the host:
+  #   sudo mkdir -p /mnt/ebs/pgadmin-data && sudo chown 5050:5050 /mnt/ebs/pgadmin-data
+  #   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
+  #         --query SecretString --output text | jq -r .PGADMIN_DEFAULT_PASSWORD)
+  #   PGADMIN_DEFAULT_PASSWORD="$PW" docker compose -f docker-compose.infra.yml up -d pgadmin4
   pgadmin4:
     image: dpage/pgadmin4
     container_name: pgadmin4
+    volumes:
+      - /mnt/ebs/pgadmin-data:/var/lib/pgadmin
     ports:
       - "5050:80"
     environment:

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -30,7 +30,8 @@ sudo docker network create --driver bridge dockerNet
 #     "SEC_CONTACT_EMAIL": "johnefattore@gmail.com",
 #     "LLM_SERVER_URL": "http://localhost:8081",
 #     "SHOW_JPA_SQL": "false",
-#     "FRED_API_KEY": "<fred-api-key>"
+#     "FRED_API_KEY": "<fred-api-key>",
+#     "PGADMIN_DEFAULT_PASSWORD": "<pgadmin-password>"
 #   }'
 #
 # Requires: EC2 instance role with secretsmanager:GetSecretValue on the secret,
@@ -87,15 +88,24 @@ sudo docker run --name nginx --network dockerNet \
 sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
 
 # pgadmin4
-# PGADMIN_DEFAULT_PASSWORD seeds the admin account on first run only (persisted
-# thereafter). Supply the real value via the $PGADMIN_DEFAULT_PASSWORD env on the
-# host -- do NOT hardcode it here.
+# The pgadmin image hard-fails at startup ("You need to define the
+# PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD ...") when the password env
+# is empty and /var/lib/pgadmin/pgadmin4.db doesn't exist yet, so fetch it from
+# fattorestreet/env on the host (same pattern as the postgres fresh-volume
+# recipe) instead of relying on a host shell var. The account seeds on first run
+# and persists in the /mnt/ebs/pgadmin-data volume thereafter (pgadmin runs as
+# uid 5050, which must own the mount).
+sudo mkdir -p /mnt/ebs/pgadmin-data
+sudo chown 5050:5050 /mnt/ebs/pgadmin-data
+PGADMIN_PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
+  --query SecretString --output text | jq -r .PGADMIN_DEFAULT_PASSWORD)
 sudo docker run -d \
   --name pgadmin4 \
   --network dockerNet \
+  -v /mnt/ebs/pgadmin-data:/var/lib/pgadmin \
   -p 5050:80 \
   -e PGADMIN_DEFAULT_EMAIL=johnefattore@gmail.com \
-  -e PGADMIN_DEFAULT_PASSWORD="$PGADMIN_DEFAULT_PASSWORD" \
+  -e PGADMIN_DEFAULT_PASSWORD="$PGADMIN_PW" \
   dpage/pgadmin4
 
 # Certbot get SSL cert


### PR DESCRIPTION
## Summary
- pgadmin4 failed to start on the host: the image hard-fails on first run when `PGADMIN_DEFAULT_PASSWORD` is empty, and `run.sh` read it from an ad-hoc host shell var that nothing in the deploy path sets. Root cause of the live breakage: `deploy.sh` evicted the old docker-run container at the compose cutover, and with no volume the seeded admin account died with the container layer, making every restart a failing "first run".
- `run.sh` now fetches the password from the `fattorestreet/env` secret on the host (same pattern as the postgres fresh-volume recipe) and mounts `/mnt/ebs/pgadmin-data:/var/lib/pgadmin` (chowned to uid 5050, which pgadmin runs as).
- `docker-compose.infra.yml` gets the same volume plus a first-run fetch-from-secret recipe in comments, mirroring how `POSTGRES_PASSWORD` is documented; the empty-default env mapping stays since it is ignored once `pgadmin4.db` exists and is needed for a future re-seed.
- `compose.sh` runbook comment updated to cover both first-run passwords.

## Test plan
- `docker compose -f docker-compose.infra.yml config --quiet` passes.
- Ran the new run.sh block on the EC2 host: `PGADMIN_DEFAULT_PASSWORD` added to the secret, container started cleanly, logged into pgadmin at /pgadmin4/ and browsed the postgres + springboot databases.
- Remaining: next automated deploy will evict the docker-run container and recreate it under compose; account should persist via the volume (env ignored after first init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)