### PR TITLE
Add Error Prone, gated behind a profile so it stays out of the image build

### DIFF
--- a/.claude/rules/springboot-java.md
+++ b/.claude/rules/springboot-java.md
@@ -53,6 +53,8 @@ Mirror the same package names under `src/test/java/.../sec_api/` for unit tests.
   - one intentional site: `@SuppressFBWarnings(value = "...", justification = "...")` at the narrowest scope. The justification is mandatory
 - Prefer `InputStream.skipNBytes` over `skipBytes`; the latter can skip fewer bytes than asked and returns the count, which silently desynchronises binary parsing
 - PMD also gates `mvn verify`, with a deliberately small ruleset in `springboot/config/pmd/ruleset.xml`. It references individual rules, never whole categories, so it only reports what Spotless, Checkstyle and SpotBugs do not. Keep it that way when adding rules
+- Error Prone runs at `compile` via the `errorprone` profile. Its ERROR-tier checks fail the build; WARNING-tier ones are advisory
+- Pass an explicit `ZoneId` to `LocalDate.now()`, `LocalDateTime.now()` and `Year.now()`. Without one they silently use the server's default zone, which decides what "today" means for trading-day and filing-window logic. Error Prone reports these as `JavaTimeDefaultTimeZone`
 
 ## SEC EDGAR Patterns
 

--- a/.claude/rules/springboot-java.md
+++ b/.claude/rules/springboot-java.md
@@ -48,6 +48,10 @@ Mirror the same package names under `src/test/java/.../sec_api/` for unit tests.
 - Checkstyle owns semantics; Spotless owns whitespace, import order and line length. Never add whitespace, wrapping or `LineLength` modules to the Checkstyle config
 - Utility classes need a private constructor and `final`; the `@SpringBootApplication` class is exempt (Spring instantiates it) and is suppressed by name
 - Records are implicitly static, so write `public record X(...)`, not `public static record X(...)`
+- SpotBugs + FindSecBugs gate `mvn verify`. To silence a finding:
+  - a whole category: `springboot/config/spotbugs/exclude.xml`, with a written rationale in the XML comment
+  - one intentional site: `@SuppressFBWarnings(value = "...", justification = "...")` at the narrowest scope. The justification is mandatory
+- Prefer `InputStream.skipNBytes` over `skipBytes`; the latter can skip fewer bytes than asked and returns the count, which silently desynchronises binary parsing
 
 ## SEC EDGAR Patterns
 

--- a/.claude/rules/springboot-java.md
+++ b/.claude/rules/springboot-java.md
@@ -52,6 +52,7 @@ Mirror the same package names under `src/test/java/.../sec_api/` for unit tests.
   - a whole category: `springboot/config/spotbugs/exclude.xml`, with a written rationale in the XML comment
   - one intentional site: `@SuppressFBWarnings(value = "...", justification = "...")` at the narrowest scope. The justification is mandatory
 - Prefer `InputStream.skipNBytes` over `skipBytes`; the latter can skip fewer bytes than asked and returns the count, which silently desynchronises binary parsing
+- PMD also gates `mvn verify`, with a deliberately small ruleset in `springboot/config/pmd/ruleset.xml`. It references individual rules, never whole categories, so it only reports what Spotless, Checkstyle and SpotBugs do not. Keep it that way when adding rules
 
 ## SEC EDGAR Patterns
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,14 @@ jobs:
           path: springboot/target/site/jacoco/
           retention-days: 7
 
+      - name: Upload SpotBugs report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: springboot-spotbugs
+          path: springboot/target/spotbugsXml.xml
+          retention-days: 7
+
   secrets:
     name: Secret scan (detect-secrets)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: uv run python manage.py test
 
   springboot:
-    name: Spring Boot (lint, test)
+    name: Spring Boot (lint, test, verify)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -105,8 +105,23 @@ jobs:
       - name: Lint (Checkstyle)
         run: ./mvnw -B -ntp checkstyle:check
 
-      - name: Run tests
-        run: ./mvnw -B -ntp test
+      # verify, not test: `jacoco:check` binds to verify, so the coverage floor
+      # in pom.xml was never actually enforced by CI before this. verify also
+      # runs spring-boot:repackage, so packaging failures surface here instead
+      # of only in docker-build.yml.
+      - name: Build, test & verify
+        run: ./mvnw -B -ntp verify
+
+      # always(): the job stops at the first failed step, so without this a
+      # coverage failure would report the threshold but not the report showing
+      # which package dropped.
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: springboot-jacoco
+          path: springboot/target/site/jacoco/
+          retention-days: 7
 
   secrets:
     name: Secret scan (detect-secrets)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + tests, and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs + PMD), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs + PMD), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs + PMD + Error Prone), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
 
 ## Architecture
 

--- a/springboot/.mvn/jvm.config
+++ b/springboot/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/springboot/CLAUDE.md
+++ b/springboot/CLAUDE.md
@@ -6,7 +6,7 @@ Conventions are covered by the path-scoped rule `.claude/rules/springboot-java.m
 
 ## Quality Gates
 
-Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check` and `checkstyle:check`. See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
+Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (which enforces the JaCoCo coverage floor). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
 
 ## Writing Tests
 

--- a/springboot/CLAUDE.md
+++ b/springboot/CLAUDE.md
@@ -6,7 +6,7 @@ Conventions are covered by the path-scoped rule `.claude/rules/springboot-java.m
 
 ## Quality Gates
 
-Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (which enforces the JaCoCo coverage floor). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
+Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (JaCoCo coverage floor + SpotBugs/FindSecBugs). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
 
 ## Writing Tests
 

--- a/springboot/CLAUDE.md
+++ b/springboot/CLAUDE.md
@@ -6,7 +6,7 @@ Conventions are covered by the path-scoped rule `.claude/rules/springboot-java.m
 
 ## Quality Gates
 
-Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (JaCoCo coverage floor + SpotBugs/FindSecBugs + PMD). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
+Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (JaCoCo coverage floor + SpotBugs/FindSecBugs + PMD + Error Prone). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
 
 ## Writing Tests
 

--- a/springboot/CLAUDE.md
+++ b/springboot/CLAUDE.md
@@ -6,7 +6,7 @@ Conventions are covered by the path-scoped rule `.claude/rules/springboot-java.m
 
 ## Quality Gates
 
-Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (JaCoCo coverage floor + SpotBugs/FindSecBugs). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
+Run `./mvnw spotless:apply` to fix formatting before committing; CI runs `spotless:check`, `checkstyle:check` and `mvn verify` (JaCoCo coverage floor + SpotBugs/FindSecBugs + PMD). See "Code Quality" in `README.md`. Never pass `-Dquality.skip=true` locally, it exists only for the Docker build stage.
 
 ## Writing Tests
 

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -335,6 +335,9 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 | Checkstyle | `validate` | `config/checkstyle/checkstyle.xml` |
 | SpotBugs + FindSecBugs | `verify` | `config/spotbugs/exclude.xml` |
 | PMD | `verify` | `config/pmd/ruleset.xml` |
+| Error Prone | `compile` | `pom.xml` (`errorprone` profile) |
+
+Error Prone runs as a javac plugin, so unlike the others it cannot be turned off with a `<skip>` parameter. It lives in a profile that deactivates whenever `-Dquality.skip` is passed, which is what keeps it out of the Docker build. Its ERROR-tier checks fail the build; WARNING-tier checks are advisory and worth reading, particularly `JavaTimeDefaultTimeZone`.
 | JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco.line.minimum`) |
 
 To silence a SpotBugs finding, silence a whole **category** in `config/spotbugs/exclude.xml` with a written rationale, or a single intentional **site** with `@SuppressFBWarnings(value = "...", justification = "...")` at the narrowest scope. The justification is not optional; reviewers should reject entries without one. Two blocks in that file are marked `REVISIT` because they are accepted risk rather than false positives.

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -333,7 +333,10 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 | Maven enforcer (Maven 3.9+, Java 17+) | `validate` | `pom.xml` |
 | Spotless | `validate` | `pom.xml` (inline) |
 | Checkstyle | `validate` | `config/checkstyle/checkstyle.xml` |
+| SpotBugs + FindSecBugs | `verify` | `config/spotbugs/exclude.xml` |
 | JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco.line.minimum`) |
+
+To silence a SpotBugs finding, silence a whole **category** in `config/spotbugs/exclude.xml` with a written rationale, or a single intentional **site** with `@SuppressFBWarnings(value = "...", justification = "...")` at the narrowest scope. The justification is not optional; reviewers should reject entries without one. Two blocks in that file are marked `REVISIT` because they are accepted risk rather than false positives.
 
 CI runs `mvn verify`, so the coverage floor is enforced on every PR. The floor lives in the `jacoco.line.minimum` property; raise it deliberately as coverage improves and never lower it to make a build pass. It is overridable on the command line (`-Djacoco.line.minimum=0.95`) purely so the gate itself can be tested.
 

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -334,6 +334,7 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 | Spotless | `validate` | `pom.xml` (inline) |
 | Checkstyle | `validate` | `config/checkstyle/checkstyle.xml` |
 | SpotBugs + FindSecBugs | `verify` | `config/spotbugs/exclude.xml` |
+| PMD | `verify` | `config/pmd/ruleset.xml` |
 | JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco.line.minimum`) |
 
 To silence a SpotBugs finding, silence a whole **category** in `config/spotbugs/exclude.xml` with a written rationale, or a single intentional **site** with `@SuppressFBWarnings(value = "...", justification = "...")` at the narrowest scope. The justification is not optional; reviewers should reject entries without one. Two blocks in that file are marked `REVISIT` because they are accepted risk rather than false positives.

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -325,6 +325,7 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 ./mvnw spotless:apply    # auto-fix formatting (imports, whitespace, indentation)
 ./mvnw spotless:check    # what CI checks
 ./mvnw checkstyle:check  # lint rules
+./mvnw verify            # everything CI runs: gates + tests + coverage floor
 ```
 
 | Gate | Phase | Config |
@@ -332,7 +333,9 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 | Maven enforcer (Maven 3.9+, Java 17+) | `validate` | `pom.xml` |
 | Spotless | `validate` | `pom.xml` (inline) |
 | Checkstyle | `validate` | `config/checkstyle/checkstyle.xml` |
-| JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco:check`) |
+| JaCoCo coverage floor | `verify` | `pom.xml` (`jacoco.line.minimum`) |
+
+CI runs `mvn verify`, so the coverage floor is enforced on every PR. The floor lives in the `jacoco.line.minimum` property; raise it deliberately as coverage improves and never lower it to make a build pass. It is overridable on the command line (`-Djacoco.line.minimum=0.95`) purely so the gate itself can be tested.
 
 Checkstyle owns semantics; Spotless owns whitespace, import order and line length. Never add whitespace, wrapping or `LineLength` modules to `checkstyle.xml`: two owners of the same concern produce a build that cannot be made green. The ruleset is curated rather than inherited from `sun_checks.xml` or `google_checks.xml`, and its header comment records what was excluded and why.
 

--- a/springboot/config/pmd/ruleset.xml
+++ b/springboot/config/pmd/ruleset.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<ruleset name="sec-api"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                             https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        Curated PMD ruleset for sec-api.
+
+        PMD is the third analyser here, after Spotless (shape), Checkstyle
+        (semantics) and SpotBugs+FindSecBugs (bytecode defects). It earns its
+        place only where it sees something the others do not, so this file
+        references INDIVIDUAL RULES rather than whole category files.
+
+        Whole categories are deliberately NOT imported:
+          category/java/codestyle.xml   - Spotless and Checkstyle own style.
+                                          Importing it guarantees conflicts.
+          category/java/documentation.xml - no Javadoc culture in this tree.
+          category/java/performance.xml - mostly micro-optimisation advice
+                                          that fights readability.
+          category/java/design.xml      - complexity metrics would fail
+                                          immediately on the XBRL mapping and
+                                          corporate-action detectors.
+          category/java/security.xml    - FindSecBugs already covers this, at
+                                          bytecode level, more precisely.
+
+        The remaining rules below are ones SpotBugs does not report:
+        unused private methods and parameters are PMD's genuine edge, since
+        SpotBugs only reports uncalled private METHODS, not parameters, and
+        PMD sees source-level constructs the bytecode has already erased.
+    </description>
+
+    <!-- ===== Genuinely dead code =====
+         UnusedFormalParameter is the reason PMD is here at all: neither
+         SpotBugs nor Checkstyle reports it.
+         NOT included, to avoid three tools reporting one problem:
+           UnusedPrivateMethod  - SpotBugs UPM_UNCALLED_PRIVATE_METHOD already
+                                  covers it, and the five current hits are
+                                  tracked in config/spotbugs/exclude.xml.
+           UnusedLocalVariable  - Checkstyle already has this rule. -->
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+    <rule ref="category/java/bestpractices.xml/UnusedAssignment" />
+
+    <!-- ===== Likely mistakes ===== -->
+    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals" />
+    <rule ref="category/java/errorprone.xml/BrokenNullCheck" />
+    <rule ref="category/java/errorprone.xml/MisplacedNullCheck" />
+    <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode" />
+    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
+    <rule ref="category/java/errorprone.xml/JumbledIncrementer" />
+
+    <!-- ===== Needless control flow =====
+         NOT included:
+           UselessParentheses - a codestyle rule, and importing it would break
+             the ownership split stated above. Its 12 hits were all explicit
+             grouping in boolean and arithmetic expressions, where the parens
+             help the reader more than the rule does.
+           AvoidBranchingStatementAsLastInLoop - its single hit was a false
+             positive: a `break` that ends a first-match search whose earlier
+             paths `continue`, so the loop is not pointless. A rule whose only
+             finding is wrong costs more than it returns. -->
+    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable" />
+    <rule ref="category/java/design.xml/SimplifiedTernary" />
+    <rule ref="category/java/design.xml/CollapsibleIfStatements" />
+
+</ruleset>

--- a/springboot/config/spotbugs/exclude.xml
+++ b/springboot/config/spotbugs/exclude.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs / FindSecBugs exclusions for sec-api.
+
+  Analysis runs at effort=Max, threshold=Low, so the raw finding count is high
+  (268 on the first run). Each block below silences a CATEGORY that is either
+  structurally intentional in this codebase or has an unfavourable fix/benefit
+  ratio. Genuine findings were fixed in code, not listed here.
+
+  Rules for editing this file:
+    - Silence a category here only with a written justification.
+    - Silence a single intentional site with @SuppressFBWarnings in the code,
+      not here.
+    - Never add a bare <Bug pattern="..."/> with no <Package>/<Class> scope
+      unless it genuinely applies everywhere.
+-->
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/master/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- 1. Mutable-object exposure in JPA entities (30 EI_EXPOSE_REP +
+         48 EI_EXPOSE_REP2 across entities and records).
+         Hibernate REQUIRES live references to relationship collections;
+         defensive copying breaks dirty checking and lazy loading. For the
+         records, every one is constructed from List.of()/Map.ofEntries()/
+         stream().toList() and never mutated, and the canonical constructor
+         cannot copy without hand-writing a compact constructor for each.
+         This is how JPA and records work, not a defect. -->
+    <Match>
+        <Or>
+            <Bug pattern="EI_EXPOSE_REP" />
+            <Bug pattern="EI_EXPOSE_REP2" />
+            <Bug pattern="EI_EXPOSE_STATIC_REP2" />
+            <Bug pattern="MS_EXPOSE_REP" />
+        </Or>
+    </Match>
+
+    <!-- 2. FindSecBugs CRLF_INJECTION_LOGS (81 sites).
+         All are SLF4J parameterised logging of SEC-sourced identifiers
+         (tickers, CIKs, accession numbers) into CloudWatch, which is
+         structured storage rather than a text file a human greps. Sanitising
+         81 call sites is not a good trade for the risk.
+         REVISIT if user-supplied strings ever reach the logger. -->
+    <Match>
+        <Bug pattern="CRLF_INJECTION_LOGS" />
+    </Match>
+
+    <!-- 3. FindSecBugs SPRING_ENDPOINT (22 sites).
+         Fires on every @RequestMapping method. It is an inventory aid telling
+         you where your endpoints are, not a finding: having controllers is the
+         point of the service. Authorisation is enforced in SecurityConfig. -->
+    <Match>
+        <Bug pattern="SPRING_ENDPOINT" />
+    </Match>
+
+    <!-- 4. IMPROPER_UNICODE (20 sites).
+         Case-insensitive comparison of SEC tickers, CIKs, XBRL tags and form
+         types, all ASCII by construction. The Turkish-I class of bug needs
+         non-ASCII input, which cannot reach these paths.
+         REVISIT if any of these comparisons start handling user-entered text. -->
+    <Match>
+        <Bug pattern="IMPROPER_UNICODE" />
+    </Match>
+
+    <!-- 5. REC_CATCH_EXCEPTION (14 sites).
+         Every one is in a per-ticker or per-filing loop where the deliberate
+         policy is "log and continue to the next ticker" rather than aborting a
+         multi-hour ingest partway through. Narrowing these would change
+         runtime behaviour for the worse. -->
+    <Match>
+        <Bug pattern="REC_CATCH_EXCEPTION" />
+    </Match>
+
+    <!-- 6. THROWS_METHOD_THROWS_* (11 sites).
+         FindSecBugs style rules objecting to `throws Exception` and to
+         throwing RuntimeException. Both are deliberate here: the SEC client
+         wraps transport failures in RuntimeException so callers in the ingest
+         loops can treat any failure uniformly. Low signal, high churn. -->
+    <Match>
+        <Or>
+            <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION" />
+            <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE" />
+            <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION" />
+        </Or>
+    </Match>
+
+    <!-- 7. UPM_UNCALLED_PRIVATE_METHOD, scoped to two classes.
+         REVISIT - THIS IS UNRESOLVED, NOT INTENTIONAL. SpotBugs found five
+         genuinely dead private methods:
+           EtfCorporateActionService.evaluateIdentity
+           EtfCorporateActionService.extractDividendAmount
+           EtfCorporateActionService.extractEtfDateSignals
+           EtfCorporateActionService.loadFilingMeta
+           EquityDividendNormalizer.isLater
+         Roughly 150 lines. They are excluded rather than deleted because this
+         is live territory for the ETF/equity dividend accuracy work, and
+         whether they are abandoned or staged for an in-flight change is a
+         call for whoever owns that work, not for the commit that turns
+         SpotBugs on. Delete them (and this block) once that is settled.
+         Scoped to these two classes so new dead code elsewhere still fails. -->
+    <Match>
+        <Or>
+            <Class name="com.fattorestreet.sec_api.corporateaction.EtfCorporateActionService" />
+            <Class name="com.fattorestreet.sec_api.corporateaction.support.EquityDividendNormalizer" />
+        </Or>
+        <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD" />
+    </Match>
+
+    <!-- 8. REDOS, scoped to the corporate-action date extractors (20 sites).
+         REVISIT - THIS IS A REAL RISK, ACCEPTED FOR NOW, NOT A FALSE POSITIVE.
+         FindSecBugs flags the SEC filing date-extraction regexes for
+         catastrophic backtracking: they combine lazy bounded quantifiers
+         (.{0,900}?) with large month-name alternations. A pathological filing
+         could stall the nightly ingest.
+
+         Excluded rather than fixed because rewriting 20 interlocking regexes
+         is exactly the kind of change that silently degrades dividend and
+         split extraction accuracy, and this repo has dedicated accuracy-pass
+         workflows for that. It belongs in that work, not in the commit that
+         turns SpotBugs on.
+
+         Mitigating for now: input is SEC EDGAR filings, not user-supplied
+         text, and the ingest is a batch job rather than a request path.
+         If these regexes ever run against user input, fix before shipping.
+         The durable fix is a match timeout or possessive quantifiers. -->
+    <Match>
+        <Package name="~com\.fattorestreet\.sec_api\.corporateaction(\..*)?" />
+        <Bug pattern="REDOS" />
+    </Match>
+
+    <!-- 9. DE_MIGHT_IGNORE (5 sites).
+         Empty catch blocks in per-message and per-filing loops where skipping
+         the malformed item is the whole point. SpotBugs reads bytecode, so a
+         comment cannot satisfy it and the only "fix" would be logging inside
+         hot loops: PcapParser.extractTrades runs per IEX message and has no
+         logger by design, since it is tuned for throughput. Logging there
+         would cost more than the finding is worth. -->
+    <Match>
+        <Or>
+            <Class name="com.fattorestreet.sec_api.util.PcapParser" />
+            <Class name="com.fattorestreet.sec_api.fundamentals.EdgarService" />
+            <Class name="com.fattorestreet.sec_api.corporateaction.CorporateActionFilingDateService" />
+        </Or>
+        <Bug pattern="DE_MIGHT_IGNORE" />
+    </Match>
+
+    <!-- 10. Minor style findings with no correctness content:
+         SIC_INNER_SHOULD_BE_STATIC_ANON - anonymous ParameterizedTypeReference
+           subclasses, which MUST be anonymous to carry the generic type token.
+         NM_CONFUSING - countryHQ() vs countryHq() on two unrelated records in
+           different packages that are never used together.
+         CT_CONSTRUCTOR_THROW - IwbHoldingsTickerSet validates its resource in
+           the constructor, which is correct fail-fast behaviour for a bean. -->
+    <Match>
+        <Or>
+            <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON" />
+            <Bug pattern="NM_CONFUSING" />
+            <Bug pattern="CT_CONSTRUCTOR_THROW" />
+        </Or>
+    </Match>
+
+</FindBugsFilter>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -53,6 +53,7 @@
 		<jacoco.line.minimum>0.76</jacoco.line.minimum>
 		<spotbugs.annotations.version>4.9.6</spotbugs.annotations.version>
 		<pmd.plugin.version>3.27.0</pmd.plugin.version>
+		<errorprone.version>2.36.0</errorprone.version>
 	</properties>
 	<dependencies>
 		<!-- @SuppressFBWarnings only; provided+optional so it never ships in the jar -->
@@ -356,5 +357,56 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<!-- Error Prone runs as a javac plugin during `compile`, which the Docker
+		     build stage reaches via `package`. Unlike the other gates it cannot be
+		     turned off with a <skip> parameter, so it lives in a profile that
+		     deactivates whenever -Dquality.skip is passed on the command line.
+		     Maven property activation inspects command-line -D and settings.xml,
+		     not the <properties> block, so the default quality.skip=false above
+		     does NOT deactivate it for a normal build. -->
+		<profile>
+			<id>errorprone</id>
+			<activation>
+				<property>
+					<name>!quality.skip</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<compilerArgs>
+								<arg>-XDcompilePolicy=simple</arg>
+								<arg>--should-stop=ifError=FLOW</arg>
+								<!-- Default severities: ERROR-tier checks fail the build,
+								     WARNING-tier ones are advisory. The tree is clean at
+								     ERROR tier today, so this gate starts green.
+								     The :OFF list below silences pure-style checks that
+								     would drown the warnings worth reading. Do not add a
+								     check here without saying why it does not apply. -->
+								<arg>-Xplugin:ErrorProne \
+								    -Xep:MissingSummary:OFF \
+								    -Xep:NonApiType:OFF \
+								    -Xep:InlineFormatString:OFF \
+								    -Xep:MixedMutabilityReturnType:OFF \
+								    -Xep:ArrayRecordComponent:OFF</arg>
+							</compilerArgs>
+							<annotationProcessorPaths>
+								<path>
+									<groupId>com.google.errorprone</groupId>
+									<artifactId>error_prone_core</artifactId>
+									<version>${errorprone.version}</version>
+								</path>
+							</annotationProcessorPaths>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -51,8 +51,17 @@
 		     pass. Overridable on the command line so the gate itself can be
 		     tested (-Djacoco.line.minimum=0.95 should fail). -->
 		<jacoco.line.minimum>0.76</jacoco.line.minimum>
+		<spotbugs.annotations.version>4.9.6</spotbugs.annotations.version>
 	</properties>
 	<dependencies>
+		<!-- @SuppressFBWarnings only; provided+optional so it never ships in the jar -->
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<version>${spotbugs.annotations.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -288,10 +297,20 @@
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
 				<version>4.10.3.0</version>
+				<!-- Plugin-level so `spotbugs:check` works as a standalone goal too. -->
 				<configuration>
+					<skip>${quality.skip}</skip>
 					<effort>Max</effort>
+					<!-- Kept at Low deliberately. Raising to Medium would silence
+					     FindSecBugs patterns that report at Low while NOT silencing
+					     EI_EXPOSE_REP, which is already Medium, so the threshold is
+					     the wrong instrument. The exclude filter is the right one. -->
 					<threshold>Low</threshold>
 					<xmlOutput>true</xmlOutput>
+					<htmlOutput>true</htmlOutput>
+					<includeTests>false</includeTests>
+					<failOnError>true</failOnError>
+					<excludeFilterFile>config/spotbugs/exclude.xml</excludeFilterFile>
 					<plugins>
 						<plugin>
 							<groupId>com.h3xstream.findsecbugs</groupId>
@@ -300,6 +319,15 @@
 						</plugin>
 					</plugins>
 				</configuration>
+				<executions>
+					<execution>
+						<id>spotbugs-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -52,6 +52,7 @@
 		     tested (-Djacoco.line.minimum=0.95 should fail). -->
 		<jacoco.line.minimum>0.76</jacoco.line.minimum>
 		<spotbugs.annotations.version>4.9.6</spotbugs.annotations.version>
+		<pmd.plugin.version>3.27.0</pmd.plugin.version>
 	</properties>
 	<dependencies>
 		<!-- @SuppressFBWarnings only; provided+optional so it never ships in the jar -->
@@ -290,6 +291,30 @@
 								<exclude>com/fattorestreet/sec_api/SecApiApplication.class</exclude>
 							</excludes>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${pmd.plugin.version}</version>
+				<configuration>
+					<skip>${quality.skip}</skip>
+					<rulesets>
+						<ruleset>config/pmd/ruleset.xml</ruleset>
+					</rulesets>
+					<includeTests>false</includeTests>
+					<printFailingErrors>true</printFailingErrors>
+					<failOnViolation>true</failOnViolation>
+					<linkXRef>false</linkXRef>
+				</configuration>
+				<executions>
+					<execution>
+						<id>pmd-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
 					</execution>
 				</executions>
 			</plugin>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -44,6 +44,13 @@
 		<spotless.version>2.46.1</spotless.version>
 		<checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
 		<checkstyle.version>10.26.1</checkstyle.version>
+
+		<!-- Coverage floor enforced by jacoco:check at verify. Actual at the time
+		     CI started running verify: 81.5% line, 61.9% branch. Raise this
+		     deliberately when coverage improves; never lower it to make a build
+		     pass. Overridable on the command line so the gate itself can be
+		     tested (-Djacoco.line.minimum=0.95 should fail). -->
+		<jacoco.line.minimum>0.76</jacoco.line.minimum>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -265,7 +272,7 @@
 										<limit>
 											<counter>LINE</counter>
 											<value>COVEREDRATIO</value>
-											<minimum>0.76</minimum>
+											<minimum>${jacoco.line.minimum}</minimum>
 										</limit>
 									</limits>
 								</rule>

--- a/springboot/src/main/java/com/fattorestreet/sec_api/client/WebService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/client/WebService.java
@@ -28,6 +28,8 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 @Service
 public class WebService {
     private static final Logger log = LoggerFactory.getLogger(WebService.class);
@@ -318,6 +320,13 @@ public class WebService {
         return response.getBody();
     }
 
+    @SuppressFBWarnings(
+            value = "BC_VACUOUS_INSTANCEOF",
+            justification = "SecRequestOperation declares no checked exceptions today, so the"
+                    + " catch can only ever hold a RuntimeException and SpotBugs reads the"
+                    + " instanceof as vacuous. It is kept deliberately: if the interface ever"
+                    + " gains a checked exception, this is what keeps the wrapping correct"
+                    + " instead of throwing a ClassCastException.")
     private <T> ResponseEntity<T> executeSecRequestWithRetry(
             String requestLabel,
             SecRequestOperation<T> operation) {

--- a/springboot/src/main/java/com/fattorestreet/sec_api/controller/AdminController.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/controller/AdminController.java
@@ -287,11 +287,11 @@ public class AdminController {
             long startTime = System.currentTimeMillis();
             Map<String, Object> result;
             if (ticker != null && !ticker.isBlank()) {
-                Asset asset = assetRepository.findByListings_Ticker(ticker.toUpperCase());
+                Asset asset = assetRepository.findByListings_Ticker(ticker.toUpperCase(Locale.ROOT));
                 if (asset == null) {
                     return ResponseEntity.notFound().build();
                 }
-                result = filingSummaryService.summarizeTicker(ticker.toUpperCase(), asset);
+                result = filingSummaryService.summarizeTicker(ticker.toUpperCase(Locale.ROOT), asset);
             } else {
                 result = filingSummaryService.summarizeAll();
             }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionFilingDateService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionFilingDateService.java
@@ -563,7 +563,8 @@ public class CorporateActionFilingDateService {
         try {
             discovered = filingDiscoveryService.discoverFilings(cik);
         } catch (Exception ignored) {
-            discovered = Collections.emptyList();
+            // discovery failure means no candidates for this CIK; the initialiser
+            // above already holds that, so the run continues to the next ticker
         }
         Map<String, Integer> discoveredByForm = new TreeMap<>();
         Map<String, Integer> selectedByForm = new TreeMap<>();

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
@@ -118,10 +118,10 @@ public class CorporateActionValidationService {
                 if (amount > 0) {
                     out.add(new NormalizedEvent(ActionType.DIVIDEND, action.getEffectiveDate(), round4(amount), "sec"));
                 }
-            } else if (action.getActionType() == ActionType.SPLIT) {
-                if (action.getRatio() != null && action.getRatio() > 0) {
-                    out.add(new NormalizedEvent(ActionType.SPLIT, action.getEffectiveDate(), round4(action.getRatio()), "sec"));
-                }
+            } else if (action.getActionType() == ActionType.SPLIT
+                    && action.getRatio() != null
+                    && action.getRatio() > 0) {
+                out.add(new NormalizedEvent(ActionType.SPLIT, action.getEffectiveDate(), round4(action.getRatio()), "sec"));
             }
         }
         out.sort(Comparator.comparing(NormalizedEvent::date).thenComparing(NormalizedEvent::value));

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquitySplitDetector.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquitySplitDetector.java
@@ -242,7 +242,11 @@ public class EquitySplitDetector {
         if (existing != null) {
             double existingConfidence = existing.getConfidenceScore() != null ? existing.getConfidenceScore() : -1;
             boolean dateChanged = !effectiveDate.equals(existing.getEffectiveDate());
-            if (confidence < existingConfidence || (!dateChanged && confidence == existingConfidence)) {
+            // Double.compare, not ==: exact same semantics for these stored
+            // confidence scores, but well-defined for NaN and not a float
+            // equality test SpotBugs has to guess the intent of.
+            if (confidence < existingConfidence
+                    || (!dateChanged && Double.compare(confidence, existingConfidence) == 0)) {
                 return false;
             }
             if (dateChanged) {

--- a/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
@@ -113,7 +113,6 @@ public class EdgarService {
                     "paymentsForRepurchaseOfCommonStock", false));
 
     private static final class AnnualData {
-        int fiscalYear;
         LocalDate periodStart;
         LocalDate periodEnd;
         Map<String, Number> fields = new HashMap<>();
@@ -306,7 +305,6 @@ public class EdgarService {
                         AnnualData data = annualMap.get(cik);
                         if (data == null) {
                             data = new AnnualData();
-                            data.fiscalYear = node.has("fy") ? node.get("fy").asInt() : year;
                             data.periodStart = start;
                             data.periodEnd = end;
                             annualMap.put(cik, data);

--- a/springboot/src/main/java/com/fattorestreet/sec_api/index/IndexLoadRunner.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/index/IndexLoadRunner.java
@@ -13,6 +13,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * One-shot entrypoint for running the index load (metrics refresh + cap-ranked rebuilds) and then
  * exiting.
@@ -69,6 +71,12 @@ public class IndexLoadRunner implements ApplicationRunner {
     }
 
     @Override
+    @SuppressFBWarnings(
+            value = "DM_EXIT",
+            justification = "One-shot Fargate task: exiting the JVM with the load's status code is"
+                    + " how the task reports success or failure to EventBridge. SpringApplication.exit"
+                    + " runs shutdown hooks first, so this is the documented Spring Boot pattern for"
+                    + " a task that must propagate an exit code.")
     public void run(ApplicationArguments args) {
         int exitCode = runLoad();
         // Terminate the JVM so the ephemeral task stops. SpringApplication.exit runs shutdown hooks.

--- a/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/HistLoadRunner.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/HistLoadRunner.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Component;
 
 import com.fattorestreet.sec_api.corporateaction.PriceAdjustmentService;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * One-shot entrypoint for running the IEX HIST price load and then exiting.
  *
@@ -61,6 +63,12 @@ public class HistLoadRunner implements ApplicationRunner {
     }
 
     @Override
+    @SuppressFBWarnings(
+            value = "DM_EXIT",
+            justification = "One-shot Fargate task: exiting the JVM with the load's status code is"
+                    + " how the task reports success or failure to EventBridge. SpringApplication.exit"
+                    + " runs shutdown hooks first, so this is the documented Spring Boot pattern for"
+                    + " a task that must propagate an exit code.")
     public void run(ApplicationArguments args) {
         int exitCode = runLoad();
         // Terminate the JVM so the ephemeral task stops. SpringApplication.exit runs shutdown hooks.

--- a/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java
@@ -111,10 +111,9 @@ public class IexHistService {
         int errors = 0;
 
         CompletableFuture<Path> nextDownload = null;
-        DayTask nextTask = null;
 
         if (!toProcess.isEmpty()) {
-            nextTask = toProcess.get(0);
+            DayTask nextTask = toProcess.get(0);
             log.info("[{}] Prefetching TOPS ({} MB)...", nextTask.date, nextTask.sizeMb);
             nextDownload = startAsyncDownload(nextTask.link);
         }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/util/PcapParser.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/util/PcapParser.java
@@ -54,7 +54,10 @@ public final class PcapParser {
         Map<Long, String> symbolCache = new HashMap<>(16384);
 
         if (magic == PCAP_MAGIC_LE || magic == Integer.reverseBytes(PCAP_MAGIC_LE)) {
-            in.skipBytes(20);
+            // skipNBytes, not skipBytes: skipBytes may skip fewer bytes than asked
+            // and returns the count, so ignoring it silently desynchronises every
+            // subsequent read. skipNBytes loops and throws EOFException instead.
+            in.skipNBytes(20);
             return parsePcapPackets(in, consumer, symbolCache);
         } else if (magic == PCAPNG_SHB_MAGIC) {
             return parsePcapngBlocks(in, consumer, symbolCache);
@@ -103,7 +106,7 @@ public final class PcapParser {
         in.readFully(lenBytes);
         int shbLen = ByteBuffer.wrap(lenBytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
         int remaining = shbLen - 8;
-        if (remaining > 0) in.skipBytes(remaining);
+        if (remaining > 0) in.skipNBytes(remaining);
 
         byte[] blockHeader = new byte[8];
         byte[] blockData = new byte[65536];
@@ -136,7 +139,13 @@ public final class PcapParser {
                     }
                 }
             } else {
-                in.skipBytes(remaining);
+                try {
+                    in.skipNBytes(remaining);
+                } catch (EOFException e) {
+                    // truncated trailing block; matches the readFully EOF handling
+                    // above, which ends parsing rather than failing the file
+                    break;
+                }
             }
         }
         return tradeCount;


### PR DESCRIPTION
Stacked on #130. Final stage of the Java quality-gate series.

## The gating problem, and the fix

Error Prone runs as a **javac plugin during `compile`**, which the Docker build stage reaches via `package`. Unlike every other gate in this series it has **no `<skip>` parameter**, so it can't use the `quality.skip` switch directly.

It lives in a profile activated by `!quality.skip`. Maven property activation inspects command-line `-D` rather than the `<properties>` block, so the Dockerfile's `-Dquality.skip=true` deactivates it while a normal build keeps it on.

Verified with `help:active-profiles`:
- normal build → `errorprone` is listed as active
- `-Dquality.skip=true` → no active profiles, and the Dockerfile command emits **zero** Error Prone output

## `.mvn/jvm.config` is required, not optional

Error Prone forks javac internals and on JDK 16+ dies with the unhelpful `An unknown compilation problem occurred` without `--add-exports`/`--add-opens` into `jdk.compiler`. That's exactly what happened on the first run here. The file is discovered from the project base directory, so it works with both `./mvnw` and a bare `mvn`, and it isn't copied into the Docker build stage — which doesn't matter, because the profile is off there.

## The gate starts green

The tree is already clean at ERROR tier. Five pure-style checks are switched off (`MissingSummary`, `NonApiType`, `InlineFormatString`, `MixedMutabilityReturnType`, `ArrayRecordComponent`) — they were half the output and would have drowned the warnings worth reading.

## ⚠️ What remains is advisory, and one item deserves a real follow-up

**`JavaTimeDefaultTimeZone` — 16 sites.** `LocalDate.now()`, `LocalDateTime.now()` and `Year.now()` called with no `ZoneId`. In a service whose whole job is trading days, filing windows and dividend dates, **the server's default zone silently decides what "today" means**. Fixing it needs a decision on the right zone (`America/New_York` vs UTC) applied consistently — a domain change that doesn't belong in the commit that installs the tool.

Also flagged: `NarrowCalculation` (2 — int products that could overflow before being widened to `long`), `StringSplitter` (6), `EmptyCatch` (3), `NarrowingCompoundAssignment` (2), `UnusedMethod` (5 — the same dead methods SpotBugs found), `ThreadLocalUsage` (1).

## Verification

- `mvn verify` green across all six gates with 564 tests
- `clean package -DskipTests -Dquality.skip=true` (the Dockerfile command) succeeds
- `detect-secrets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)