### PR TITLE
compile sass before the react build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Format check (Prettier)
         run: npm run format:check
 
+      # index.html links the gitignored custom.css, so without this Vite only
+      # warns and still exits 0, emitting a bundle missing the theme stylesheet.
+      # Mirrors the sass step in nginx/Dockerfile.
+      - name: Compile Sass
+        run: npx sass src/styles/custom.scss src/styles/custom.css
+
       - name: Build (TypeScript + Vite)
         run: npm run build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + build + tests, Django tests, Spring Boot tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
 
 ## Architecture
 

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -96,8 +96,12 @@ Linting is not part of `npm run build`, and there are no local git hooks, so the
 run either on demand or in CI. All four checks (`lint`, `lint:styles`,
 `format:check`, `build`) must pass before merge.
 
-`src/styles/custom.css` is the compiled output of `custom.scss` and is excluded
-from both Prettier and Stylelint; edit the `.scss` source instead.
+`src/styles/custom.css` is the gitignored compiled output of `custom.scss` and is
+excluded from both Prettier and Stylelint; edit the `.scss` source instead. Run
+the Sass compile above before `npm run build` on a fresh clone: `index.html`
+links `custom.css` directly, and if it is missing Vite only warns and still
+exits 0, producing a bundle with no theme stylesheet. CI and `nginx/Dockerfile`
+both compile it first for this reason.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

`index.html` links `src/styles/custom.css`, which is gitignored and generated from `custom.scss`. On a fresh CI checkout that file does not exist, and Vite only warns before exiting 0:

```
./src/styles/custom.css doesn't exist at build time, it will remain unchanged to be resolved at runtime
```

So the frontend job's Build step has been passing while emitting a bundle with no theme stylesheet (19.63 kB instead of 253.42 kB) and a `<link>` pointing at a path that would 404.

**Production was never affected.** `nginx/Dockerfile` already compiles the Sass before building, and that is what gets deployed. The gap was that `ci.yml` validated an artifact that did not match the shipped one, so a Sass error in `custom.scss` would pass CI green and only surface later in the image build.

This adds the same `npx sass` invocation to the frontend job, immediately before the build, mirroring the Dockerfile.

## Test plan

Reproduced the failure and the fix locally by deleting `custom.css` to simulate a fresh checkout:

- Without the step: build exits 0, emits `index-*.css` at 19.63 kB, prints the "doesn't exist at build time" warning
- With the step: build exits 0, emits `index-*.css` at 253.42 kB, no warning

Also run on this branch: `npm run lint`, `npm run lint:styles`, `npm run format:check`, `npx vitest --run` (143 tests across 15 files), and `pre-commit run detect-secrets --all-files`. All pass.

Docs updated: the CI description in `CLAUDE.md`, and a note in `react-app/README.md` that the Sass compile is required before `npm run build` on a fresh clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)