### PR TITLE
run the index load as a daily scheduled Fargate task

### DIFF
--- a/.claude/plans/lets-take-a-look-pure-rivest.md
+++ b/.claude/plans/lets-take-a-look-pure-rivest.md
@@ -1,0 +1,122 @@
+# Daily Fargate Job for the Index Fund Generator
+
+## Context
+
+The Fattore index generator (FAT50 / FAT100 / FAT1000) currently runs only when triggered manually from the Admin page via authenticated REST endpoints. The nightly IEX HIST price load already runs as a daily EventBridge-scheduled Fargate task (`springboot/deploy/terraform/`), but index metrics and membership go stale unless someone remembers to click the buttons. Goal: review the load process and add a second daily Fargate job that refreshes index metrics and rebuilds the three indexes automatically, downstream of the nightly price load.
+
+## How the load works today (review)
+
+Two-phase process, all in Spring Boot (`com.fattorestreet.sec_api`), no Django/Celery involvement:
+
+**Phase 1 — metrics refresh** (`index/IndexMetricsRefreshService`):
+- Scope defaults to the Russell 1000 universe from bundled `resources/data/IWB_holdings.csv` (`refreshRussell1000Listings(year)`); `all` and single-ticker scopes also exist.
+- Per listing: skip checks (asset exists, not a fund, has CIK, has a positive latest IEX `DailyPrice`), then two SEC calls via `client/WebService` (companyfacts for shares outstanding + public float, submissions for jurisdiction), throttled to ≥250 ms between requests.
+- Computes marketCap, freeFloat, freeFloatMarketCap, volume; GOOG/GOOGL caps halved; upserts `ListingIndexMetrics` by (listing, year) in short per-listing transactions.
+- Failure isolation per ticker; aborts the batch after 25 consecutive SEC fetch failures. ~1000 tickers ⇒ thousands of SEC calls ⇒ long-running (tens of minutes), which is why the frontend uses `timeout: 0`.
+
+**Phase 2 — index rebuild** (`index/FattoreIndexRebuildService.rebuild(year)`, one bean per index via `config/FattoreIndexRebuildConfig`):
+- DB-only and fast: filters eligible metrics (US-incorporated, non-fund, positive free-float cap), ranks by freeFloatMarketCap, takes top-N, cap-weights to exactly 100%, then full delete + reinsert of `IndexMember` rows per index. Idempotent.
+
+**Triggers today**: `POST /admin/indexes/refresh-stocks` and `POST /admin/indexes/rebuild` (`controller/AdminController`; rebuild with `refreshMetrics=true` refreshes once then rebuilds FAT100, FAT1000, FAT50). Admin auth = Django SimpleJWT, user_id 1 only. No scheduler exists for this load.
+
+**Operational ordering**: listings → daily prices (nightly hist-load Fargate job) → metrics refresh → rebuild. So the new job must run after the hist load.
+
+## Existing Fargate pattern to reuse
+
+- Run-mode switch: `app.run-mode=${APP_RUN_MODE:server}` in `application.properties`; `marketdata/HistLoadRunner` is `@ConditionalOnProperty(havingValue="hist-load")`, an `ApplicationRunner` that runs once and `System.exit`s (0/1) — container exit code surfaces success.
+- Same Docker image works for server and job modes (entrypoint no-ops when `SECRETS_ARN` unset; ECS injects `POSTGRES_PASSWORD`/`SECRET_KEY` natively from the shared `fattorestreet/env` secret).
+- Terraform module `springboot/deploy/terraform/`: dedicated ECR repo (manual ARM64 buildx push, not CI), ECS cluster, Fargate ARM64 task def, task SG + Postgres ingress rule, execution/task IAM roles, EventBridge Scheduler cron (default `cron(30 6 * * ? *)` UTC), public subnet + public IP (no NAT), retry 0.
+
+## Implementation plan
+
+**Key safety finding**: `FattoreIndexRebuildService.rebuild(year)` deletes `IndexMember` rows **by index code only** (`deleteByMarketIndex_Code`, lines 80/91), not by year — even when zero metrics are eligible. A rebuild after a failed/partial refresh would shrink or wipe live indexes. The runner guards against this (below).
+
+### Part 1 — Spring Boot (`springboot/src/main/java/com/fattorestreet/sec_api/`)
+
+**1a. Create `index/IndexLoadService.java`** — `@Service`, extracts orchestration shared by controller and runner. Constructor-injects `IndexMetricsRefreshService` + the three `@Qualifier`ed `FattoreIndexRebuildService` beans; builds the canonical ordered list FAT100, FAT1000, FAT50 in the constructor (do not inject `List<...>` by type — bean order isn't guaranteed).
+- `RefreshResult refresh(String scope, int year)` — `"russell1000"`/`"iwb"` → `refreshRussell1000Listings`, `"all"` → `refreshAllTickers`, else `IllegalArgumentException`.
+- `List<RebuildResult> rebuildAll(int year)` — rebuild each in order.
+
+**1b. Refactor `controller/AdminController.java`** to delegate: `refreshIndexStocks` scope switch (~line 303) → `indexLoadService.refresh(...)` (catch `IllegalArgumentException` → 400; single-ticker branch stays); `rebuildCapRankedIndexes` no-code path (~line 346) → `indexLoadService.rebuildAll(...)`; drop the now-unused `capRankedRebuildAllOrdered` field. Keep `capRankedRebuildByCode` + legacy endpoints untouched. Response payloads unchanged.
+
+**1c. Create `index/IndexLoadRunner.java`** — mirror `marketdata/HistLoadRunner.java` exactly: `@Component`, `@ConditionalOnProperty(name = "app.run-mode", havingValue = "index-load")`, `ApplicationRunner`, package-private `int runLoad()`, then `System.exit(SpringApplication.exit(context, () -> exitCode))`.
+
+Config via `@Value`:
+- `app.index-load.year` (default `0` = current year)
+- `app.index-load.scope` (default `russell1000`)
+- `app.index-load.skip-refresh` (default `false`)
+- `app.index-load.ticker` (default empty; single-ticker smoke-test mode via `refreshSingleTicker`, still rebuilds)
+- `app.index-load.min-processed` (default `800`)
+
+`runLoad()` policy:
+1. Unless skip-refresh, run refresh; log processed/skipped + skip reasons.
+2. **Guard**: if refresh ran and `processed < min-processed` (single-ticker mode: `processed == 0`), skip rebuild and return 1 — yesterday's members are strictly better than a wiped/shrunken index.
+3. Otherwise `rebuildAll(year)`, log each `RebuildResult`; `partial == true` is fine (FAT1000 is routinely partial). Return 0.
+4. Any exception → log, return 1. (If rebuild throws after a good refresh, metrics are persisted; next run or manual `/admin/indexes/rebuild` recovers.)
+
+**1d. `src/main/resources/application.properties`** — extend the run-mode comment to mention `index-load`; add:
+```
+app.index-load.year=${INDEX_LOAD_YEAR:0}
+app.index-load.scope=${INDEX_LOAD_SCOPE:russell1000}
+app.index-load.skip-refresh=${INDEX_LOAD_SKIP_REFRESH:false}
+app.index-load.ticker=${INDEX_LOAD_TICKER:}
+app.index-load.min-processed=${INDEX_LOAD_MIN_PROCESSED:800}
+```
+
+### Part 2 — Terraform (`springboot/deploy/terraform/`)
+
+Extend the existing module; **no renames of existing resources** (renaming would destroy/recreate the ECR repo, cluster, roles, schedule). Reuse: ECR repo + image (same jar, mode via env var), cluster, execution/task roles, task SG + Postgres ingress rule, scheduler role, `fattorestreet/env` secret wiring. New per-job resources get their own name prefix.
+
+`variables.tf` additions:
+- `index_load_name_prefix` (default `"fattorestreet-index-load"`)
+- `index_load_task_cpu` (default `512`) / `index_load_task_memory` (default `2048`) — the load is SEC-network-bound (≥250 ms throttle, mostly idle); tune after first run
+- `index_load_scope` (default `"russell1000"`)
+- `index_load_schedule_expression` (default `"cron(30 9 * * ? *)"` — 3 h after hist-load's `cron(30 6 * * ? *)`, shared `schedule_timezone`)
+- `index_load_schedule_enabled` (default `true`)
+
+`main.tf` additions:
+- `aws_cloudwatch_log_group.index_load` — `/ecs/${var.index_load_name_prefix}`
+- `aws_ecs_task_definition.index_load` — same FARGATE/ARM64/awsvpc pattern, reuse both IAM roles + ECR image `:${var.image_tag}`; env `APP_RUN_MODE=index-load`, `INDEX_LOAD_SCOPE`, `DB_URL`, `DB_USERNAME`; secrets `POSTGRES_PASSWORD`, `SECRET_KEY` identical to hist-load; container name `index-load`
+- Edit `data.aws_iam_policy_document.scheduler_run_task` — add the new task def ARNs to `ecs:RunTask` resources (in-place policy update; PassRole already covers reused roles)
+- `aws_scheduler_schedule.index_load` — same target shape (existing cluster, public subnets + task SG, `assign_public_ip = true`, retry 0)
+- Do **not** touch the task SG description — changing it forces SG replacement
+
+`outputs.tf`: `index_load_task_definition_family`, `index_load_log_group_name`, `index_load_schedule_name`.
+`terraform.tfvars.example`: index-load block, e.g. `index_load_schedule_expression = "cron(0 5 * * ? *)"` with the existing `America/New_York` timezone (hist load at 02:00 ET finishes in minutes; 05:00 ET stays pre-market).
+
+### Part 3 — Tests (`springboot/src/test/java/com/fattorestreet/sec_api/`)
+
+- **`index/IndexLoadServiceTest.java`** — `@ExtendWith(MockitoExtension.class)`: scope dispatch (russell1000/iwb/all), unknown scope throws, `rebuildAll` order FAT100→FAT1000→FAT50 via Mockito `InOrder`.
+- **`index/IndexLoadRunnerTest.java`** — mirror `HistLoadRunnerTest` (`ReflectionTestUtils.setField` for config): exit 0 on success and on partial skips above threshold; exit 1 + `verify(never())` rebuild when below `min-processed`; skip-refresh mode rebuilds only; refresh/rebuild exceptions → 1; `year=0` resolves to current year; ticker mode uses `refreshSingleTicker`.
+- **`controller/AdminControllerTest.java`** — retarget the no-code rebuild test (~line 477) and refresh-stocks scope tests (~lines 278–343) to stub `@MockitoBean IndexLoadService`; single-code/legacy tests unchanged. Keep the JaCoCo floor green (`mvn verify`).
+
+### Part 4 — Docs
+
+- `springboot/README.md` — add `index-load` run mode next to `hist-load`/`APP_RUN_MODE`, and note the daily Fargate schedule + `INDEX_LOAD_*` env vars in the market-index section (~lines 124–153).
+- `springboot/deploy/terraform/README.md` — retitle to cover both nightly loads; add index-load section: schedule (05:00 ET, after hist load), guard behavior, manual `aws ecs run-task` test using the new outputs, tuning rows; note there is no Celery/beat entry to disable (unlike hist-load) — admin endpoints stay for manual runs.
+- `docs/API_REFERENCE.md` — no changes (no endpoint/payload changes).
+
+### Rollout order
+
+1. Merge Java + tests; push the ARM64 image to the existing ECR repo (`docker buildx build --platform linux/arm64 -t "$REPO:latest" --push .`) — the runner must be in the image before the schedule fires.
+2. `terraform apply` (optionally `index_load_schedule_enabled = false` first).
+3. Manual `aws ecs run-task` test, then enable the schedule.
+
+## Verification
+
+Local:
+- `cd springboot && mvn test`, then `mvn verify` (JaCoCo floor).
+- Smoke test against local Postgres (needs a listing with CIK + DailyPrice, e.g. AAPL): `APP_RUN_MODE=index-load INDEX_LOAD_TICKER=AAPL mvn spring-boot:run` — expect one-ticker refresh, three rebuilds logged, exit 0 (`echo $?`).
+- Guard check: `INDEX_LOAD_TICKER=ZZZZBAD` → exit 1, no rebuild logged.
+- `APP_RUN_MODE=server` still serves normally (runner bean absent).
+
+AWS:
+- One-off: `aws ecs run-task --cluster $(terraform output -raw ecs_cluster_name) --task-definition $(terraform output -raw index_load_task_definition_family) --launch-type FARGATE --network-configuration ...` (same shape as the README hist-load test); `aws logs tail $(terraform output -raw index_load_log_group_name) --follow`.
+- Confirm exit code 0 (`aws ecs describe-tasks` → `containers[0].exitCode`), refresh reaches 100%, three rebuild lines; `GET /index-members?code=FAT50|FAT100|FAT1000` reflects the run. Check CloudWatch memory to validate the 2048 MiB default. After the first scheduled night, confirm the 05:00 ET firing and that hist-load finished well before.
+
+## Accepted decisions & residual risks
+
+- **Shared `IndexLoadService` refactor**: chosen (user-confirmed); payload-identical, small test updates.
+- **`INDEX_LOAD_MIN_PROCESSED=800` guard**: chosen (user-confirmed); protects against partial SEC outages and the empty-new-year case. Note: early January, a legitimately fresh year starts at 0 processed — the first successful full refresh of the year clears the guard naturally.
+- **Naming debt**: shared cluster/ECR/roles keep the `fattorestreet-hist-load` name to avoid destroy/recreate; only new per-job resources use `fattorestreet-index-load`. Cosmetic, deliberate.
+- **Schedule coupling**: 05:00 ET assumes hist-load (02:00 ET) finishes in minutes as documented; if it ever runs long, metrics use the prior close and self-correct the next night.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -214,9 +214,9 @@
         "filename": "springboot/src/main/resources/application.properties",
         "hashed_secret": "43f7cbf139f31e89209406fd8f1942033bd47aec",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 21
       }
     ]
   },
-  "generated_at": "2026-07-18T18:26:51Z"
+  "generated_at": "2026-07-18T18:57:16Z"
 }

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -72,6 +72,11 @@ Before adding or changing any external data source:
 | (property) `fattore50.rebuild.top-n` | `50` | How many names the Fattore 50 rebuild includes. Set in `.env` as `fattore50.rebuild.top-n=50` if needed. |
 | (property) `fattore100.rebuild.top-n` | `100` | How many names the Fattore 100 rebuild includes. Set in `.env` as `fattore100.rebuild.top-n=100` if needed. |
 | (property) `fattore1000.rebuild.top-n` | `1000` | How many names the Fattore 1000 rebuild includes. Set in `.env` as `fattore1000.rebuild.top-n=1000` if needed. |
+| `INDEX_LOAD_YEAR` | `0` (current year) | Target calendar year for the one-shot index load (`APP_RUN_MODE=index-load`) |
+| `INDEX_LOAD_SCOPE` | `russell1000` | Index-load metrics refresh scope: `russell1000` (IWB universe) or `all` |
+| `INDEX_LOAD_SKIP_REFRESH` | `false` | When `true`, the index load skips the metrics refresh and only rebuilds |
+| `INDEX_LOAD_TICKER` | (empty) | When set, the index load refreshes just this ticker (smoke-test mode) before rebuilding |
+| `INDEX_LOAD_MIN_PROCESSED` | `800` | Minimum refreshed listings before the index load rebuilds; below it the task keeps existing members and exits `1` |
 | `LLM_SERVER_URL` | `http://localhost:8081` | URL of the llama.cpp server for 10-K summarization |
 | `DJANGO_PORTFOLIO_BASE_URL` | `http://localhost:8000/portfolio` | Base URL for Django portfolio API used by diagnostics-only yfinance validation |
 | `SEC_HTTP_CONNECT_TIMEOUT_MS` | `15000` | SEC API connect timeout (milliseconds) |
@@ -154,6 +159,8 @@ curl -X POST -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8080/admi
 curl -X POST -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8080/admin/indexes/rebuild-fattore-100
 curl -X POST -H "Authorization: Bearer $ACCESS_TOKEN" http://localhost:8080/admin/indexes/rebuild-fattore-1000
 ```
+
+**Scheduled run (Fargate):** the same refresh + rebuild-all sequence runs nightly as an ephemeral Fargate task (`APP_RUN_MODE=index-load` via `IndexLoadRunner`, scheduled after the hist-load task so fresh `DailyPrice` rows exist; see `deploy/terraform/README.md`). The runner skips the rebuild and exits `1` if the refresh processes fewer than `INDEX_LOAD_MIN_PROCESSED` listings — the rebuild deletes members by index code, so rebuilding after a mostly-failed refresh (SEC outage, empty new calendar year) would shrink the live indexes. The admin endpoints above remain for manual runs.
 
 List available indexes and fetch constituents:
 

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -1,23 +1,36 @@
-# Nightly IEX HIST load on Fargate
+# Nightly Fargate loads (IEX HIST + index)
 
-Runs the bulky nightly price load (`IexHistService.loadHistData`) as an **ephemeral Fargate task**
-instead of keeping 4 GB of RAM provisioned 24/7 on the EC2 box. The same Spring Boot jar runs the
-API on EC2 (default `APP_RUN_MODE=server`) and the one-shot load on Fargate (`APP_RUN_MODE=hist-load`,
-via `HistLoadRunner`, which runs the load once and exits). After a successful load the task also runs
-corporate-action price adjustment (`adjustAllTickers`, rolling SEC re-detection included); set
-`HIST_LOAD_ADJUST_ENABLED=false` on the task to skip it.
+Runs two nightly loads as **ephemeral Fargate tasks** instead of keeping the RAM provisioned 24/7
+on the EC2 box. The same Spring Boot jar runs the API on EC2 (default `APP_RUN_MODE=server`) and
+the one-shot loads on Fargate — run mode is selected purely by the `APP_RUN_MODE` env var:
+
+- **`hist-load`** (`HistLoadRunner`) — the bulky IEX price load (`IexHistService.loadHistData`),
+  which runs once and exits. After a successful load the task also runs corporate-action price
+  adjustment (`adjustAllTickers`, rolling SEC re-detection included); set
+  `HIST_LOAD_ADJUST_ENABLED=false` on the task to skip it.
+- **`index-load`** (`IndexLoadRunner`) — index metrics refresh (SEC companyfacts/submissions for
+  the Russell 1000 universe) followed by cap-ranked rebuilds of FAT100, FAT1000, FAT50. Scheduled
+  a few hours **after** the hist load so fresh `DailyPrice` rows exist. Guard: if the refresh
+  processes fewer than `INDEX_LOAD_MIN_PROCESSED` listings (default 800), the task skips the
+  rebuild and exits `1` — the rebuild deletes members by index code, so rebuilding after a
+  mostly-failed refresh (SEC outage, empty new calendar year) would shrink the live indexes.
+
+Both tasks share the ECR repo/image, ECS cluster, IAM roles, and task security group; each has its
+own task definition, log group, and schedule.
 
 ## Architecture
 
 ```
-EventBridge Scheduler (cron)
-        │ RunTask
-        ▼
-Fargate task (ARM64, 1 vCPU / 4 GB, public subnet + public IP, no NAT)
-   APP_RUN_MODE=hist-load  → HistLoadRunner → loadHistData() → adjustAllTickers(false) → System.exit
-        │ 5432
-        ▼
-Postgres on the EC2 instance  (its SG gets one ingress rule from the task SG)
+EventBridge Scheduler (cron)                EventBridge Scheduler (cron, ~3h later)
+        │ RunTask                                   │ RunTask
+        ▼                                           ▼
+Fargate task (ARM64, 1 vCPU / 4 GB)         Fargate task (ARM64, 0.5 vCPU / 2 GB)
+   APP_RUN_MODE=hist-load                      APP_RUN_MODE=index-load
+   → HistLoadRunner → loadHistData()           → IndexLoadRunner → refresh metrics
+   → adjustAllTickers(false) → System.exit     → rebuild FAT100/FAT1000/FAT50 → System.exit
+        │ 5432 (public subnet + public IP, no NAT)  │ 5432
+        ▼                                           ▼
+Postgres on the EC2 instance  (its SG gets one ingress rule from the shared task SG)
 ```
 
 Cost shape: you pay for ~4 GB only for the minutes the task runs each night, not all month.
@@ -85,13 +98,37 @@ aws logs tail "$(terraform output -raw log_group_name)" --follow
 Confirm it connects to Postgres, processes days, and exits `0`. **Profile peak memory** from the
 task's CloudWatch metrics — if it sits well under 4 GB, set `task_memory = 2048` and re-apply.
 
+Same shape for the index load (use the `index_load_*` outputs; it shares the cluster and SG):
+
+```bash
+aws ecs run-task \
+  --cluster "$CLUSTER" \
+  --task-definition "$(terraform output -raw index_load_task_definition_family)" \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[subnet-xxxx],securityGroups=[$SG],assignPublicIp=ENABLED}"
+
+aws logs tail "$(terraform output -raw index_load_log_group_name)" --follow
+```
+
+Confirm the refresh progress lines reach 100%, three `Rebuilt FAT...` lines appear, and the exit
+code is `0` (`aws ecs describe-tasks` → `containers[0].exitCode`). Then check
+`GET /index-members?code=FAT50` (and `FAT100`/`FAT1000`) reflects the run. A cheap smoke test
+before a full run: override `INDEX_LOAD_TICKER=AAPL` on the task
+(`--overrides '{"containerOverrides":[{"name":"index-load","environment":[{"name":"INDEX_LOAD_TICKER","value":"AAPL"}]}]}'`)
+to refresh one ticker and still rebuild.
+
 ## Schedule cutover (done)
 
 This schedule replaced the old django-celery-beat trigger for `portfolio.tasks.load_iex_hist`;
 Celery has since been removed from the Django service entirely. The Spring Boot
 `/admin/load-hist` HTTP endpoint stays in place for manual runs.
 
-To pause the Fargate schedule without destroying anything: `schedule_enabled = false` + `terraform apply`.
+To pause either Fargate schedule without destroying anything: `schedule_enabled = false` (hist load)
+or `index_load_schedule_enabled = false` (index load) + `terraform apply`.
+
+The index load had no Celery/beat trigger to replace — it was manual-only via the admin endpoints
+(`POST /admin/indexes/refresh-stocks`, `POST /admin/indexes/rebuild`), which stay in place for
+manual runs.
 
 ## Tuning knobs
 
@@ -99,5 +136,10 @@ To pause the Fargate schedule without destroying anything: `schedule_enabled = f
 |----------|---------|-------|
 | `task_memory` | `4096` | Lower to `2048` after profiling a real run. |
 | `hist_load_days` | `20` | Days walked back; already-loaded days are skipped (idempotent). |
-| `schedule_expression` / `schedule_timezone` | `cron(0 2 * * ? *)` / `America/New_York` | When it runs. |
-| `schedule_enabled` | `true` | Toggle the nightly trigger. 
+| `schedule_expression` / `schedule_timezone` | `cron(0 2 * * ? *)` / `America/New_York` | When the hist load runs. |
+| `schedule_enabled` | `true` | Toggle the nightly hist-load trigger. |
+| `index_load_task_cpu` / `index_load_task_memory` | `512` / `2048` | The index load is SEC-rate-limit bound (mostly idle); profile the first real run. |
+| `index_load_scope` | `russell1000` | Metrics refresh scope (`russell1000` or `all`). |
+| `index_load_min_processed` | `800` | Rebuild guard threshold; below it the task keeps yesterday's members and exits `1`. |
+| `index_load_schedule_expression` | `cron(0 5 * * ? *)` (tfvars) | When the index load runs; shares `schedule_timezone`. Keep it well after the hist load. |
+| `index_load_schedule_enabled` | `true` | Toggle the nightly index-load trigger. 

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -1,6 +1,8 @@
 locals {
-  container_name = "hist-load"
-  tags           = merge({ Project = "FattoreStreet", Component = "springboot-hist-load" }, var.tags)
+  container_name       = "hist-load"
+  tags                 = merge({ Project = "FattoreStreet", Component = "springboot-hist-load" }, var.tags)
+  index_container_name = "index-load"
+  index_tags           = merge({ Project = "FattoreStreet", Component = "springboot-index-load" }, var.tags)
 }
 
 # ---------------------------------------------------------------------------
@@ -179,8 +181,13 @@ resource "aws_iam_role" "scheduler" {
 
 data "aws_iam_policy_document" "scheduler_run_task" {
   statement {
-    actions   = ["ecs:RunTask"]
-    resources = ["${aws_ecs_task_definition.this.arn_without_revision}:*", aws_ecs_task_definition.this.arn]
+    actions = ["ecs:RunTask"]
+    resources = [
+      "${aws_ecs_task_definition.this.arn_without_revision}:*",
+      aws_ecs_task_definition.this.arn,
+      "${aws_ecs_task_definition.index_load.arn_without_revision}:*",
+      aws_ecs_task_definition.index_load.arn,
+    ]
     condition {
       test     = "ArnLike"
       variable = "ecs:cluster"
@@ -225,6 +232,103 @@ resource "aws_scheduler_schedule" "this" {
       # Pinned to this revision; `terraform apply` rolls it forward on deploy, and the :tag image is
       # still resolved at launch so re-pushing the same tag picks up new image content.
       task_definition_arn = aws_ecs_task_definition.this.arn
+      task_count          = 1
+      launch_type         = "FARGATE"
+
+      network_configuration {
+        subnets          = var.public_subnet_ids
+        security_groups  = [aws_security_group.task.id]
+        assign_public_ip = true
+      }
+    }
+
+    retry_policy {
+      maximum_retry_attempts = 0
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Index load: second daily one-shot task (metrics refresh + Fattore index
+# rebuilds). Shares the ECR image, cluster, IAM roles, and task SG above —
+# APP_RUN_MODE selects the behavior. Scheduled after the hist load so the
+# refresh sees fresh DailyPrice rows.
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "index_load" {
+  name              = "/ecs/${var.index_load_name_prefix}"
+  retention_in_days = var.log_retention_days
+  tags              = local.index_tags
+}
+
+resource "aws_ecs_task_definition" "index_load" {
+  family                   = var.index_load_name_prefix
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.index_load_task_cpu
+  memory                   = var.index_load_task_memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = local.index_container_name
+      image     = "${aws_ecr_repository.this.repository_url}:${var.image_tag}"
+      essential = true
+
+      environment = [
+        { name = "APP_RUN_MODE", value = "index-load" },
+        { name = "INDEX_LOAD_SCOPE", value = var.index_load_scope },
+        { name = "INDEX_LOAD_MIN_PROCESSED", value = tostring(var.index_load_min_processed) },
+        { name = "DB_URL", value = "jdbc:postgresql://${var.db_host}:${var.db_port}/${var.db_name}" },
+        { name = "DB_USERNAME", value = var.db_username },
+      ]
+
+      # Pull individual keys out of the single fattorestreet/env JSON secret.
+      # ECS syntax: <secret-arn>:<json-key>:<version-stage>:<version-id> (last two left empty).
+      secrets = [
+        { name = "POSTGRES_PASSWORD", valueFrom = "${var.env_secret_arn}:POSTGRES_PASSWORD::" },
+        { name = "SECRET_KEY", valueFrom = "${var.env_secret_arn}:SECRET_KEY::" },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.index_load.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "index-load"
+        }
+      }
+    }
+  ])
+
+  tags = local.index_tags
+}
+
+resource "aws_scheduler_schedule" "index_load" {
+  name       = var.index_load_name_prefix
+  group_name = "default"
+  state      = var.index_load_schedule_enabled ? "ENABLED" : "DISABLED"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = var.index_load_schedule_expression
+  schedule_expression_timezone = var.schedule_timezone
+
+  target {
+    arn      = aws_ecs_cluster.this.arn
+    role_arn = aws_iam_role.scheduler.arn
+
+    ecs_parameters {
+      # Pinned to this revision; `terraform apply` rolls it forward on deploy, and the :tag image is
+      # still resolved at launch so re-pushing the same tag picks up new image content.
+      task_definition_arn = aws_ecs_task_definition.index_load.arn
       task_count          = 1
       launch_type         = "FARGATE"
 

--- a/springboot/deploy/terraform/outputs.tf
+++ b/springboot/deploy/terraform/outputs.tf
@@ -27,3 +27,18 @@ output "schedule_name" {
   description = "EventBridge schedule name."
   value       = aws_scheduler_schedule.this.name
 }
+
+output "index_load_task_definition_family" {
+  description = "Index-load task definition family."
+  value       = aws_ecs_task_definition.index_load.family
+}
+
+output "index_load_log_group_name" {
+  description = "CloudWatch log group for index-load task output."
+  value       = aws_cloudwatch_log_group.index_load.name
+}
+
+output "index_load_schedule_name" {
+  description = "EventBridge schedule name for the index load."
+  value       = aws_scheduler_schedule.index_load.name
+}

--- a/springboot/deploy/terraform/terraform.tfvars.example
+++ b/springboot/deploy/terraform/terraform.tfvars.example
@@ -25,3 +25,9 @@ hist_load_days = 20
 schedule_expression = "cron(0 2 * * ? *)"
 schedule_timezone   = "America/New_York"
 schedule_enabled    = true
+
+# Index load: 05:00 America/New_York daily (3h after the hist load so fresh
+# DailyPrice rows exist, still pre-market). Shares schedule_timezone above.
+index_load_schedule_expression = "cron(0 5 * * ? *)"
+index_load_schedule_enabled    = true
+index_load_task_memory         = 2048 # SEC-rate-limit bound; tune after profiling a real run

--- a/springboot/deploy/terraform/variables.tf
+++ b/springboot/deploy/terraform/variables.tf
@@ -122,6 +122,59 @@ variable "schedule_enabled" {
   default     = true
 }
 
+# ---------------------------------------------------------------------------
+# Index load (second daily job; shares the cluster, ECR image, IAM roles, and
+# task SG with the hist load — only the task definition, log group, and
+# schedule are its own).
+# ---------------------------------------------------------------------------
+
+variable "index_load_name_prefix" {
+  description = "Name for the index-load task definition family, log group, and schedule."
+  type        = string
+  default     = "fattorestreet-index-load"
+}
+
+variable "index_load_task_cpu" {
+  description = "Index-load Fargate task CPU units. The load is SEC-rate-limit bound (mostly idle), so 0.5 vCPU suffices."
+  type        = number
+  default     = 512
+}
+
+variable "index_load_task_memory" {
+  description = "Index-load Fargate task memory (MiB). Parses one SEC companyfacts JSON at a time; tune after profiling."
+  type        = number
+  default     = 2048
+}
+
+variable "index_load_scope" {
+  description = "Metrics refresh scope (INDEX_LOAD_SCOPE): russell1000 (IWB holdings universe) or all."
+  type        = string
+  default     = "russell1000"
+}
+
+variable "index_load_min_processed" {
+  description = <<-EOT
+    Minimum listings the metrics refresh must process before the rebuild runs
+    (INDEX_LOAD_MIN_PROCESSED). Below it the task keeps yesterday's index members and exits 1 —
+    the rebuild deletes members by index code, so rebuilding after a mostly-failed refresh
+    (SEC outage, empty new calendar year) would shrink the live indexes.
+  EOT
+  type        = number
+  default     = 800
+}
+
+variable "index_load_schedule_expression" {
+  description = "EventBridge Scheduler cron for the index load. Default 09:30 UTC daily, 3h after the hist load so fresh DailyPrice rows exist."
+  type        = string
+  default     = "cron(30 9 * * ? *)"
+}
+
+variable "index_load_schedule_enabled" {
+  description = "Whether the index-load schedule is ENABLED. Set false to deploy the task without auto-running it yet."
+  type        = bool
+  default     = true
+}
+
 variable "log_retention_days" {
   description = "CloudWatch log retention for the task."
   type        = number

--- a/springboot/src/main/java/com/fattorestreet/sec_api/controller/AdminController.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/controller/AdminController.java
@@ -50,11 +50,11 @@ public class AdminController {
     private final FilingSummaryService filingSummaryService;
     private final com.fattorestreet.sec_api.repository.AssetRepository assetRepository;
     private final com.fattorestreet.sec_api.index.IndexMetricsRefreshService indexMetricsRefreshService;
+    private final com.fattorestreet.sec_api.index.IndexLoadService indexLoadService;
     private final com.fattorestreet.sec_api.index.FattoreIndexRebuildService fattore50IndexRebuildService;
     private final com.fattorestreet.sec_api.index.FattoreIndexRebuildService fattore100IndexRebuildService;
     private final com.fattorestreet.sec_api.index.FattoreIndexRebuildService fattore1000IndexRebuildService;
     private final Map<String, com.fattorestreet.sec_api.index.FattoreIndexRebuildService> capRankedRebuildByCode;
-    private final List<com.fattorestreet.sec_api.index.FattoreIndexRebuildService> capRankedRebuildAllOrdered;
     private final ObjectMapper mapper = new ObjectMapper();
 
     public AdminController(
@@ -70,6 +70,7 @@ public class AdminController {
             FilingSummaryService filingSummaryService,
             com.fattorestreet.sec_api.repository.AssetRepository assetRepository,
             com.fattorestreet.sec_api.index.IndexMetricsRefreshService indexMetricsRefreshService,
+            com.fattorestreet.sec_api.index.IndexLoadService indexLoadService,
             @Qualifier("fattore50IndexRebuildService")
             com.fattorestreet.sec_api.index.FattoreIndexRebuildService fattore50IndexRebuildService,
             @Qualifier("fattore100IndexRebuildService")
@@ -89,6 +90,7 @@ public class AdminController {
         this.filingSummaryService = filingSummaryService;
         this.assetRepository = assetRepository;
         this.indexMetricsRefreshService = indexMetricsRefreshService;
+        this.indexLoadService = indexLoadService;
         this.fattore50IndexRebuildService = fattore50IndexRebuildService;
         this.fattore100IndexRebuildService = fattore100IndexRebuildService;
         this.fattore1000IndexRebuildService = fattore1000IndexRebuildService;
@@ -96,9 +98,6 @@ public class AdminController {
                 FattoreIndexCodes.FAT50.toUpperCase(Locale.ROOT), fattore50IndexRebuildService,
                 FattoreIndexCodes.FAT100.toUpperCase(Locale.ROOT), fattore100IndexRebuildService,
                 FattoreIndexCodes.FAT1000.toUpperCase(Locale.ROOT), fattore1000IndexRebuildService);
-        // Lexicographic by market index code: FAT100, FAT1000, FAT50
-        this.capRankedRebuildAllOrdered = List.of(
-                fattore100IndexRebuildService, fattore1000IndexRebuildService, fattore50IndexRebuildService);
     }
 
     @GetMapping("/admin/asset-load")
@@ -343,16 +342,11 @@ public class AdminController {
                 effectiveScope = "ticker:" + ticker.trim().toUpperCase(Locale.ROOT);
                 r = indexMetricsRefreshService.refreshSingleTicker(ticker, resolvedYear);
             } else {
-                String normalizedScope = scope != null ? scope.trim().toLowerCase(Locale.ROOT) : "russell1000";
-                effectiveScope = normalizedScope;
-                switch (normalizedScope) {
-                    case "russell1000", "iwb" -> r = indexMetricsRefreshService.refreshRussell1000Listings(resolvedYear);
-                    case "all" -> r = indexMetricsRefreshService.refreshAllTickers(resolvedYear);
-                    default -> {
-                        return ResponseEntity.badRequest().body(
-                                "Unknown scope: " + scope + ". Supported: russell1000 (iwb), all"
-                        );
-                    }
+                effectiveScope = scope != null ? scope.trim().toLowerCase(Locale.ROOT) : "russell1000";
+                try {
+                    r = indexLoadService.refresh(scope, resolvedYear);
+                } catch (IllegalArgumentException e) {
+                    return ResponseEntity.badRequest().body(e.getMessage());
                 }
             }
             String duration = formatDuration(System.currentTimeMillis() - startTime);
@@ -386,18 +380,15 @@ public class AdminController {
             @RequestParam(defaultValue = "false") boolean refreshMetrics,
             @RequestParam(required = false) Integer year,
             @RequestParam(required = false) String code) {
-        List<com.fattorestreet.sec_api.index.FattoreIndexRebuildService> services;
-        if (code == null || code.isBlank()) {
-            services = capRankedRebuildAllOrdered;
-        } else {
+        com.fattorestreet.sec_api.index.FattoreIndexRebuildService one = null;
+        if (code != null && !code.isBlank()) {
             String normalized = code.trim().toUpperCase(Locale.ROOT);
-            com.fattorestreet.sec_api.index.FattoreIndexRebuildService one = capRankedRebuildByCode.get(normalized);
+            one = capRankedRebuildByCode.get(normalized);
             if (one == null) {
                 return ResponseEntity.badRequest()
                         .body("Unknown index code: " + code.trim() + ". Supported: "
                                 + String.join(", ", capRankedRebuildByCode.keySet()));
             }
-            services = List.of(one);
         }
         try {
             int resolvedYear = (year != null) ? year : java.time.Year.now().getValue();
@@ -412,10 +403,11 @@ public class AdminController {
                         "skipped", rr.skipped(),
                         "skippedTickers", rr.skippedTickers()));
             }
-            List<Map<String, Object>> rebuilds = new ArrayList<>();
-            for (com.fattorestreet.sec_api.index.FattoreIndexRebuildService service : services) {
-                rebuilds.add(toRebuildPayload(service.rebuild(resolvedYear)));
-            }
+            List<com.fattorestreet.sec_api.index.FattoreIndexRebuildService.RebuildResult> results =
+                    (one == null) ? indexLoadService.rebuildAll(resolvedYear) : List.of(one.rebuild(resolvedYear));
+            List<Map<String, Object>> rebuilds = results.stream()
+                    .map(AdminController::toRebuildPayload)
+                    .collect(Collectors.toList());
             payload.put("rebuilds", rebuilds);
             payload.put("duration", formatDuration(System.currentTimeMillis() - startTime));
             return ResponseEntity.ok(payload);

--- a/springboot/src/main/java/com/fattorestreet/sec_api/index/IndexLoadRunner.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/index/IndexLoadRunner.java
@@ -1,0 +1,116 @@
+package com.fattorestreet.sec_api.index;
+
+import java.time.Year;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * One-shot entrypoint for running the index load (metrics refresh + cap-ranked rebuilds) and then
+ * exiting.
+ *
+ * <p>Activated only when {@code app.run-mode=index-load} (env {@code APP_RUN_MODE=index-load}); in
+ * the default {@code server} mode this bean is not created and the application serves the API as
+ * usual. Designed for an ephemeral Fargate scheduled task, mirroring
+ * {@link com.fattorestreet.sec_api.marketdata.HistLoadRunner}: the task <em>is</em> the work, so
+ * there is no inbound HTTP call and no JWT verification.
+ *
+ * <p>Exit codes (surfaced as the container exit code): {@code 0} on completion, {@code 1} when the
+ * load throws or the refresh processed fewer listings than {@code app.index-load.min-processed}.
+ * The threshold matters because {@link FattoreIndexRebuildService#rebuild} deletes members by index
+ * code (not year) before reinserting — rebuilding on top of a mostly-failed refresh (SEC outage,
+ * empty new calendar year) would shrink or wipe the live indexes, so the rebuild is skipped and
+ * yesterday's members are kept.
+ */
+@Component
+@ConditionalOnProperty(name = "app.run-mode", havingValue = "index-load")
+public class IndexLoadRunner implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(IndexLoadRunner.class);
+
+    private final IndexLoadService indexLoadService;
+    private final IndexMetricsRefreshService indexMetricsRefreshService;
+    private final ConfigurableApplicationContext context;
+
+    /** Target calendar year; {@code 0} means the current year. */
+    @Value("${app.index-load.year:0}")
+    private int year;
+
+    @Value("${app.index-load.scope:russell1000}")
+    private String scope;
+
+    /** Skip the metrics refresh and only rebuild (assumes metrics for the year already exist). */
+    @Value("${app.index-load.skip-refresh:false}")
+    private boolean skipRefresh;
+
+    /** When set, refresh only this ticker (smoke-test mode); the rebuild still runs. */
+    @Value("${app.index-load.ticker:}")
+    private String ticker;
+
+    /** Minimum refreshed listings required before rebuilding; ignored in single-ticker mode. */
+    @Value("${app.index-load.min-processed:800}")
+    private int minProcessed;
+
+    public IndexLoadRunner(
+            IndexLoadService indexLoadService,
+            IndexMetricsRefreshService indexMetricsRefreshService,
+            ConfigurableApplicationContext context) {
+        this.indexLoadService = indexLoadService;
+        this.indexMetricsRefreshService = indexMetricsRefreshService;
+        this.context = context;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        int exitCode = runLoad();
+        // Terminate the JVM so the ephemeral task stops. SpringApplication.exit runs shutdown hooks.
+        System.exit(SpringApplication.exit(context, () -> exitCode));
+    }
+
+    /**
+     * Runs the load and returns the process exit code: {@code 0} on completion (per-ticker skips
+     * are fine — metrics upsert by (listing, year), so unprocessed tickers keep prior values),
+     * {@code 1} when the refresh falls below the rebuild guard or either phase throws.
+     */
+    int runLoad() {
+        long startTime = System.currentTimeMillis();
+        int resolvedYear = year > 0 ? year : Year.now().getValue();
+        boolean singleTicker = ticker != null && !ticker.isBlank();
+        log.info("Starting one-shot index load (year={}, scope={}, skipRefresh={}, ticker={}, minProcessed={})",
+                resolvedYear, scope, skipRefresh, singleTicker ? ticker : "-", minProcessed);
+        try {
+            if (!skipRefresh) {
+                IndexMetricsRefreshService.RefreshResult r = singleTicker
+                        ? indexMetricsRefreshService.refreshSingleTicker(ticker, resolvedYear)
+                        : indexLoadService.refresh(scope, resolvedYear);
+                log.info("Index metrics refresh finished -- processed={}, skipped={}, skippedTickers={}",
+                        r.processed(), r.skipped(), r.skippedTickers());
+                int required = singleTicker ? 1 : minProcessed;
+                if (r.processed() < required) {
+                    log.error("Refresh processed {} listings (< {}); skipping rebuild to keep existing index "
+                            + "members and exiting non-zero so the task is marked failed.",
+                            r.processed(), required);
+                    return 1;
+                }
+            }
+            List<FattoreIndexRebuildService.RebuildResult> rebuilds = indexLoadService.rebuildAll(resolvedYear);
+            for (FattoreIndexRebuildService.RebuildResult rb : rebuilds) {
+                log.info("Rebuilt {} -- memberCount={}, partial={}", rb.indexCode(), rb.memberCount(), rb.partial());
+            }
+            long elapsedMs = System.currentTimeMillis() - startTime;
+            log.info("Index load finished in {}m {}s", elapsedMs / 60000, (elapsedMs % 60000) / 1000);
+            return 0;
+        } catch (Exception e) {
+            log.error("Index load failed", e);
+            return 1;
+        }
+    }
+}

--- a/springboot/src/main/java/com/fattorestreet/sec_api/index/IndexLoadService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/index/IndexLoadService.java
@@ -1,0 +1,55 @@
+package com.fattorestreet.sec_api.index;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+/**
+ * Orchestrates the two-phase index load shared by {@code AdminController} and {@link IndexLoadRunner}:
+ * a metrics refresh ({@link IndexMetricsRefreshService}) followed by cap-ranked rebuilds of every
+ * configured Fattore index in canonical order.
+ */
+@Service
+public class IndexLoadService {
+
+    private final IndexMetricsRefreshService indexMetricsRefreshService;
+    private final List<FattoreIndexRebuildService> rebuildAllOrdered;
+
+    public IndexLoadService(
+            IndexMetricsRefreshService indexMetricsRefreshService,
+            @Qualifier("fattore50IndexRebuildService") FattoreIndexRebuildService fattore50IndexRebuildService,
+            @Qualifier("fattore100IndexRebuildService") FattoreIndexRebuildService fattore100IndexRebuildService,
+            @Qualifier("fattore1000IndexRebuildService") FattoreIndexRebuildService fattore1000IndexRebuildService) {
+        this.indexMetricsRefreshService = indexMetricsRefreshService;
+        // Lexicographic by market index code: FAT100, FAT1000, FAT50
+        this.rebuildAllOrdered = List.of(
+                fattore100IndexRebuildService, fattore1000IndexRebuildService, fattore50IndexRebuildService);
+    }
+
+    /**
+     * Runs the metrics refresh for the given scope: {@code russell1000}/{@code iwb} (IWB holdings
+     * universe) or {@code all} (every listing in the database).
+     *
+     * @throws IllegalArgumentException for an unknown scope
+     */
+    public IndexMetricsRefreshService.RefreshResult refresh(String scope, int year) {
+        String normalized = scope != null ? scope.trim().toLowerCase(Locale.ROOT) : "russell1000";
+        return switch (normalized) {
+            case "russell1000", "iwb" -> indexMetricsRefreshService.refreshRussell1000Listings(year);
+            case "all" -> indexMetricsRefreshService.refreshAllTickers(year);
+            default -> throw new IllegalArgumentException(
+                    "Unknown scope: " + scope + ". Supported: russell1000 (iwb), all");
+        };
+    }
+
+    /**
+     * Rebuilds all configured cap-ranked indexes in canonical order (FAT100, FAT1000, FAT50).
+     */
+    public List<FattoreIndexRebuildService.RebuildResult> rebuildAll(int year) {
+        return rebuildAllOrdered.stream()
+                .map(service -> service.rebuild(year))
+                .toList();
+    }
+}

--- a/springboot/src/main/resources/application.properties
+++ b/springboot/src/main/resources/application.properties
@@ -1,12 +1,18 @@
 spring.application.name=sec-api
 spring.config.import=optional:file:.env[.properties]
 
-# Run mode: "server" (default, serve the API) or "hist-load" (run the IEX HIST price load once and exit).
-# The one-shot mode powers the ephemeral Fargate scheduled task; see deploy/terraform/README.md.
+# Run mode: "server" (default, serve the API), "hist-load" (run the IEX HIST price load once and exit),
+# or "index-load" (refresh index metrics + rebuild the Fattore indexes once and exit).
+# The one-shot modes power the ephemeral Fargate scheduled tasks; see deploy/terraform/README.md.
 app.run-mode=${APP_RUN_MODE:server}
 app.hist-load.days=${HIST_LOAD_DAYS:20}
 # Run corporate-action price adjustment after the one-shot load (hist-load mode only).
 app.hist-load.adjust-enabled=${HIST_LOAD_ADJUST_ENABLED:true}
+app.index-load.year=${INDEX_LOAD_YEAR:0}
+app.index-load.scope=${INDEX_LOAD_SCOPE:russell1000}
+app.index-load.skip-refresh=${INDEX_LOAD_SKIP_REFRESH:false}
+app.index-load.ticker=${INDEX_LOAD_TICKER:}
+app.index-load.min-processed=${INDEX_LOAD_MIN_PROCESSED:800}
 
 # Must match Django SECRET_KEY (SimpleJWT HS256 access tokens). Spring validates Bearer JWTs for /admin/**.
 app.django-jwt-secret=${SECRET_KEY:}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/controller/AdminControllerTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/controller/AdminControllerTest.java
@@ -37,7 +37,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AdminController.class)
-@Import(SecurityConfig.class)
+// Real IndexLoadService (built from the mocked refresh/rebuild beans) so the tests exercise the
+// controller's delegation to it rather than stubbing the orchestration away.
+@Import({SecurityConfig.class, com.fattorestreet.sec_api.index.IndexLoadService.class})
 @TestPropertySource(properties = "SECRET_KEY=test-jwt-signing-secret-32chars-min!") // pragma: allowlist secret
 class AdminControllerTest {
 

--- a/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexLoadRunnerTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexLoadRunnerTest.java
@@ -1,0 +1,142 @@
+package com.fattorestreet.sec_api.index;
+
+import java.math.BigDecimal;
+import java.time.Year;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IndexLoadRunnerTest {
+
+    @Mock
+    private IndexLoadService indexLoadService;
+
+    @Mock
+    private IndexMetricsRefreshService indexMetricsRefreshService;
+
+    @Mock
+    private ConfigurableApplicationContext context;
+
+    private IndexLoadRunner runner;
+
+    private final int currentYear = Year.now().getValue();
+
+    @BeforeEach
+    void setUp() {
+        runner = new IndexLoadRunner(indexLoadService, indexMetricsRefreshService, context);
+        ReflectionTestUtils.setField(runner, "year", 0);
+        ReflectionTestUtils.setField(runner, "scope", "russell1000");
+        ReflectionTestUtils.setField(runner, "skipRefresh", false);
+        ReflectionTestUtils.setField(runner, "ticker", "");
+        ReflectionTestUtils.setField(runner, "minProcessed", 800);
+    }
+
+    private static IndexMetricsRefreshService.RefreshResult refreshResult(int processed) {
+        return new IndexMetricsRefreshService.RefreshResult(processed, 3, List.of("X:no_cik"));
+    }
+
+    private static List<FattoreIndexRebuildService.RebuildResult> rebuildResults(boolean partial) {
+        return List.of(
+                new FattoreIndexRebuildService.RebuildResult("FAT100", 2026, 100, false, BigDecimal.TEN, List.of("MSFT")),
+                new FattoreIndexRebuildService.RebuildResult("FAT1000", 2026, 900, partial, BigDecimal.TEN, List.of("GOOG")),
+                new FattoreIndexRebuildService.RebuildResult("FAT50", 2026, 50, false, BigDecimal.TEN, List.of("AAPL")));
+    }
+
+    @Test
+    void returnsZeroWhenRefreshMeetsThresholdAndRebuildsSucceed() {
+        when(indexLoadService.refresh("russell1000", currentYear)).thenReturn(refreshResult(950));
+        when(indexLoadService.rebuildAll(currentYear)).thenReturn(rebuildResults(false));
+
+        assertEquals(0, runner.runLoad());
+        verify(indexLoadService).rebuildAll(currentYear);
+    }
+
+    @Test
+    void returnsZeroWhenRebuildIsPartial() {
+        // FAT1000 is routinely partial (fewer eligible names than topN); that is not a failure.
+        when(indexLoadService.refresh("russell1000", currentYear)).thenReturn(refreshResult(950));
+        when(indexLoadService.rebuildAll(currentYear)).thenReturn(rebuildResults(true));
+
+        assertEquals(0, runner.runLoad());
+    }
+
+    @Test
+    void skipsRebuildAndReturnsOneWhenBelowMinProcessed() {
+        when(indexLoadService.refresh("russell1000", currentYear)).thenReturn(refreshResult(200));
+
+        assertEquals(1, runner.runLoad());
+        verify(indexLoadService, never()).rebuildAll(anyInt());
+    }
+
+    @Test
+    void skipRefreshRebuildsWithoutRefreshing() {
+        ReflectionTestUtils.setField(runner, "skipRefresh", true);
+        when(indexLoadService.rebuildAll(currentYear)).thenReturn(rebuildResults(false));
+
+        assertEquals(0, runner.runLoad());
+        verify(indexLoadService, never()).refresh(anyString(), anyInt());
+        verify(indexMetricsRefreshService, never()).refreshSingleTicker(anyString(), anyInt());
+    }
+
+    @Test
+    void explicitYearOverridesCurrentYear() {
+        ReflectionTestUtils.setField(runner, "year", 2024);
+        when(indexLoadService.refresh("russell1000", 2024)).thenReturn(refreshResult(950));
+        when(indexLoadService.rebuildAll(2024)).thenReturn(rebuildResults(false));
+
+        assertEquals(0, runner.runLoad());
+        verify(indexLoadService).refresh("russell1000", 2024);
+        verify(indexLoadService).rebuildAll(2024);
+    }
+
+    @Test
+    void tickerModeUsesSingleTickerRefreshAndIgnoresMinProcessed() {
+        ReflectionTestUtils.setField(runner, "ticker", "AAPL");
+        when(indexMetricsRefreshService.refreshSingleTicker("AAPL", currentYear)).thenReturn(
+                new IndexMetricsRefreshService.RefreshResult(1, 0, List.of()));
+        when(indexLoadService.rebuildAll(currentYear)).thenReturn(rebuildResults(false));
+
+        assertEquals(0, runner.runLoad());
+        verify(indexLoadService, never()).refresh(anyString(), anyInt());
+    }
+
+    @Test
+    void tickerModeReturnsOneWhenTickerNotProcessed() {
+        ReflectionTestUtils.setField(runner, "ticker", "ZZZZBAD");
+        when(indexMetricsRefreshService.refreshSingleTicker("ZZZZBAD", currentYear)).thenReturn(
+                new IndexMetricsRefreshService.RefreshResult(0, 1, List.of("ZZZZBAD:unknown_ticker")));
+
+        assertEquals(1, runner.runLoad());
+        verify(indexLoadService, never()).rebuildAll(anyInt());
+    }
+
+    @Test
+    void returnsOneWhenRefreshThrows() {
+        when(indexLoadService.refresh("russell1000", currentYear)).thenThrow(new RuntimeException("boom"));
+
+        assertEquals(1, runner.runLoad());
+        verify(indexLoadService, never()).rebuildAll(anyInt());
+    }
+
+    @Test
+    void returnsOneWhenRebuildThrows() {
+        when(indexLoadService.refresh("russell1000", currentYear)).thenReturn(refreshResult(950));
+        when(indexLoadService.rebuildAll(currentYear)).thenThrow(new RuntimeException("boom"));
+
+        assertEquals(1, runner.runLoad());
+    }
+}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexLoadServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/index/IndexLoadServiceTest.java
@@ -1,0 +1,112 @@
+package com.fattorestreet.sec_api.index;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IndexLoadServiceTest {
+
+    @Mock
+    private IndexMetricsRefreshService indexMetricsRefreshService;
+
+    @Mock
+    private FattoreIndexRebuildService fattore50IndexRebuildService;
+
+    @Mock
+    private FattoreIndexRebuildService fattore100IndexRebuildService;
+
+    @Mock
+    private FattoreIndexRebuildService fattore1000IndexRebuildService;
+
+    private IndexLoadService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new IndexLoadService(
+                indexMetricsRefreshService,
+                fattore50IndexRebuildService,
+                fattore100IndexRebuildService,
+                fattore1000IndexRebuildService);
+    }
+
+    private static FattoreIndexRebuildService.RebuildResult result(String code) {
+        return new FattoreIndexRebuildService.RebuildResult(code, 2026, 1, false, BigDecimal.ONE, List.of("AAPL"));
+    }
+
+    @Test
+    void refreshRussell1000ScopeUsesRussellListings() {
+        IndexMetricsRefreshService.RefreshResult expected =
+                new IndexMetricsRefreshService.RefreshResult(10, 2, List.of("X:no_cik"));
+        when(indexMetricsRefreshService.refreshRussell1000Listings(2026)).thenReturn(expected);
+
+        assertEquals(expected, service.refresh("russell1000", 2026));
+        verify(indexMetricsRefreshService, never()).refreshAllTickers(anyInt());
+    }
+
+    @Test
+    void refreshIwbAliasAndCaseInsensitive() {
+        IndexMetricsRefreshService.RefreshResult expected =
+                new IndexMetricsRefreshService.RefreshResult(5, 0, List.of());
+        when(indexMetricsRefreshService.refreshRussell1000Listings(2026)).thenReturn(expected);
+
+        assertEquals(expected, service.refresh(" IWB ", 2026));
+    }
+
+    @Test
+    void refreshAllScopeUsesAllTickers() {
+        IndexMetricsRefreshService.RefreshResult expected =
+                new IndexMetricsRefreshService.RefreshResult(20, 1, List.of("Y:no_price"));
+        when(indexMetricsRefreshService.refreshAllTickers(2026)).thenReturn(expected);
+
+        assertEquals(expected, service.refresh("all", 2026));
+        verify(indexMetricsRefreshService, never()).refreshRussell1000Listings(anyInt());
+    }
+
+    @Test
+    void refreshNullScopeDefaultsToRussell1000() {
+        IndexMetricsRefreshService.RefreshResult expected =
+                new IndexMetricsRefreshService.RefreshResult(3, 0, List.of());
+        when(indexMetricsRefreshService.refreshRussell1000Listings(2026)).thenReturn(expected);
+
+        assertEquals(expected, service.refresh(null, 2026));
+    }
+
+    @Test
+    void refreshUnknownScopeThrows() {
+        assertThrows(IllegalArgumentException.class, () -> service.refresh("nope", 2026));
+        verify(indexMetricsRefreshService, never()).refreshRussell1000Listings(anyInt());
+        verify(indexMetricsRefreshService, never()).refreshAllTickers(anyInt());
+    }
+
+    @Test
+    void rebuildAllRunsInCanonicalOrder() {
+        when(fattore100IndexRebuildService.rebuild(2026)).thenReturn(result("FAT100"));
+        when(fattore1000IndexRebuildService.rebuild(2026)).thenReturn(result("FAT1000"));
+        when(fattore50IndexRebuildService.rebuild(2026)).thenReturn(result("FAT50"));
+
+        List<FattoreIndexRebuildService.RebuildResult> results = service.rebuildAll(2026);
+
+        assertEquals(List.of("FAT100", "FAT1000", "FAT50"),
+                results.stream().map(FattoreIndexRebuildService.RebuildResult::indexCode).toList());
+        InOrder order = inOrder(
+                fattore100IndexRebuildService, fattore1000IndexRebuildService, fattore50IndexRebuildService);
+        order.verify(fattore100IndexRebuildService).rebuild(2026);
+        order.verify(fattore1000IndexRebuildService).rebuild(2026);
+        order.verify(fattore50IndexRebuildService).rebuild(2026);
+    }
+}


### PR DESCRIPTION
## Summary
- The Fattore index load (metrics refresh + FAT100/FAT1000/FAT50 rebuilds) previously ran only when triggered by hand from the Admin page, so index membership went stale. It now runs nightly as an ephemeral Fargate task, downstream of the hist load so fresh DailyPrice rows exist.
- New `APP_RUN_MODE=index-load` runner (`IndexLoadRunner`, mirroring `HistLoadRunner`) with env knobs: `INDEX_LOAD_YEAR`, `INDEX_LOAD_SCOPE`, `INDEX_LOAD_SKIP_REFRESH`, `INDEX_LOAD_TICKER` (single-ticker smoke test), `INDEX_LOAD_MIN_PROCESSED`.
- Safety guard: `FattoreIndexRebuildService.rebuild` deletes members by index code (not year), so rebuilding after a mostly-failed refresh (SEC outage, empty new calendar year) would shrink the live indexes. The runner skips the rebuild and exits 1 when the refresh processes fewer than `INDEX_LOAD_MIN_PROCESSED` listings (default 800), keeping yesterday's members.
- Shared orchestration extracted into `IndexLoadService`; `AdminController` delegates to it (response payloads unchanged).
- Terraform: second task definition (0.5 vCPU / 2 GB ARM64), log group, and EventBridge schedule (tfvars example: 05:00 ET, 3h after the hist load), reusing the existing cluster, ECR image, IAM roles, and task SG so no existing resources are renamed or replaced.
- Plan file included at `.claude/plans/lets-take-a-look-pure-rivest.md`.

## Test plan
- `mvn verify` passes: 548 tests, 0 failures, JaCoCo floor green. New `IndexLoadServiceTest` (scope dispatch, rebuild ordering) and `IndexLoadRunnerTest` (exit codes, guard, skip-refresh, ticker mode); `AdminControllerTest` now imports the real `IndexLoadService` so existing assertions exercise the delegation.
- `terraform validate` and `terraform fmt -check` clean.
- Remaining (post-merge rollout): push the ARM64 image to ECR, `terraform apply`, one manual `aws ecs run-task` smoke test (`INDEX_LOAD_TICKER=AAPL` override documented in the terraform README), then let the schedule fire and check CloudWatch memory against the 2 GB default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)