### PR TITLE
Switch the springboot CI job from mvn test to mvn verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: uv run python manage.py test
 
   springboot:
-    name: Spring Boot (lint, test)
+    name: Spring Boot (lint, test, verify)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -105,8 +105,23 @@ jobs:
       - name: Lint (Checkstyle)
         run: ./mvnw -B -ntp checkstyle:check
 
-      - name: Run tests
-        run: ./mvnw -B -ntp test
+      # verify, not test: `jacoco:check` binds to verify, so the coverage floor
+      # in pom.xml was never actually enforced by CI before this. verify also
+      # runs spring-boot:repackage, so packaging failures surface here instead
+      # of only in docker-build.yml.
+      - name: Build, test & verify
+        run: ./mvnw -B -ntp verify
+
+      # always(): the job stops at the first failed step, so without this a
+      # coverage failure would report the threshold but not the report showing
+      # which package dropped.
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: springboot-jacoco
+          path: springboot/target/site/jacoco/
+          retention-days: 7
 
   secrets:
     name: Secret scan (detect-secrets)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
 
 ## Architecture
 

--- a/springboot/CLAUDE.md
+++ b/springboot/CLAUDE.md
@@ -6,7 +6,7 @@ Conventions are covered by the path-scoped rule `.claude/rules/springboot-java.m
 
 ## Quality Gates
 
-Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check` and `checkstyle:check`. See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
+Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (which enforces the JaCoCo coverage floor). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
 
 ## Writing Tests
 

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -325,6 +325,7 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 ./mvnw spotless:apply    # auto-fix formatting (imports, whitespace, indentation)
 ./mvnw spotless:check    # what CI checks
 ./mvnw checkstyle:check  # lint rules
+./mvnw verify            # everything CI runs: gates + tests + coverage floor
 ```
 
 | Gate | Phase | Config |
@@ -332,7 +333,9 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 | Maven enforcer (Maven 3.9+, Java 17+) | `validate` | `pom.xml` |
 | Spotless | `validate` | `pom.xml` (inline) |
 | Checkstyle | `validate` | `config/checkstyle/checkstyle.xml` |
-| JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco:check`) |
+| JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco.line.minimum`) |
+
+CI runs `mvn verify`, so the coverage floor is enforced on every PR. The floor lives in the `jacoco.line.minimum` property; raise it deliberately as coverage improves and never lower it to make a build pass. It is overridable on the command line (`-Djacoco.line.minimum=0.95`) purely so the gate itself can be tested.
 
 Checkstyle owns semantics; Spotless owns whitespace, import order and line length. Never add whitespace, wrapping or `LineLength` modules to `checkstyle.xml`: two owners of the same concern produce a build that cannot be made green. The ruleset is curated rather than inherited from `sun_checks.xml` or `google_checks.xml`, and its header comment records what was excluded and why.
 

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -44,6 +44,13 @@
 		<spotless.version>2.46.1</spotless.version>
 		<checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
 		<checkstyle.version>10.26.1</checkstyle.version>
+
+		<!-- Coverage floor enforced by jacoco:check at verify. Actual at the time
+		     CI started running verify: 81.5% line, 61.9% branch. Raise this
+		     deliberately when coverage improves; never lower it to make a build
+		     pass. Overridable on the command line so the gate itself can be
+		     tested (-Djacoco.line.minimum=0.95 should fail). -->
+		<jacoco.line.minimum>0.76</jacoco.line.minimum>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -265,7 +272,7 @@
 										<limit>
 											<counter>LINE</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.76</minimum>
+											<minimum>${jacoco.line.minimum}</minimum>
 										</limit>
 									</limits>
 								</rule>


### PR DESCRIPTION
The pom has configured a `jacoco:check` line-coverage floor for some time, but `jacoco:check` binds to `verify` and CI only ran `mvn -B test` — so **the coverage gate had never actually executed in CI**. `springboot/README.md:320` already claimed `mvn verify` enforced it, so the docs were ahead of the pipeline. This makes the claim true.

`verify` also runs `spring-boot:repackage`, so packaging failures now surface in the test job rather than only in `docker-build.yml`.

## Coverage headroom

81.5% line / 61.9% branch against the 0.76 floor, so 5.5 points of headroom. Keeping the floor at 0.76 in this PR so that any red is unambiguously the switch and not a new threshold.

Note the previously recorded 80.55% / 60% figures came from stale surefire and jacoco output sitting in `target/`. A clean run gives the numbers above, and the suite is **564 tests, not 548**.

## The floor is now testable

It was a hardcoded `<minimum>0.76</minimum>`, which made the gate impossible to exercise without editing the pom. Extracted to a `jacoco.line.minimum` property, and verified both directions:

- `./mvnw verify -Djacoco.line.minimum=0.95` → **BUILD FAILURE**
- `./mvnw verify` (0.76) → **BUILD SUCCESS**

## Verification

- `./mvnw verify` passes end to end: enforcer → Spotless → Checkstyle → 564 tests → jacoco:report → repackage → jacoco:check
- `detect-secrets` clean

The JaCoCo report uploads as an artifact with `if: always()`, because the job halts at the first failed step and a coverage failure would otherwise report the threshold without the report showing which package dropped.

Follow-up worth considering separately: branch coverage is 61.9% and completely ungated. A `BRANCH` rule at 0.55 would catch a PR adding a dozen untested `if` branches, which the line gate lets through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)