### PR TITLE
Quiet editor-only Java diagnostics and fix the real null-pointer sites

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "java.compile.nullAnalysis.mode": "automatic",
-    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.compile.nullAnalysis.mode": "disabled",
+    "java.configuration.updateBuildConfiguration": "automatic",
     "python.terminal.activateEnvironment": false
 }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
@@ -509,16 +509,16 @@ public class EdgarService {
         Long l = q.getLiabilities();
         Long e = q.getStockholdersEquity();
 
-        int present = (a != null ? 1 : 0) + (l != null ? 1 : 0) + (e != null ? 1 : 0);
-        if (present != 2)
-            return;
-
-        if (a == null)
+        // Exactly one of the three may be missing; derive it from assets = liabilities + equity.
+        // Spelling out each operand's null check (rather than counting non-nulls) is what lets
+        // the compiler see that the arithmetic below can never unbox a null.
+        if (a == null && l != null && e != null) {
             q.setAssets(l + e);
-        else if (l == null)
+        } else if (l == null && a != null && e != null) {
             q.setLiabilities(a - e);
-        else
+        } else if (e == null && a != null && l != null) {
             q.setStockholdersEquity(a - l);
+        }
     }
 
     public void updateFinancials(Asset asset) throws Exception {

--- a/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/IexHistService.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -125,7 +126,10 @@ public class IexHistService {
 
             Path tempFile = null;
             try {
-                tempFile = nextDownload.join();
+                // Non-null whenever this loop runs: the prefetch above is started under the same
+                // non-empty check that gates the loop. Asserted rather than assumed so a future
+                // edit that breaks the pairing fails loudly instead of NPEing mid-ingest.
+                tempFile = Objects.requireNonNull(nextDownload, "prefetch not started before ingest loop").join();
                 long dlMs = System.currentTimeMillis() - dayStart;
                 log.info("[{}] Download ready ({}s), parsing trades...", current.date, dlMs / 1000);
 
@@ -196,7 +200,6 @@ public class IexHistService {
         }, downloadExecutor);
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, List<Map<String, Object>>> fetchHistIndex() throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(HIST_INDEX_URL))


### PR DESCRIPTION
**PR 5 of 5** — base `linters/03-redos-timeout`, not `main`.

The VS Code Problems panel showed **167 diagnostics** for `springboot/` while `mvn verify` was fully green. Almost none were build gates:

| Count | What | Gate? |
|---|---|---|
| 99 | JDT annotation-based null-safety | No — editor only |
| 10 | `PcapTestData` / `TestJwtTokens` "cannot be resolved" | No — **phantom** |
| 5 | JDT raw-type | No — editor only |
| 4 | "Potential null pointer access" | No — but genuine |

### Two settings remove 109 of them, without touching a line of Java

**`java.compile.nullAnalysis.mode`: `automatic` → `disabled`** — the 99 null-safety warnings come from JDT reacting to Spring/JSpecify annotations on library signatures while this repo is unannotated. Clearing them legitimately would mean annotating all ~74 main files, and nothing in CI would enforce it. The flow-based "Potential null pointer access" check is separate and survives.

**`java.configuration.updateBuildConfiguration`: `interactive` → `automatic`** — the 10 unresolved-symbol errors are phantom: both files exist and all tests compile. The JDT workspace had drifted from `pom.xml` because a dismissed prompt leaves it stale.

### The 4 genuine null-pointer sites are fixed properly

**`IexHistService`** — `nextDownload` is provably non-null whenever the ingest loop runs (the prefetch is started under the same non-empty check that gates the loop), but the guard and the loop are separate statements so the compiler cannot see it. Asserted with `requireNonNull` so a future edit that breaks the pairing fails loudly instead of NPEing mid-ingest.

**`EdgarService.deriveBalanceSheetFields`** — counted non-nulls, then dereferenced based on the count. Provably safe, unprovable to the compiler, and the counter hid the accounting identity. Rewritten to check each operand explicitly: same behaviour, states `assets = liabilities + equity` plainly, and no unprovable unboxing.

Also drops a now-unnecessary `@SuppressWarnings("unchecked")` on `fetchHistIndex`, whose body is type-safe via `TypeReference`.

### Left alone

The 5 JDT raw-type warnings. `-Werror` deliberately does not enable `-Xlint:rawtypes`/`unchecked`, which Spring and JPA generics would make noise.

### Verification

`mvn verify` green, **569 tests**. Reload the VS Code Java workspace to see the editor drop from 167 diagnostics to roughly 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
