### PR TITLE
isolate pgadmin4 on its own network; postfix off, limits, pinned tag

### DIFF
--- a/.claude/plans/floating-sniffing-pebble.md
+++ b/.claude/plans/floating-sniffing-pebble.md
@@ -1,0 +1,64 @@
+# pgadmin4 hardening round 2: network segmentation, postfix off, limits, pinned tag
+
+## Context
+
+PR #102 (branch `pgadmin-least-privilege`) already gave pgadmin a read-only DB role and minimal container privileges (no host port, read-only rootfs, cap_drop ALL, no-new-privileges). This round applies the remaining privilege cleanups agreed with the user (items 2–5 of the follow-up list), added to the same open PR:
+
+2. **Network segmentation** — pgadmin currently shares `dockerNet` with every container, so a compromised pgadmin could reach unauthenticated redis and the app containers. Also, postgres (5432) and redis (6379) are published on `0.0.0.0`, protected only by the EC2 security group.
+3. **Disable Postfix** — the pgadmin image starts a root-owned Postfix for password-reset emails nobody uses.
+4. **Resource limits** — cap memory and PIDs so the container can't starve the host (which also runs the DB).
+5. **Pin image tag** — `dpage/pgadmin4` floats on `latest`; Docker Hub has a rolling major tag `9` (verified), matching the repo's postgres:17 / redis:8 pinning convention.
+
+User decision: postgres host port becomes `127.0.0.1:5432:5432`; redis host port is removed entirely (apps use dockerNet DNS, unaffected).
+
+## Changes
+
+### `deploy/docker-compose.infra.yml`
+- Top-level `networks:`: add `pgadminNet` (external), keep `dockerNet`.
+- `postgres`: `ports:` → `"127.0.0.1:5432:5432"`; `networks: [dockerNet, pgadminNet]`.
+- `redis`: remove `ports:` block.
+- `pgadmin4`:
+  - `image: dpage/pgadmin4:9`
+  - `networks: [pgadminNet]` (off dockerNet — can only reach postgres + be reached by nginx)
+  - env: add `PGADMIN_DISABLE_POSTFIX: "True"`
+  - `mem_limit: 512m`, `pids_limit: 100`
+  - update the least-privilege comment block accordingly
+
+### `deploy/docker-compose.yml`
+- `nginx`: `networks: [dockerNet, pgadminNet]` so the `/pgadmin4/` upstream still resolves.
+- Top-level `networks:`: add `pgadminNet` (external).
+
+### `deploy/run.sh` (manual docker-run mirror)
+- Add `sudo docker network create --driver bridge pgadminNet` next to the dockerNet creation.
+- postgres run: `-p 127.0.0.1:5432:5432`.
+- redis run: drop `-p 6379:6379`.
+- pgadmin run: `dpage/pgadmin4:9`, `--network pgadminNet`, `-e PGADMIN_DISABLE_POSTFIX=True`, `--memory 512m --pids-limit 100`.
+- nginx run: add `--network dockerNet` note — docker run only accepts one `--network` at create; add a `sudo docker network connect pgadminNet nginx` line after the nginx run.
+- postgres run: needs both networks too → `docker network connect pgadminNet postgres` line after it.
+
+### `deploy/compose.sh`
+- Step for one-time host setup: add `sudo docker network create --driver bridge pgadminNet` beside the existing network creation reference.
+
+### `docs/DEPLOYMENT.md`
+- Extend the "pgadmin4 (least privilege)" section: isolated `pgadminNet` (nginx + postgres + pgadmin only), postfix disabled, memory/PID limits, pinned `:9` tag; note postgres now binds 127.0.0.1 and redis has no host port (admin via `docker exec`, laptop access via SSM port forward).
+
+## Rollout ordering (goes in PR body)
+
+`pgadminNet` must exist on the EC2 host **before** the merge deploy runs, or `deploy.sh`'s `compose up` fails:
+
+```bash
+sudo docker network create --driver bridge pgadminNet
+```
+
+Everything else converges automatically on deploy (deploy.sh runs `up -d` on both compose files, recreating postgres/redis/pgadmin/nginx with the new settings). Brief postgres recreate blip is expected. pgadmin UI connection (`pgadmin_ro`) is unaffected — host `postgres` resolves over pgadminNet.
+
+## Verification (local Docker)
+
+1. `docker network create testDockerNet && docker network create testPgadminNet`.
+2. Run postgres:17 on both nets, a redis:8 on testDockerNet only, pgadmin with the full new flag set (`:9` tag, read-only, tmpfs, cap-drop, no-new-privileges, postfix disabled, mem/pids limits) on testPgadminNet only.
+3. Assert: login page HTTP 200 on the mapped port; from inside the pgadmin container Python, TCP connect to `postgres:5432` succeeds, and name resolution/connect to `redis` fails (no lateral movement).
+4. `docker stats --no-stream` shows the 512MiB limit; `docker inspect` shows PidsLimit 100.
+5. Clean up all test containers/networks.
+6. `docker compose -f deploy/docker-compose.infra.yml config` and `docker compose -f deploy/docker-compose.yml config` to validate syntax (external networks may need stubs or `docker network create` locally first).
+
+Then commit to `pgadmin-least-privilege`, push (updates PR #102), and update the PR body with the new scope + the pre-merge network-creation step.

--- a/deploy/compose.sh
+++ b/deploy/compose.sh
@@ -24,8 +24,11 @@
 # One-time host setup
 # ---------------------------------------------------------------------------
 
-# 1. Shared bridge network (both compose files reference it as external)
+# 1. Bridge networks (both compose files reference them as external):
+#    dockerNet for the app stack, pgadminNet to isolate pgadmin4 (members:
+#    pgadmin4, postgres, nginx only)
 sudo docker network create --driver bridge dockerNet
+sudo docker network create --driver bridge pgadminNet
 
 # 2. Env file for compose: copy the template and fill in the real secret ARN
 #    (the fattorestreet/env secret itself is created per the doc block in

--- a/deploy/docker-compose.infra.yml
+++ b/deploy/docker-compose.infra.yml
@@ -24,20 +24,22 @@ services:
     container_name: postgres
     volumes:
       - /mnt/ebs/postgres-data:/var/lib/postgresql/data
+    # Host-local only: apps connect over dockerNet; admin psql from the EC2
+    # host (or a laptop via SSM port forwarding) uses 127.0.0.1
     ports:
-      - "0.0.0.0:5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
-    networks: [dockerNet]
+    networks: [dockerNet, pgadminNet]
     restart: unless-stopped
 
   # Major pinned like postgres; bump deliberately with the redis-py/django-redis
-  # client pins in django/pyproject.toml.
+  # client pins in django/pyproject.toml. No host port: redis has no auth, and
+  # django reaches it over dockerNet (redis://redis:6379); debug with
+  # `docker exec -it redis redis-cli`.
   redis:
     image: redis:8
     container_name: redis
-    ports:
-      - "6379:6379"
     networks: [dockerNet]
     restart: unless-stopped
 
@@ -51,13 +53,16 @@ services:
   #         --query SecretString --output text | jq -r .PGADMIN_DEFAULT_PASSWORD)
   #   PGADMIN_DEFAULT_PASSWORD="$PW" docker compose -f docker-compose.infra.yml up -d pgadmin4
   #
-  # Least privilege: no host port (nginx reaches pgadmin4:80 over dockerNet),
-  # read-only rootfs (only the data volume and /tmp are writable), all Linux
-  # capabilities dropped, and no privilege escalation. The DB connection
-  # registered in pgadmin should use the read-only pgadmin_ro role, not
-  # postgres -- see sql/pgadmin-readonly.sql.
+  # Least privilege: no host port (nginx reaches pgadmin4:80 over pgadminNet),
+  # isolated on pgadminNet (can only reach postgres, not redis/django/
+  # springboot), read-only rootfs (only the data volume and the tmpfs mounts
+  # are writable), all Linux capabilities dropped, no privilege escalation,
+  # bundled postfix disabled (root process, unused), and memory/PID limits so
+  # it can't starve the host. Major pinned like postgres/redis. The DB
+  # connection registered in pgadmin should use the read-only pgadmin_ro role,
+  # not postgres -- see sql/pgadmin-readonly.sql.
   pgadmin4:
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:9
     container_name: pgadmin4
     volumes:
       - /mnt/ebs/pgadmin-data:/var/lib/pgadmin
@@ -67,6 +72,7 @@ services:
       # Pinned: newer images default to 8080, which would silently break the
       # nginx upstream (http://pgadmin4) on an image pull
       PGADMIN_LISTEN_PORT: 80
+      PGADMIN_DISABLE_POSTFIX: "True"
     read_only: true
     tmpfs:
       - /tmp
@@ -74,9 +80,14 @@ services:
     cap_drop: [ALL]
     security_opt:
       - no-new-privileges:true
-    networks: [dockerNet]
+    mem_limit: 512m
+    pids_limit: 100
+    networks: [pgadminNet]
     restart: unless-stopped
 
+# Both created once on the host: docker network create --driver bridge <name>
 networks:
   dockerNet:
+    external: true
+  pgadminNet:
     external: true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -52,9 +52,13 @@ services:
     # start after the backends; nginx.conf re-resolves their IPs every 10s
     # via Docker DNS, so recreated backends are picked up without a restart
     depends_on: [django, springboot]
-    networks: [dockerNet]
+    # pgadminNet: pgadmin4 is isolated there (docker-compose.infra.yml); nginx
+    # joins it to proxy /pgadmin4/
+    networks: [dockerNet, pgadminNet]
     restart: unless-stopped
 
 networks:
   dockerNet:
+    external: true
+  pgadminNet:
     external: true

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -7,8 +7,10 @@
 # start (see each image's docker-entrypoint.sh). Fill in the placeholders below
 # (<...>) on the host before running.
 
-# network
+# networks: dockerNet for the app stack, pgadminNet to isolate pgadmin4
+# (members: pgadmin4, postgres, nginx only)
 sudo docker network create --driver bridge dockerNet
+sudo docker network create --driver bridge pgadminNet
 
 # ---------------------------------------------------------------------------
 # Secrets: ALL app config lives in ONE Secrets Manager secret, fattorestreet/env.
@@ -54,12 +56,16 @@ SECRETS_ARN=arn:aws:secretsmanager:us-east-1:<ACCOUNT_ID>:secret:fattorestreet/e
 #   PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
 #         --query SecretString --output text | jq -r .POSTGRES_PASSWORD)
 #   sudo docker run ... -e POSTGRES_PASSWORD="$PW" ... postgres:17
+# Host-local port only: apps connect over dockerNet; admin psql from the EC2
+# host (or a laptop via SSM port forwarding) uses 127.0.0.1. Also joined to
+# pgadminNet so the isolated pgadmin4 container can reach it.
 sudo docker run -d \
   --name postgres \
   --network dockerNet \
   -v /mnt/ebs/postgres-data:/var/lib/postgresql/data \
-  -p 0.0.0.0:5432:5432 \
+  -p 127.0.0.1:5432:5432 \
   postgres:17
+sudo docker network connect pgadminNet postgres
 
 # django (config from fattorestreet/env via SECRETS_ARN)
 sudo docker run --name django --network dockerNet -d \
@@ -83,10 +89,15 @@ sudo docker run --name nginx --network dockerNet \
   --log-opt awslogs-group=nginx-logs \
   --log-opt awslogs-stream=nginx-{{.ID}} \
   -d johnfattore/nginx
+# docker run only attaches one network at create; join pgadminNet after so
+# nginx can proxy /pgadmin4/ to the isolated pgadmin4 container
+sudo docker network connect pgadminNet nginx
 
 # Redis (major pinned like postgres above; bump deliberately with the
-# redis-py/django-redis client pins in django/pyproject.toml)
-sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
+# redis-py/django-redis client pins in django/pyproject.toml). No host port:
+# redis has no auth, and django reaches it over dockerNet (redis://redis:6379);
+# debug with `docker exec -it redis redis-cli`.
+sudo docker run --network dockerNet --name redis -d redis:8
 
 # pgadmin4
 # The pgadmin image hard-fails at startup ("You need to define the
@@ -98,27 +109,33 @@ sudo docker run --network dockerNet --name redis -d -p 6379:6379 redis:8
 # uid 5050, which must own the mount).
 #
 # Least privilege (mirrors docker-compose.infra.yml): no host port (nginx
-# reaches pgadmin4:80 over dockerNet), read-only rootfs with only the data
-# volume and /tmp writable, all capabilities dropped, no privilege escalation.
-# Register the DB connection in pgadmin as the read-only pgadmin_ro role
-# (created once via sql/pgadmin-readonly.sql), not postgres.
+# reaches pgadmin4:80 over pgadminNet), isolated on pgadminNet (can only reach
+# postgres, not redis/django/springboot), read-only rootfs with only the data
+# volume and the tmpfs mounts writable, all capabilities dropped, no privilege
+# escalation, bundled postfix disabled (root process, unused), memory/PID
+# limits. Major pinned like postgres/redis. Register the DB connection in
+# pgadmin as the read-only pgadmin_ro role (created once via
+# sql/pgadmin-readonly.sql), not postgres.
 sudo mkdir -p /mnt/ebs/pgadmin-data
 sudo chown 5050:5050 /mnt/ebs/pgadmin-data
 PGADMIN_PW=$(aws secretsmanager get-secret-value --secret-id "$SECRETS_ARN" \
   --query SecretString --output text | jq -r .PGADMIN_DEFAULT_PASSWORD)
 sudo docker run -d \
   --name pgadmin4 \
-  --network dockerNet \
+  --network pgadminNet \
   -v /mnt/ebs/pgadmin-data:/var/lib/pgadmin \
   --read-only \
   --tmpfs /tmp \
   --tmpfs /var/log/pgadmin \
   --cap-drop ALL \
   --security-opt no-new-privileges:true \
+  --memory 512m \
+  --pids-limit 100 \
   -e PGADMIN_DEFAULT_EMAIL=johnefattore@gmail.com \
   -e PGADMIN_DEFAULT_PASSWORD="$PGADMIN_PW" \
   -e PGADMIN_LISTEN_PORT=80 \
-  dpage/pgadmin4
+  -e PGADMIN_DISABLE_POSTFIX=True \
+  dpage/pgadmin4:9
 
 # Certbot get SSL cert
 sudo docker run --rm \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -18,9 +18,11 @@ The production environment runs on a single EC2 instance behind Route 53:
 4.  **Data stores**: PostgreSQL 17 and Redis 8 containers on the same Docker network, with Postgres data on the EBS volume.
 
 ### pgadmin4 (least privilege)
-- No host port: pgadmin is reachable only through nginx at `/pgadmin4/`, over `dockerNet`.
-- The container runs with a read-only root filesystem (only the `/var/lib/pgadmin` volume and a `/tmp` tmpfs are writable), all Linux capabilities dropped, and `no-new-privileges` (see `deploy/docker-compose.infra.yml`).
+- No host port: pgadmin is reachable only through nginx at `/pgadmin4/`.
+- Network isolation: pgadmin lives on its own bridge network `pgadminNet` whose only members are `pgadmin4`, `postgres`, and `nginx` — a compromised pgadmin cannot reach redis, Django, or Spring Boot. Both networks are external; create them once on the host with `docker network create --driver bridge <name>`.
+- The container runs with a read-only root filesystem (only the `/var/lib/pgadmin` volume and `/tmp` + `/var/log/pgadmin` tmpfs are writable), all Linux capabilities dropped, `no-new-privileges`, the bundled Postfix disabled, 512m/100-PID resource limits, and the image major pinned (`dpage/pgadmin4:9`) like postgres/redis (see `deploy/docker-compose.infra.yml`).
 - Its database connection uses the read-only `pgadmin_ro` role (SELECT-only on the `postgres` and `springboot` databases), not the `postgres` superuser. Create the role once with `deploy/sql/pgadmin-readonly.sql` (run instructions in the file), store its password in `fattorestreet/env` as `PGADMIN_RO_DB_PASSWORD`, and register the server connection in the pgadmin UI with that role.
+- Postgres publishes `5432` on `127.0.0.1` only (admin `psql` from the EC2 host, or a laptop via SSM port forwarding); redis has no host port at all (no auth — debug with `docker exec -it redis redis-cli`). Apps are unaffected: they connect container-to-container over `dockerNet`.
 
 ## 🚀 Build & Deploy
 


### PR DESCRIPTION
## Summary
Follow-up to #102, finishing the pgadmin privilege cleanup:
- pgadmin shared `dockerNet` with every container, so a compromised pgadmin could reach unauthenticated redis and the app backends. It now lives on a dedicated `pgadminNet` whose only members are `pgadmin4`, `postgres`, and `nginx` (which joins both networks to keep proxying `/pgadmin4/`)
- postgres's host port binds to `127.0.0.1` (admin psql from the host or via SSM port forwarding); redis's host port is removed entirely (no auth, nothing external uses it). Apps are unaffected: they connect container-to-container over `dockerNet`
- `PGADMIN_DISABLE_POSTFIX=True` removes the image's bundled root-owned mail server
- 512m memory / 100 PID limits so the container can't starve the host
- Image pinned to `dpage/pgadmin4:9`, matching the postgres:17 / redis:8 major-pinning convention

## Rollout: one manual step BEFORE merging
`deploy.sh` will fail its `compose up` if the new network doesn't exist yet. On the EC2 host, first run:
```bash
sudo docker network create --driver bridge pgadminNet
```
Everything else converges automatically on the merge deploy (postgres/redis/pgadmin/nginx recreate with the new settings; brief postgres blip expected). The `pgadmin_ro` UI connection keeps working since `postgres` resolves over `pgadminNet`.

## Test plan
- [x] Reproduced the topology locally in Docker (postgres on both networks, redis on the app network, pgadmin isolated with the full flag set): login page serves HTTP 200; from inside the pgadmin container `postgres:5432` connects while `redis` does not even resolve; `docker inspect` confirms the memory/PID limits; no postfix processes
- [x] `docker compose config` validates both compose files
- [ ] After merge: confirm `/pgadmin4/` works through nginx, `psql` from the EC2 host via 127.0.0.1, and that `curl -m 3 <ec2-ip>:5432/6379` from outside times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)