### PR TITLE
Add email alerting for failed Fargate load tasks; fix terraform README drift

### DIFF
--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -15,6 +15,11 @@ the one-shot loads on Fargate — run mode is selected purely by the `APP_RUN_MO
   rebuild and exits `1` — the rebuild deletes members by index code, so rebuilding after a
   mostly-failed refresh (SEC outage, empty new calendar year) would shrink the live indexes.
 
+  The offset is a fixed gap, **not a dependency**: if the hist load fails or overruns, the index
+  load still fires and computes metrics from the previous day's prices (the min-processed guard
+  only protects against a failed *refresh*, not stale prices). One day of staleness in cap ranks
+  is acceptable; the failure alert below is what tells you the hist load needs attention.
+
 Both tasks share the ECR repo/image, ECS cluster, IAM roles, and task security group; each has its
 own task definition, log group, and schedule.
 
@@ -67,7 +72,7 @@ Then build the **ARM64** image and push it to the ECR repo Terraform created:
 
 ```bash
 REPO=$(terraform output -raw ecr_repository_url)
-REGION=$(terraform output -raw ... 2>/dev/null || echo us-east-1)   # or your var.aws_region
+REGION=us-east-1   # your var.aws_region
 aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${REPO%/*}"
 
 # Build for linux/arm64 to match runtime_platform = ARM64. Build context is springboot/.
@@ -130,16 +135,33 @@ The index load had no Celery/beat trigger to replace — it was manual-only via 
 (`POST /admin/indexes/refresh-stocks`, `POST /admin/indexes/rebuild`), which stay in place for
 manual runs.
 
+## Failure alerting
+
+Set `notification_email` in `terraform.tfvars` and an EventBridge rule + SNS topic email you
+whenever a task in the cluster stops with a non-zero exit code or fails to start. After the first
+`terraform apply`, **confirm the subscription** from the email AWS sends (until then, no alerts
+are delivered).
+
+Both runners exit `1` only on total failure — the load throwing, every attempted day failing, or
+the index refresh falling below the rebuild guard. Partial errors (some days, some tickers) exit
+`0` and self-heal on the next night's idempotent run, so an alert always means that night's run
+did no useful work. There are no automatic retries (`maximum_retry_attempts = 0`); on an alert,
+check the CloudWatch logs and, once fixed, either wait for the next scheduled run or re-run
+manually with the `aws ecs run-task` commands above.
+
+Leave `notification_email = ""` to skip creating the alerting resources entirely.
+
 ## Tuning knobs
 
 | Variable | Default | Notes |
 |----------|---------|-------|
 | `task_memory` | `4096` | Lower to `2048` after profiling a real run. |
 | `hist_load_days` | `20` | Days walked back; already-loaded days are skipped (idempotent). |
-| `schedule_expression` / `schedule_timezone` | `cron(0 2 * * ? *)` / `America/New_York` | When the hist load runs. |
+| `schedule_expression` / `schedule_timezone` | `cron(30 6 * * ? *)` / `Etc/UTC` | When the hist load runs (tfvars example: `cron(0 2 * * ? *)` / `America/New_York`). |
 | `schedule_enabled` | `true` | Toggle the nightly hist-load trigger. |
 | `index_load_task_cpu` / `index_load_task_memory` | `512` / `2048` | The index load is SEC-rate-limit bound (mostly idle); profile the first real run. |
 | `index_load_scope` | `russell1000` | Metrics refresh scope (`russell1000` or `all`). |
 | `index_load_min_processed` | `800` | Rebuild guard threshold; below it the task keeps yesterday's members and exits `1`. |
-| `index_load_schedule_expression` | `cron(0 5 * * ? *)` (tfvars) | When the index load runs; shares `schedule_timezone`. Keep it well after the hist load. |
-| `index_load_schedule_enabled` | `true` | Toggle the nightly index-load trigger. 
+| `index_load_schedule_expression` | `cron(30 9 * * ? *)` | When the index load runs (tfvars example: `cron(0 5 * * ? *)`); shares `schedule_timezone`. Keep it well after the hist load. |
+| `index_load_schedule_enabled` | `true` | Toggle the nightly index-load trigger. |
+| `notification_email` | `""` | Email alerted when a task exits non-zero or fails to start; `""` disables alerting. | 

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -344,3 +344,84 @@ resource "aws_scheduler_schedule" "index_load" {
     }
   }
 }
+
+# ---------------------------------------------------------------------------
+# Failure alerting: email (SNS) when any task in the cluster stops with a
+# non-zero exit code or never starts. Both nightly loads exit 1 only on total
+# failure (partial errors self-heal next run), so an alert means that night's
+# run did no useful work. Created only when notification_email is set.
+# ---------------------------------------------------------------------------
+resource "aws_sns_topic" "task_failures" {
+  count = var.notification_email != "" ? 1 : 0
+  name  = "${var.name_prefix}-task-failures"
+  tags  = local.tags
+}
+
+resource "aws_sns_topic_subscription" "task_failures_email" {
+  count     = var.notification_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.task_failures[0].arn
+  protocol  = "email"
+  endpoint  = var.notification_email
+}
+
+data "aws_iam_policy_document" "task_failures_topic" {
+  count = var.notification_email != "" ? 1 : 0
+
+  statement {
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.task_failures[0].arn]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.task_failures[0].arn]
+    }
+  }
+}
+
+resource "aws_sns_topic_policy" "task_failures" {
+  count  = var.notification_email != "" ? 1 : 0
+  arn    = aws_sns_topic.task_failures[0].arn
+  policy = data.aws_iam_policy_document.task_failures_topic[0].json
+}
+
+resource "aws_cloudwatch_event_rule" "task_failures" {
+  count       = var.notification_email != "" ? 1 : 0
+  name        = "${var.name_prefix}-task-failures"
+  description = "Nightly load task stopped with a non-zero exit code or failed to start"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ecs"]
+    detail-type = ["ECS Task State Change"]
+    detail = {
+      clusterArn = [aws_ecs_cluster.this.arn]
+      lastStatus = ["STOPPED"]
+      "$or" = [
+        { containers = { exitCode = [{ anything-but = [0] }] } },
+        { stopCode = ["TaskFailedToStart"] }
+      ]
+    }
+  })
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "task_failures_sns" {
+  count = var.notification_email != "" ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.task_failures[0].name
+  arn   = aws_sns_topic.task_failures[0].arn
+
+  input_transformer {
+    input_paths = {
+      group    = "$.detail.group"
+      exitCode = "$.detail.containers[0].exitCode"
+      reason   = "$.detail.stoppedReason"
+      taskArn  = "$.detail.taskArn"
+    }
+    # Output must be a JSON value; the surrounding quotes make it a JSON string.
+    input_template = "\"FattoreStreet nightly load failed: <group> stopped with exit code <exitCode>. Reason: <reason>. Task: <taskArn>. Logs: /ecs/${var.name_prefix} or /ecs/${var.index_load_name_prefix}.\""
+  }
+}

--- a/springboot/deploy/terraform/outputs.tf
+++ b/springboot/deploy/terraform/outputs.tf
@@ -42,3 +42,8 @@ output "index_load_schedule_name" {
   description = "EventBridge schedule name for the index load."
   value       = aws_scheduler_schedule.index_load.name
 }
+
+output "task_failures_sns_topic_arn" {
+  description = "SNS topic notified on task failures (empty when notification_email is unset)."
+  value       = var.notification_email != "" ? aws_sns_topic.task_failures[0].arn : ""
+}

--- a/springboot/deploy/terraform/terraform.tfvars.example
+++ b/springboot/deploy/terraform/terraform.tfvars.example
@@ -31,3 +31,7 @@ schedule_enabled    = true
 index_load_schedule_expression = "cron(0 5 * * ? *)"
 index_load_schedule_enabled    = true
 index_load_task_memory         = 2048 # SEC-rate-limit bound; tune after profiling a real run
+
+# Email alerted when a nightly task exits non-zero or fails to start (confirm
+# the SNS subscription once after apply). Leave "" to disable alerting.
+notification_email = "you@example.com"

--- a/springboot/deploy/terraform/variables.tf
+++ b/springboot/deploy/terraform/variables.tf
@@ -175,6 +175,18 @@ variable "index_load_schedule_enabled" {
   default     = true
 }
 
+variable "notification_email" {
+  description = <<-EOT
+    Email address alerted (via an SNS topic + EventBridge rule) when a task in the cluster stops
+    with a non-zero exit code or fails to start. Both nightly loads exit 1 only on total failure,
+    so an alert means that night's run did no useful work. Empty string (the default) disables
+    the alerting resources entirely. The subscription must be confirmed once from the
+    confirmation email AWS sends after `terraform apply`.
+  EOT
+  type        = string
+  default     = ""
+}
+
 variable "log_retention_days" {
   description = "CloudWatch log retention for the task."
   type        = number


### PR DESCRIPTION
## Summary
- Nightly Fargate load failures were only visible in CloudWatch logs; a silent week of failed hist loads would quietly stale adjusted prices and index metrics. A new `notification_email` variable (default `""` = disabled) creates an SNS topic + email subscription and an EventBridge rule that fires when any task in the cluster stops with a non-zero exit code or fails to start. Since both runners exit 1 only on total failure (partial errors self-heal on the next idempotent run), an alert always means that night's run did no useful work.
- The email is a readable one-liner (task family, exit code, stopped reason, log groups) via an input transformer, not raw event JSON; the topic policy only allows that specific rule to publish.
- Fixed terraform README drift: the tuning-knobs table now shows the real `variables.tf` schedule defaults (`cron(30 6 * * ? *)` / `Etc/UTC`, `cron(30 9 * * ? *)`) with the tfvars-example values noted alongside, and the broken `REGION=$(terraform output -raw ...)` placeholder is gone.
- Documented that the 3h hist-load → index-load gap is a fixed offset, not a dependency, plus a new "Failure alerting" section (confirm-subscription step, what to do on an alert).

## Test plan
- `terraform fmt -check` and `terraform validate` pass
- `uvx pre-commit run detect-secrets --all-files` passes with no baseline churn
- Remaining: set `notification_email` in `terraform.tfvars`, `terraform apply`, confirm the SNS subscription email, then verify with a forced failing run (e.g. `aws ecs run-task` with an override like `HIST_LOAD_DAYS=abc`) that the alert email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)