### PR TITLE
Migrate JsonNode.asText to asString for Jackson 3

### DIFF
--- a/springboot/src/main/java/com/fattorestreet/sec_api/controller/AdminController.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/controller/AdminController.java
@@ -545,7 +545,7 @@ public class AdminController {
         if (fieldsNode != null && fieldsNode.isArray() && dataNode != null && dataNode.isArray()) {
             List<String> fields = new ArrayList<>();
             for (JsonNode fieldNode : fieldsNode) {
-                String field = fieldNode.asText(null);
+                String field = fieldNode.asString(null);
                 fields.add(field == null ? "" : field);
             }
             for (JsonNode dataRow : dataNode) {
@@ -583,7 +583,7 @@ public class AdminController {
             if (value == null || value.isNull()) {
                 continue;
             }
-            String text = value.asText();
+            String text = value.asString();
             if (text != null && !text.isBlank()) {
                 return text.trim();
             }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/AdjustedPriceValidationService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/AdjustedPriceValidationService.java
@@ -255,7 +255,7 @@ public class AdjustedPriceValidationService {
                     djangoPortfolioBaseUrl,
                     encodedTicker));
             rows.forEach(row -> {
-                LocalDate date = parseIsoDate(row.path("date").asText(null));
+                LocalDate date = parseIsoDate(row.path("date").asString(null));
                 double value = row.path("value").asDouble(0.0);
                 if (date != null && !date.isBefore(minDateInclusive) && value > 0) {
                     out.put(date, value);

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
@@ -176,7 +176,7 @@ public class CorporateActionValidationService {
             return;
         }
         dividendsNode.forEach(row -> {
-            String dateText = row.path("date").asText(null);
+            String dateText = row.path("date").asString(null);
             double amount = row.path("amount").asDouble(0.0);
             if (amount <= 0) {
                 amount = row.path("value").asDouble(0.0);
@@ -193,7 +193,7 @@ public class CorporateActionValidationService {
             return;
         }
         splitsNode.forEach(row -> {
-            String dateText = row.path("date").asText(null);
+            String dateText = row.path("date").asString(null);
             LocalDate date = parseIsoDate(dateText);
             if (date == null || date.isBefore(minDateInclusive)) {
                 return;

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/EdgarFilingDiscoveryService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/EdgarFilingDiscoveryService.java
@@ -70,7 +70,7 @@ public class EdgarFilingDiscoveryService {
                 if (scanned >= Math.max(maxSubmissionFilesToScan, 0)) {
                     break;
                 }
-                String name = fileEntry.path("name").asText(null);
+                String name = fileEntry.path("name").asString(null);
                 if (name == null || name.isBlank()) {
                     continue;
                 }
@@ -104,10 +104,10 @@ public class EdgarFilingDiscoveryService {
                 for (JsonNode filing : filingsArray) {
                     addFilingRow(
                             out,
-                            filing.path("accessionNumber").asText(null),
-                            filing.path("form").asText(null),
-                            filing.path("primaryDocument").asText(null),
-                            parseIsoDate(filing.path("filingDate").asText(null)));
+                            filing.path("accessionNumber").asString(null),
+                            filing.path("form").asString(null),
+                            filing.path("primaryDocument").asString(null),
+                            parseIsoDate(filing.path("filingDate").asString(null)));
                 }
             }
         } catch (JacksonException ex) {
@@ -128,10 +128,10 @@ public class EdgarFilingDiscoveryService {
         for (int i = 0; i < count; i++) {
             addFilingRow(
                     out,
-                    accession.path(i).asText(null),
-                    forms.path(i).asText(null),
-                    primaryDocs.path(i).asText(null),
-                    parseIsoDate(filingDates.path(i).asText(null)));
+                    accession.path(i).asString(null),
+                    forms.path(i).asString(null),
+                    primaryDocs.path(i).asString(null),
+                    parseIsoDate(filingDates.path(i).asString(null)));
         }
     }
 

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/EtfCorporateActionService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/EtfCorporateActionService.java
@@ -299,7 +299,7 @@ public class EtfCorporateActionService {
                 JsonNode items = root.path("directory").path("item");
                 if (items.isArray()) {
                     for (JsonNode item : items) {
-                        String name = item.path("name").asText(null);
+                        String name = item.path("name").asString(null);
                         if (isLikelyDistributionDocument(name)) {
                             ordered.add(name);
                         }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityDividendFactParser.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityDividendFactParser.java
@@ -103,7 +103,7 @@ public class EquityDividendFactParser {
     }
 
     private EquityCorporateActionService.DividendFact parseDividendFactRow(JsonNode entry, String conceptName) {
-        String form = entry.has("form") ? entry.get("form").asText() : "";
+        String form = entry.has("form") ? entry.get("form").asString() : "";
         if (!isRelevantDividendForm(form)) {
             return null;
         }
@@ -112,14 +112,14 @@ public class EquityDividendFactParser {
         }
         LocalDate endDate;
         try {
-            endDate = LocalDate.parse(entry.get("end").asText());
+            endDate = LocalDate.parse(entry.get("end").asString());
         } catch (Exception ignored) {
             return null;
         }
         LocalDate startDate = null;
         if (entry.has("start")) {
             try {
-                startDate = LocalDate.parse(entry.get("start").asText());
+                startDate = LocalDate.parse(entry.get("start").asString());
             } catch (Exception ignored) {
                 startDate = null;
             }
@@ -131,7 +131,7 @@ public class EquityDividendFactParser {
         LocalDate filedDate = null;
         if (entry.has("filed")) {
             try {
-                filedDate = LocalDate.parse(entry.get("filed").asText());
+                filedDate = LocalDate.parse(entry.get("filed").asString());
             } catch (Exception ignored) {
                 filedDate = null;
             }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquitySplitDetector.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquitySplitDetector.java
@@ -78,7 +78,7 @@ public class EquitySplitDetector {
 
         List<SharesEntry> entries = new ArrayList<>();
         for (JsonNode entry : sharesNode) {
-            String form = entry.has("form") ? entry.get("form").asText() : "";
+            String form = entry.has("form") ? entry.get("form").asString() : "";
             if (!isRelevantSplitForm(form)) {
                 continue;
             }
@@ -86,7 +86,7 @@ public class EquitySplitDetector {
                 continue;
             }
             long val = entry.get("val").asLong();
-            LocalDate endDate = LocalDate.parse(entry.get("end").asText());
+            LocalDate endDate = LocalDate.parse(entry.get("end").asString());
             if (val > 0) {
                 entries.add(new SharesEntry(endDate, val));
             }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/FilingExtractionStore.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/FilingExtractionStore.java
@@ -222,11 +222,11 @@ public class FilingExtractionStore {
 
     private LocalDate parseDate(JsonNode node, String field) {
         JsonNode value = node.get(field);
-        if (value == null || value.isNull() || value.asText().isBlank()) {
+        if (value == null || value.isNull() || value.asString().isBlank()) {
             return null;
         }
         try {
-            return LocalDate.parse(value.asText());
+            return LocalDate.parse(value.asString());
         } catch (Exception e) {
             return null;
         }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/economic/FredService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/economic/FredService.java
@@ -70,11 +70,11 @@ public class FredService {
         for (JsonNode observation : root.path("observations")) {
             double value;
             try {
-                value = Double.parseDouble(observation.path("value").asText());
+                value = Double.parseDouble(observation.path("value").asString());
             } catch (NumberFormatException e) {
                 continue; // FRED marks missing values with "."
             }
-            result.add(new FredObservation(LocalDate.parse(observation.path("date").asText()), value));
+            result.add(new FredObservation(LocalDate.parse(observation.path("date").asString()), value));
         }
         result.sort(Comparator.comparing(FredObservation::date));
         return result;

--- a/springboot/src/main/java/com/fattorestreet/sec_api/filing/FilingSummaryService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/filing/FilingSummaryService.java
@@ -131,13 +131,13 @@ public class FilingSummaryService {
         int summarized = 0;
 
         for (int i = 0; i < forms.size(); i++) {
-            if (!"10-K".equals(forms.get(i).asText())) continue;
+            if (!"10-K".equals(forms.get(i).asString())) continue;
 
-            String accession = accessionNumbers.get(i).asText();
+            String accession = accessionNumbers.get(i).asString();
             if (filingSummaryRepository.existsByAccessionNumber(accession)) continue;
 
-            String filingDate = filingDates.get(i).asText();
-            String primaryDoc = primaryDocuments.get(i).asText();
+            String filingDate = filingDates.get(i).asString();
+            String primaryDoc = primaryDocuments.get(i).asString();
             String accessionPath = accession.replace("-", "");
 
             String filingUrl = String.format(SEC_ARCHIVES_URL, asset.getCik(), accessionPath, primaryDoc);
@@ -245,7 +245,7 @@ public class FilingSummaryService {
             ResponseEntity<String> response = restTemplate.exchange(
                     url, HttpMethod.POST, entity, String.class);
             JsonNode root = objectMapper.readTree(response.getBody());
-            return root.path("choices").get(0).path("message").path("content").asText();
+            return root.path("choices").get(0).path("message").path("content").asString();
         } catch (Exception e) {
             log.error("LLM call failed: {}", e.getMessage());
             return null;

--- a/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
@@ -186,8 +186,8 @@ public class EdgarService {
                         if (asset == null)
                             continue;
 
-                        String startStr = node.has("start") ? node.get("start").asText() : null;
-                        String endStr = node.get("end").asText();
+                        String startStr = node.has("start") ? node.get("start").asString() : null;
+                        String endStr = node.get("end").asString();
                         LocalDate start = startStr != null ? LocalDate.parse(startStr) : LocalDate.parse(endStr);
                         LocalDate end = LocalDate.parse(endStr);
 
@@ -206,7 +206,7 @@ public class EdgarService {
                             year = Integer.parseInt(period.substring(2, 6));
                         }
                         if (node.has("fp")) {
-                            String fp = node.get("fp").asText();
+                            String fp = node.get("fp").asString();
                             if (fp.equalsIgnoreCase("Q1"))
                                 qtr = 1;
                             else if (fp.equalsIgnoreCase("Q2"))
@@ -286,8 +286,8 @@ public class EdgarService {
                         if (!assetMap.containsKey(cik))
                             continue;
 
-                        String startStr = node.has("start") ? node.get("start").asText() : null;
-                        String endStr = node.get("end").asText();
+                        String startStr = node.has("start") ? node.get("start").asString() : null;
+                        String endStr = node.get("end").asString();
                         if (startStr == null)
                             continue; // Flow concepts must have a start date
 
@@ -680,17 +680,17 @@ public class EdgarService {
                         if (!entry.has("end"))
                             continue;
 
-                        String endStr = entry.get("end").asText();
+                        String endStr = entry.get("end").asString();
                         LocalDate endDate = LocalDate.parse(endStr);
                         int fy = entry.has("fy") ? entry.get("fy").asInt() : 0;
-                        String fp = entry.has("fp") ? entry.get("fp").asText() : null;
+                        String fp = entry.has("fp") ? entry.get("fp").asString() : null;
 
                         LocalDate startDate = null;
                         int durationMonths = 0; // 0 for stock/instant
 
                         if (entry.has("start")) {
                             try {
-                                startDate = LocalDate.parse(entry.get("start").asText());
+                                startDate = LocalDate.parse(entry.get("start").asString());
                                 long days = java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate);
 
                                 // Approximate duration logic for bucketing
@@ -720,7 +720,7 @@ public class EdgarService {
                         JsonNode valNode = entry.get("val");
                         Object value = valNode.isNumber()
                                 ? (valNode.isFloatingPointNumber() ? valNode.asDouble() : valNode.asLong())
-                                : valNode.asText();
+                                : valNode.asString();
 
                         // Key by End Date for grouping similar durations
                         dataPoints.computeIfAbsent(endStr, k -> new HashMap<>()).putIfAbsent(durationMonths,

--- a/springboot/src/main/java/com/fattorestreet/sec_api/index/SecIndexFactsParser.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/index/SecIndexFactsParser.java
@@ -270,7 +270,7 @@ public final class SecIndexFactsParser {
             if (!n.has("val") || !n.has("end")) {
                 continue;
             }
-            LocalDate d = LocalDate.parse(n.get("end").asText());
+            LocalDate d = LocalDate.parse(n.get("end").asString());
             if (bestDate == null || d.isAfter(bestDate)) {
                 bestDate = d;
                 best = n;
@@ -284,10 +284,10 @@ public final class SecIndexFactsParser {
 
     private static String textOrNull(JsonNode node, String field) {
         JsonNode child = node.get(field);
-        if (child == null || child.isNull() || child.asText().isBlank()) {
+        if (child == null || child.isNull() || child.asString().isBlank()) {
             return null;
         }
-        return child.asText();
+        return child.asString();
     }
 
     private static JsonNode firstArrayUnit(JsonNode units) {

--- a/springboot/src/main/java/com/fattorestreet/sec_api/listing/EtfIdentityService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/listing/EtfIdentityService.java
@@ -141,7 +141,7 @@ public class EtfIdentityService {
         if (fieldsNode != null && fieldsNode.isArray() && dataNode != null && dataNode.isArray()) {
             List<String> fields = new ArrayList<>();
             for (JsonNode fieldNode : fieldsNode) {
-                String field = fieldNode.asText(null);
+                String field = fieldNode.asString(null);
                 fields.add(field == null ? "" : field);
             }
             for (JsonNode dataRow : dataNode) {
@@ -176,7 +176,7 @@ public class EtfIdentityService {
             if (value == null || value.isNull()) {
                 continue;
             }
-            String text = value.asText();
+            String text = value.asString();
             if (text != null && !text.isBlank()) {
                 return text.trim();
             }


### PR DESCRIPTION
**PR 2 of 5** — base `linters/00-foundation`, not `main`.

Spring Boot 4.1 pulls Jackson 3.1.4, which deprecated `asText` in favour of `asString`. These **44 call sites were the entire deprecation surface of the module** — nothing else in main or test sources is deprecated.

### Why this is safe

Verified against the shipped `JsonNode.class` before touching anything:

```
public abstract String asString();
public abstract String asString(String);
public final    String asText();      // delegates
public          String asText(String);
```

Identical signatures, and `asText()` is `final` and delegates to `asString()`. This is a **pure rename with no behaviour change**.

- 29 bare `asText()` → `asString()`
- 15 `asText(default)` → `asString(default)`
- 13 files, zero occurrences in test sources

`asInt` / `asLong` / `asDouble` are **not** deprecated and are deliberately untouched.

### Why it is its own PR

Large and entirely mechanical — it reviews far faster separated from the judgment-call changes in the rest of the stack. Every hunk is the same one-token substitution.

### Verification

`mvn verify` green, **564 tests**. Compiling with `-Dmaven.compiler.showDeprecation=true` reports **0 deprecation warnings**, down from 44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
