### PR TITLE
make the claude review check event-driven instead of polling

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -3,56 +3,159 @@ name: Claude PR Review
 # The "PR review on GitHub Actions trigger" Claude Code routine
 # (https://claude.ai/code/routines) fires on PR events via its own GitHub
 # trigger, reviews the diff with the repo's code-review skill, and posts one
-# comment per head SHA containing a "Verdict: PASS|FAIL" line. This job waits
-# for that comment and turns the verdict into a pass/fail check on the PR.
+# comment per head SHA containing a "<!-- claude-routine-review: <sha> -->"
+# marker and a "Verdict: PASS|FAIL" line.
+#
+# This workflow turns that comment into a "Claude Review Verdict" check run:
+#   seed    -> on PR events, opens the check as in_progress so it reads pending
+#   verdict -> on the routine's comment, completes it as success or failure
+#
+# Nothing polls. The verdict job runs in seconds once the comment lands, instead
+# of holding a runner in a sleep loop for 25 minutes. If the routine never posts
+# (outage, quota, trigger misfire) the check stays pending rather than failing,
+# so infrastructure trouble blocks a merge without painting healthy code red.
+#
+# Note: issue_comment workflows always run the copy of this file on the default
+# branch, so the verdict job only starts working once this is merged to main.
 
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
 
+# Serialize every run for a given PR so the seed can't reopen a check the
+# verdict job just completed. Both events have to key off the PR number: the
+# verdict job cannot know the reviewed SHA until it parses the comment body.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
 
 permissions:
-  pull-requests: read
-  issues: read
+  checks: write
+
+env:
+  # Require this context in branch protection, not the job names below.
+  CHECK_NAME: Claude Review Verdict
 
 jobs:
-  claude-review:
-    if: ${{ !github.event.pull_request.draft }}
+  seed:
+    name: Claude review (open pending check)
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      REPO: ${{ github.repository }}
+    timeout-minutes: 5
     steps:
-      - name: Wait for review verdict
+      - name: Create in-progress check run
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          marker="<!-- claude-routine-review: ${HEAD_SHA} -->"
-          echo "Waiting for review comment containing: $marker"
-          for i in $(seq 1 50); do
-            review=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate |
-              jq -r --arg m "$marker" '[.[] | select(.body | contains($m)) | .body] | last // empty' |
-              tr -d '\r')
-            if [ -n "$review" ]; then
-              echo "----- Claude review -----"
-              echo "$review"
-              echo "-------------------------"
-              if printf '%s\n' "$review" | grep -qx 'Verdict: PASS'; then
-                exit 0
-              elif printf '%s\n' "$review" | grep -qx 'Verdict: FAIL'; then
-                echo "::error::Claude review verdict is FAIL — see the review comment on the PR."
-                exit 1
-              else
-                echo "::error::Review comment found but no 'Verdict: PASS|FAIL' line."
-                exit 1
-              fi
-            fi
-            sleep 30
-          done
-          echo "::error::Timed out waiting for the Claude review comment (25 min)."
-          exit 1
+          set -euo pipefail
+
+          existing=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            --jq '[.check_runs[] | select(.name == env.CHECK_NAME)] | first | .id // empty')
+          if [ -n "$existing" ]; then
+            echo "Check run ${existing} already exists for ${HEAD_SHA}; leaving it alone."
+            exit 0
+          fi
+
+          jq -n --arg name "$CHECK_NAME" --arg sha "$HEAD_SHA" '{
+            name: $name,
+            head_sha: $sha,
+            status: "in_progress",
+            output: {
+              title: "Waiting for the Claude review",
+              summary: "The Claude Code review routine posts its verdict as a PR comment. This check completes as soon as that comment lands."
+            }
+          }' | gh api --method POST "repos/${REPO}/check-runs" --input - --jq '.html_url'
+
+  verdict:
+    name: Claude review (publish verdict)
+    # The marker literal is duplicated from the parsing step below because the
+    # env context is not available in a job-level if. Keep the two in sync.
+    #
+    # The author filter matters: without it anyone who can comment on a PR could
+    # post a fake "Verdict: PASS" and clear the gate.
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '<!-- claude-routine-review:') &&
+      (github.event.comment.user.type == 'Bot' ||
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Parse verdict and complete check run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          # Read the body from the environment rather than interpolating it into
+          # the script; it is attacker-controlled text on a fork PR.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+
+          body=$(printf '%s' "$COMMENT_BODY" | tr -d '\r')
+
+          # The routine stamps the SHA it reviewed into the marker, so the check
+          # lands on that commit even if the PR has been pushed to since.
+          head_sha=$(printf '%s\n' "$body" \
+            | grep -oE '<!-- claude-routine-review: [0-9a-f]{7,40} -->' \
+            | tail -1 \
+            | grep -oE '[0-9a-f]{7,40}' || true)
+          if [ -z "$head_sha" ]; then
+            echo "::error::Review marker present but it carries no commit SHA."
+            exit 1
+          fi
+
+          # Tolerate markdown around the verdict (**Verdict: PASS**) and take the
+          # last one, so an edited or restated verdict wins.
+          verdict=$(printf '%s\n' "$body" \
+            | sed -nE 's/^[[:space:]]*\**[[:space:]]*[Vv]erdict:[[:space:]]*\**[[:space:]]*([A-Za-z]+).*/\1/p' \
+            | tail -1 | tr '[:lower:]' '[:upper:]')
+
+          case "$verdict" in
+            PASS)
+              conclusion=success
+              title="Claude review passed"
+              ;;
+            FAIL)
+              conclusion=failure
+              title="Claude review found blocking issues"
+              ;;
+            *)
+              conclusion=failure
+              title="Review comment had no 'Verdict: PASS|FAIL' line"
+              ;;
+          esac
+
+          echo "Commit ${head_sha}: verdict '${verdict:-none}' -> ${conclusion}"
+
+          summary=$(printf 'Verdict: **%s**\n\n[Read the full review comment](%s)\n' \
+            "${verdict:-none}" "$COMMENT_URL")
+
+          # Mirror the review into the check run so it survives a deleted or
+          # edited comment. output.text caps at 65535 characters, so slice in jq
+          # (by codepoint, unlike cut/head, which would split a UTF-8 sequence).
+          common=$(jq -n --arg conclusion "$conclusion" --arg title "$title" \
+            --arg summary "$summary" --arg text "$body" '{
+              status: "completed",
+              conclusion: $conclusion,
+              output: {title: $title, summary: $summary, text: $text[0:60000]}
+            }')
+
+          check_id=$(gh api "repos/${REPO}/commits/${head_sha}/check-runs" \
+            --jq '[.check_runs[] | select(.name == env.CHECK_NAME)] | first | .id // empty')
+
+          if [ -n "$check_id" ]; then
+            printf '%s' "$common" \
+              | gh api --method PATCH "repos/${REPO}/check-runs/${check_id}" --input - --jq '.html_url'
+          else
+            # No seed ran (draft PR, or the review beat the seed job), so create
+            # the check outright.
+            printf '%s' "$common" \
+              | jq --arg name "$CHECK_NAME" --arg sha "$head_sha" '. + {name: $name, head_sha: $sha}' \
+              | gh api --method POST "repos/${REPO}/check-runs" --input - --jq '.html_url'
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA). `claude-pr-review.yml` is event-driven: it opens a `Claude Review Verdict` check run as pending on PR events, then completes it when the Claude Code review routine posts its verdict comment. Require that context (not the job names) if you turn on branch protection.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Replaces the 25-minute polling loop in `claude-pr-review.yml` with two short event-driven jobs. `seed` opens a `Claude Review Verdict` check run as pending on PR events; `verdict` completes it from an `issue_comment` trigger when the review routine posts. Runtime per PR drops from up to 25 minutes of a sleeping runner to a few seconds.
- Changes the failure mode. A routine outage, quota exhaustion, or trigger misfire used to time out and paint a red X on healthy code. The check now stays pending instead, which still blocks a merge under branch protection but does not misreport the code.
- Relaxes verdict parsing. The old `grep -qx 'Verdict: PASS'` needed an exact whole-line match, so `**Verdict: PASS**` or a trailing space would have hard-failed the gate. Parsing now handles markdown, case, CRLF, and trailing prose, and takes the last verdict so a restated one wins.
- Adds an author filter. Without it, anyone who could comment on a PR could post `Verdict: PASS` and clear the gate. Only bots and OWNER/MEMBER/COLLABORATOR comments count, which doubles as a manual override.
- Passes the comment body through an env var rather than `${{ }}` interpolation, since it is attacker-controlled on a fork PR.
- Attaches the check to the SHA in the review marker rather than the current PR head, so a review landing after a push labels the commit it actually reviewed.
- Mirrors the review into the check run's Details so it survives a deleted or edited comment.

## Test plan

Validated locally, since the workflow cannot fully run until it is on `main`:

- Workflow YAML parses; both jobs, triggers, permissions, and the concurrency group confirmed.
- Verdict parsing exercised against 12 comment bodies: plain, bold, lowercase, CRLF, leading whitespace, trailing prose, duplicate verdicts, missing verdict, short SHA, missing SHA, multiple markers, and a body containing `$(touch /tmp/pwned)` and backticked `id`. All produced the expected conclusion and nothing executed.
- jq lookup filter checked against empty, non-matching, and matching `check_runs` payloads. `gh`'s built-in jq confirmed to support `env.VAR`, which that filter relies on.
- Payload construction checked with a 89k-character multi-byte body; `output.text` truncates to 60000 codepoints and stays valid JSON.
- Extracted run blocks pass `bash -n`.

Remaining, after merge:

- `issue_comment` workflows only run the copy of the file on the default branch, so the `verdict` job does nothing until this lands. Expect the check on this PR to sit pending; that is a one-time artifact.
- Confirm on a test PR that the routine's comment actually fires `issue_comment`. It should, since only the default `GITHUB_TOKEN` is barred from triggering workflows and the routine posts through the Claude GitHub App, but this assumption is what the design rests on and I could not verify it without a live run.

`main` has no branch protection today, so this check is advisory. If you enable it, require the `Claude Review Verdict` context rather than the job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)