### PR TITLE
stop the review seed from reopening a completed verdict check

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,8 +53,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          existing=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '[.check_runs[] | select(.name == env.CHECK_NAME)] | first | .id // empty')
+          # filter=all rather than the default filter=latest. Re-running this
+          # workflow resets its check suite, and the verdict check drops out of
+          # the "latest" view while that happens, so the default query answers
+          # "no check exists" on every re-run. The seed then reopens a check the
+          # verdict job had already completed, flipping a green PR back to
+          # pending with nothing left to complete it (the verdict job only fires
+          # on a new comment). Observed on PR #133.
+          #
+          # Read the first line in the shell instead of piping to head, which
+          # would close the pipe early and trip pipefail on a large page.
+          existing_ids=$(gh api --paginate \
+            "repos/${REPO}/commits/${HEAD_SHA}/check-runs?filter=all&per_page=100" \
+            --jq '.check_runs[] | select(.name == env.CHECK_NAME) | .id')
+          existing=${existing_ids%%$'\n'*}
           if [ -n "$existing" ]; then
             echo "Check run ${existing} already exists for ${HEAD_SHA}; leaving it alone."
             exit 0


### PR DESCRIPTION
## Summary

- The `seed` job in `claude-pr-review.yml` looked up the existing `Claude Review Verdict` check with the default `filter=latest`. Re-running the workflow resets its check suite, and the API-created verdict check drops out of the `latest` view while that happens, so the lookup answered "no check exists" and the seed POSTed a fresh `in_progress` check over one the `verdict` job had already completed.
- This is not cosmetic. The `verdict` job only fires on `issue_comment: created`, so once the seed reopens the check there is nothing left to complete it and the PR sits pending forever.
- Observed on #133: all three `pull_request` workflows hit `startup_failure` (a GitHub-side failure to start, the workflow files were byte-identical to `main` and re-ran clean), and re-running `Claude PR Review` flipped its green PASS back to pending.
- Fix: query with `filter=all` and `--paginate` so previous-attempt check runs stay visible, and read the first id with shell parameter expansion instead of piping to `head`, which would close the pipe early and trip `pipefail` on a full page.

The `verdict` job's lookup is deliberately left on `filter=latest`: it wants the newest check with that name, which is the right PATCH target even when a stale one exists alongside it.

## Test plan

- Ran the new lookup against the real API on #133's head SHA, which currently carries two check runs of that name. It returns both ids and picks the newest (`89700775726`); `filter=latest` returns only one.
- Ran the negative case (a name with no check runs): empty result, exit 0, so the `set -euo pipefail` script still falls through to the create path.
- Workflow YAML parses.
- Not verifiable until this is on `main`: `issue_comment` workflows always run the default-branch copy, and the re-run path needs a real re-run to exercise end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)