### PR TITLE
lock down pgadmin4: read-only DB role + minimal container privileges

### DIFF
--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -37,6 +37,8 @@ cp .env.example .env
 # PGADMIN_DEFAULT_PASSWORD are only read on FIRST-TIME init of their empty
 # /mnt/ebs volumes -- see the comments in docker-compose.infra.yml for the
 # fetch-from-secret recipes (pgadmin's volume must be owned by uid 5050).
+# One-time after postgres is up: create the read-only pgadmin_ro role that
+# pgadmin's server connection should use -- see sql/pgadmin-readonly.sql.
 sudo docker compose -f docker-compose.infra.yml up -d
 
 # 4. App services

--- a/deploy/docker-compose.infra.yml
+++ b/deploy/docker-compose.infra.yml
@@ -50,16 +50,30 @@ services:
   #   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
   #         --query SecretString --output text | jq -r .PGADMIN_DEFAULT_PASSWORD)
   #   PGADMIN_DEFAULT_PASSWORD="$PW" docker compose -f docker-compose.infra.yml up -d pgadmin4
+  #
+  # Least privilege: no host port (nginx reaches pgadmin4:80 over dockerNet),
+  # read-only rootfs (only the data volume and /tmp are writable), all Linux
+  # capabilities dropped, and no privilege escalation. The DB connection
+  # registered in pgadmin should use the read-only pgadmin_ro role, not
+  # postgres -- see sql/pgadmin-readonly.sql.
   pgadmin4:
     image: dpage/pgadmin4
     container_name: pgadmin4
     volumes:
       - /mnt/ebs/pgadmin-data:/var/lib/pgadmin
-    ports:
-      - "5050:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: johnefattore@gmail.com
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-}
+      # Pinned: newer images default to 8080, which would silently break the
+      # nginx upstream (http://pgadmin4) on an image pull
+      PGADMIN_LISTEN_PORT: 80
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/log/pgadmin
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
     networks: [dockerNet]
     restart: unless-stopped
 

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -31,7 +31,8 @@ sudo docker network create --driver bridge dockerNet
 #     "LLM_SERVER_URL": "http://localhost:8081",
 #     "SHOW_JPA_SQL": "false",
 #     "FRED_API_KEY": "<fred-api-key>",
-#     "PGADMIN_DEFAULT_PASSWORD": "<pgadmin-password>"
+#     "PGADMIN_DEFAULT_PASSWORD": "<pgadmin-password>",
+#     "PGADMIN_RO_DB_PASSWORD": "<postgres-password-for-read-only-pgadmin_ro-role>"
 #   }'
 #
 # Requires: EC2 instance role with secretsmanager:GetSecretValue on the secret,
@@ -95,6 +96,12 @@ sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
 # recipe) instead of relying on a host shell var. The account seeds on first run
 # and persists in the /mnt/ebs/pgadmin-data volume thereafter (pgadmin runs as
 # uid 5050, which must own the mount).
+#
+# Least privilege (mirrors docker-compose.infra.yml): no host port (nginx
+# reaches pgadmin4:80 over dockerNet), read-only rootfs with only the data
+# volume and /tmp writable, all capabilities dropped, no privilege escalation.
+# Register the DB connection in pgadmin as the read-only pgadmin_ro role
+# (created once via sql/pgadmin-readonly.sql), not postgres.
 sudo mkdir -p /mnt/ebs/pgadmin-data
 sudo chown 5050:5050 /mnt/ebs/pgadmin-data
 PGADMIN_PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
@@ -103,9 +110,14 @@ sudo docker run -d \
   --name pgadmin4 \
   --network dockerNet \
   -v /mnt/ebs/pgadmin-data:/var/lib/pgadmin \
-  -p 5050:80 \
+  --read-only \
+  --tmpfs /tmp \
+  --tmpfs /var/log/pgadmin \
+  --cap-drop ALL \
+  --security-opt no-new-privileges:true \
   -e PGADMIN_DEFAULT_EMAIL=johnefattore@gmail.com \
   -e PGADMIN_DEFAULT_PASSWORD="$PGADMIN_PW" \
+  -e PGADMIN_LISTEN_PORT=80 \
   dpage/pgadmin4
 
 # Certbot get SSL cert

--- a/deploy/sql/pgadmin-readonly.sql
+++ b/deploy/sql/pgadmin-readonly.sql
@@ -1,0 +1,47 @@
+-- Read-only Postgres role for pgadmin4 (least privilege).
+--
+-- ONE-TIME, on the EC2 host, against the postgres container as the superuser
+-- (local socket auth inside the container is trusted). Fetch the role password
+-- from fattorestreet/env first (key PGADMIN_RO_DB_PASSWORD, add it to the
+-- secret if missing):
+--
+--   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
+--         --query SecretString --output text | jq -r .PGADMIN_RO_DB_PASSWORD)
+--   sudo docker exec -i postgres psql -U postgres -v ON_ERROR_STOP=1 \
+--     -v ro_password="'$PW'" -f - < deploy/sql/pgadmin-readonly.sql
+--
+-- Then in the pgadmin UI, register (or edit) the server connection to use
+-- username pgadmin_ro instead of postgres. Re-running fails on CREATE ROLE
+-- once the role exists; to rotate the password use
+-- ALTER ROLE pgadmin_ro PASSWORD '<new>' instead.
+
+CREATE ROLE pgadmin_ro LOGIN PASSWORD :ro_password
+  NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION;
+
+-- Defense in depth: sessions default to read-only transactions. The grants
+-- below are the real boundary; this just makes accidental writes fail fast.
+ALTER ROLE pgadmin_ro SET default_transaction_read_only = on;
+
+GRANT CONNECT ON DATABASE postgres TO pgadmin_ro;
+GRANT CONNECT ON DATABASE springboot TO pgadmin_ro;
+
+-- postgres db (Django)
+\connect postgres
+GRANT USAGE ON SCHEMA public TO pgadmin_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO pgadmin_ro;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO pgadmin_ro;
+-- Cover tables created by future migrations (which run as postgres)
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT ON TABLES TO pgadmin_ro;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT ON SEQUENCES TO pgadmin_ro;
+
+-- springboot db (Spring Boot)
+\connect springboot
+GRANT USAGE ON SCHEMA public TO pgadmin_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO pgadmin_ro;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO pgadmin_ro;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT ON TABLES TO pgadmin_ro;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT ON SEQUENCES TO pgadmin_ro;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -17,6 +17,11 @@ The production environment runs on a single EC2 instance behind Route 53:
 3.  **App containers**: Django (Gunicorn), Spring Boot.
 4.  **Data stores**: PostgreSQL 17 and Redis 8 containers on the same Docker network, with Postgres data on the EBS volume.
 
+### pgadmin4 (least privilege)
+- No host port: pgadmin is reachable only through nginx at `/pgadmin4/`, over `dockerNet`.
+- The container runs with a read-only root filesystem (only the `/var/lib/pgadmin` volume and a `/tmp` tmpfs are writable), all Linux capabilities dropped, and `no-new-privileges` (see `deploy/docker-compose.infra.yml`).
+- Its database connection uses the read-only `pgadmin_ro` role (SELECT-only on the `postgres` and `springboot` databases), not the `postgres` superuser. Create the role once with `deploy/sql/pgadmin-readonly.sql` (run instructions in the file), store its password in `fattorestreet/env` as `PGADMIN_RO_DB_PASSWORD`, and register the server connection in the pgadmin UI with that role.
+
 ## 🚀 Build & Deploy
 
 - **CI**: GitHub Actions (`.github/workflows/ci.yml`) runs frontend, Django, and Spring Boot tests plus a secret scan on every push/PR to `main`. A second workflow (`.github/workflows/docker-build.yml`) builds all three Docker images on every PR as a merge check (build-only); the nginx image builds the React bundle and Django static files itself, so it works from a clean checkout.


### PR DESCRIPTION
## Summary
- pgadmin4 connected to Postgres as the superuser, published port 5050 straight to the host (bypassing nginx), and ran with default container privileges — the softest target on the box
- New `deploy/sql/pgadmin-readonly.sql` creates a `pgadmin_ro` role: SELECT-only on the `postgres` and `springboot` databases, default privileges so future migration-created tables stay readable, read-only transactions by default as defense in depth; register pgadmin's server connection with this role
- Container hardening in `docker-compose.infra.yml` / `run.sh`: no host port (nginx reaches `pgadmin4:80` over dockerNet), read-only rootfs (only the data volume, `/tmp`, and `/var/log/pgadmin` tmpfs writable), `cap_drop: ALL`, `no-new-privileges`
- Pinned `PGADMIN_LISTEN_PORT=80`: current `dpage/pgadmin4` images default to 8080, which would silently break the nginx upstream on the next image pull
- Docs: rollout steps in `docs/DEPLOYMENT.md`, runbook pointer in `compose.sh`, `PGADMIN_RO_DB_PASSWORD` added to the secret template in `run.sh`

## Test plan
- [x] Ran the hardened container locally in Docker with all flags: boots clean, login page serves HTTP 200 (surfaced the `/var/log/pgadmin` and 8080 issues, both fixed)
- [x] Ran the SQL script against a scratch postgres:17 with both databases seeded: SELECT works, INSERT/CREATE fail with permission denied even after lifting the read-only transaction default, tables created afterward by `postgres` remain readable
- [ ] After merge, on the host: add `PGADMIN_RO_DB_PASSWORD` to `fattorestreet/env`, run the SQL script (command in file header), `docker compose -f docker-compose.infra.yml up -d`, re-register the pgadmin server connection as `pgadmin_ro`

🤖 Generated with [Claude Code](https://claude.com/claude-code)