### PR TITLE
Scoped AWS identity for local work, plus ECR publish from CI

### DIFF
--- a/.claude/plans/fizzy-meandering-lark.md
+++ b/.claude/plans/fizzy-meandering-lark.md
@@ -74,6 +74,34 @@ re-plan to confirm clean. Skipping the click puts it straight back into this
 state. Worth also confirming the address is right, since a typo'd endpoint
 reproduces this exact symptom forever.
 
+## 1a. The pending apply, and why it needs CloudShell (2026-07-26)
+
+`terraform plan` now returns **3 to add, 3 to change, 2 to destroy**:
+
+| Resource | Action | Why |
+|---|---|---|
+| `aws_ecs_task_definition.this` | replace | new revision carrying `SEC_CONTACT_EMAIL` (§3b) |
+| `aws_ecs_task_definition.index_load` | replace | same |
+| `aws_scheduler_schedule.this` | update | repoint at the new revision |
+| `aws_scheduler_schedule.index_load` | update | same |
+| `aws_iam_role_policy.scheduler_run_task` | update | drop the pinned revision ARNs |
+| `aws_sns_topic_subscription.task_failures_email[0]` | create | §1 |
+
+The two `destroy` entries are the old task-definition revisions being replaced,
+not anything being lost.
+
+**This apply cannot run locally.** `aws_iam_role_policy.scheduler_run_task`
+requires `iam:PutRolePolicy`, and `iam:Put*` is an explicit deny in
+`fattorestreet-developer-guardrails.json`, which beats every allow. Run it from
+CloudShell as an admin.
+
+The scheduler policy change is what stops this recurring. It previously listed
+both `family:*` and the exact current revision ARN, so every task-definition edit
+rewrote the policy and turned a routine apply into an IAM write. `family:*`
+already matches every revision, so the pinned entries were redundant; the
+schedules still pass the pinned ARN as the RunTask target and remain authorized.
+After this one apply, task-definition changes stay inside the developer role.
+
 ## 2. Repo changes (done 2026-07-26)
 
 Two items from the original step 4 needed no work: `.claude/settings.json`

--- a/.claude/plans/fizzy-meandering-lark.md
+++ b/.claude/plans/fizzy-meandering-lark.md
@@ -90,17 +90,42 @@ reproduces this exact symptom forever.
 The two `destroy` entries are the old task-definition revisions being replaced,
 not anything being lost.
 
-**This apply cannot run locally.** `aws_iam_role_policy.scheduler_run_task`
-requires `iam:PutRolePolicy`, and `iam:Put*` is an explicit deny in
-`fattorestreet-developer-guardrails.json`, which beats every allow. Run it from
-CloudShell as an admin.
+One of those six needs a credential this role does not have.
+`aws_iam_role_policy.scheduler_run_task` requires `iam:PutRolePolicy`, and
+`iam:Put*` is an explicit deny in `fattorestreet-developer-guardrails.json`,
+which beats every allow.
 
-The scheduler policy change is what stops this recurring. It previously listed
-both `family:*` and the exact current revision ARN, so every task-definition edit
-rewrote the policy and turned a routine apply into an IAM write. `family:*`
-already matches every revision, so the pinned entries were redundant; the
-schedules still pass the pinned ARN as the RunTask target and remain authorized.
-After this one apply, task-definition changes stay inside the developer role.
+**CloudShell does not solve this**, which was the first answer here and it was
+wrong. State is local and `*.tfstate` / `*.tfvars` are both gitignored, so a
+CloudShell clone has `main.tf` and nothing to apply it against. Shipping state up
+and back is possible but puts the only copy on a round trip.
+
+Instead: paste the rendered policy into the console once (IAM → role
+`fattorestreet-hist-load-sched-*` → inline policy `run-task`), then
+`terraform apply` from the Mac. Terraform refreshes, finds the policy already
+matching, plans no change to it, and never calls `iam:PutRolePolicy`. Exact JSON:
+
+```
+terraform console -plan <<< 'data.aws_iam_policy_document.scheduler_run_task.json'
+```
+
+That only holds because the document is now **static**. It originally built its
+resource list from `aws_ecs_task_definition.*.arn_without_revision`, which is
+unknown at plan time whenever a task definition is replaced. Terraform therefore
+planned a policy update on every apply regardless of what AWS already held, so a
+hand-edit would not have helped and each task-definition change dragged in an IAM
+write. Composing the ARNs from `var.name_prefix` / `var.index_load_name_prefix`
+and `data.aws_caller_identity` makes it known at plan time and invariant across
+task-definition replacement. `family:*` matches every revision, and the schedules
+still pass the pinned ARN as the RunTask target, so authorization is unchanged.
+
+### Longer term: remote state
+
+Local state on one laptop is the reason this is awkward, and it is also a single
+point of failure. An S3 backend with native locking would let CloudShell, CI, or
+a second machine apply. Not done here: the bucket is itself admin work, since the
+guardrails deny S3 outright. Worth doing before a second person or CI ever needs
+to apply.
 
 ## 2. Repo changes (done 2026-07-26)
 

--- a/.claude/plans/fizzy-meandering-lark.md
+++ b/.claude/plans/fizzy-meandering-lark.md
@@ -1,0 +1,153 @@
+# Scoped AWS identity for local + Claude Code work
+
+> **Status 2026-07-26: the identity is built and verified.** Sections below are
+> rewritten around what is left. The original design rationale is unchanged and
+> kept in "Identity model"; the console click-path lives in
+> `deploy/iam/CONSOLE-SETUP.md`.
+
+## Where things stand
+
+All local AWS access used to run through IAM user `Spike`, a member of group
+`Admin` (`AdministratorAccess`), via a long-lived static key in `~/.aws/credentials`
+`[default]`. That key was deactivated, which broke the local CLI, Terraform, SSM,
+and ECR push. GitHub Actions was never affected: it uses OIDC role
+`github-deploy-fattorestreet` and stores no key.
+
+**Done:**
+
+- Five policy documents committed to `deploy/iam/`, with `<ACCOUNT_ID>` / `<VPC_ID>`
+  placeholders, plus `render.sh` to substitute them into a temp dir and
+  `CONSOLE-SETUP.md` for the browser click-path
+- IAM user `claude-code` (no password, no group) with one inline policy:
+  `sts:AssumeRole` on `FattoreStreetDeveloper`
+- IAM role `FattoreStreetDeveloper` with the three managed policies attached,
+  4h max session duration, trusted by `user/claude-code` and `user/Spike`
+- One access key, on the Mac only, `[fattorestreet-bootstrap]` +
+  `[profile fattorestreet]` in `~/.aws/`
+- `deploy/DEPLOY.md` §5 and the `aws-inspect` skill's identity row updated
+
+**Verified 2026-07-26** under `AWS_PROFILE=fattorestreet`:
+
+- `sts:GetCallerIdentity` → `assumed-role/FattoreStreetDeveloper/claude-code`, `AROA…`
+- Reads: ECR (3 images), ECS cluster `ACTIVE` / 0 tasks, both schedules `ENABLED`,
+  both log groups at 30-day retention
+- All 8 guardrails deny: self-minting a key, attaching `AdministratorAccess`,
+  role chaining (all three roles), `GetSecretValue`, `us-west-2`, S3, RDS, Lambda
+- `terraform plan` reaches AWS and refreshes every resource
+
+## Identity model (unchanged)
+
+The user holds one permission and nothing else. The role carries the grants, so
+the key on disk is worthless alone, sessions expire hourly and refresh
+transparently, and CloudTrail attributes every call to
+`assumed-role/FattoreStreetDeveloper/claude-code`. No `mfa_serial`, deliberately:
+an MFA prompt would block every non-interactive call. The role has **no IAM
+write** and **no `GetSecretValue`**; IAM changes are applied by a human from
+CloudShell.
+
+---
+
+# What is left
+
+## 1. SNS failure alerts are not being delivered (found during verification)
+
+`terraform plan` returns `1 to add`, not "No changes":
+
+```
++ aws_sns_topic_subscription.task_failures_email[0]
+```
+
+This is **real drift, not a missing permission**. The read succeeds and returns a
+real answer: `sns list-subscriptions` → `0`, and `get-topic-attributes` →
+`SubscriptionsConfirmed 0 / Pending 0 / Deleted 0`, while Terraform state holds
+the subscription with `pending_confirmation = true`. The old admin key would have
+shown the same thing.
+
+Cause: the confirmation email to `johnefattore@gmail.com` was never clicked, and
+AWS deletes unconfirmed email subscriptions after 3 days. The topic dates from
+2026-07-19, so **nightly load failures have alerted nobody since ~2026-07-22**.
+The EventBridge rule and topic are fine; there is simply no subscriber, and a
+failed nightly run currently fails silently.
+
+Fix: `terraform apply`, then **click the confirmation link in the email**, then
+re-plan to confirm clean. Skipping the click puts it straight back into this
+state. Worth also confirming the address is right, since a typo'd endpoint
+reproduces this exact symptom forever.
+
+## 2. Repo changes (done 2026-07-26)
+
+Two items from the original step 4 needed no work: `.claude/settings.json`
+already had the read-only AWS allowlist and a `deny` on `get-secret-value`, and
+`.claude/rules/infrastructure.md` already had correct `paths:` frontmatter. Both
+landed in `bd37eda5`, after this plan was written.
+
+Applied:
+
+- **`.claude/settings.json`**: `env` block with `AWS_PROFILE=fattorestreet`,
+  `AWS_REGION`/`AWS_DEFAULT_REGION=us-east-1`, so no call needs `--profile`. The
+  allowlist is unchanged; writes (`run-task`, `send-command`, `get-login-password`,
+  `terraform apply`) still prompt on purpose.
+- **`.claude/rules/infrastructure.md`**: new **AWS credentials** section, including
+  the rule that `AccessDenied` means widen the policy in `deploy/iam/` and have a
+  human apply it, never reach for another credential.
+- **`springboot/deploy/terraform/README.md`**: **Credentials** section above
+  `## Deploy`, noting that IAM changes in `main.tf` fail on `apply` and belong in
+  CloudShell.
+- **`docs/DEPLOYMENT.md`**: bullet in the AWS hosting list.
+- **`CLAUDE.md`**: Infra bullet extended with the scoped-profile clause.
+
+## 3. Verification still outstanding
+
+Both are writes, so they need a go-ahead:
+
+- **SSM send-command**: `describe-instance-information`, then `docker ps` against
+  `Key=tag:App,Values=fattorestreet`, read back with `get-command-invocation`.
+  Exercises the `ops` policy's tag-gated `SendCommand`.
+- **ECS run-task**: the single-ticker `index-load` override from
+  `springboot/deploy/terraform/README.md:121`, then `describe-tasks` for
+  `exitCode 0`. Exercises `RunTask` + `PassRole`.
+- **Session Manager** (interactive, so yours): `aws ssm start-session --target <INSTANCE_ID>`.
+- **ECR push**: only meaningfully tested by an actual push; CI already covers this
+  path, so a local `get-login-password` + `docker login` is the cheap check.
+
+## 4. Key cleanup (only after the above passes)
+
+This identity cannot inspect IAM users: `iam:ListAccessKeys` on `user/Spike`
+returns `AccessDenied`, since `IamReadOnly` is scoped to `role/fattorestreet-*`.
+That is by design, so all of this is console or CloudShell work.
+
+1. Delete the deactivated key `AKIAS3LMQGO5KVGCRH32`, and remove its `[default]`
+   block from `~/.aws/credentials` if still present.
+2. The 2023 key `AKIAS3LMQGO5G7HTDRO3` is the larger exposure: 2.5 years old,
+   admin, on a Linux host that is not this Mac, last used 2026-06-21 for
+   `ecr:ListImages`. Its CloudTrail history is entirely describe/list plus
+   `secretsmanager:DescribeSecret`, exactly what `EC2FattoreStreetRole` already
+   grants that host. So: confirm the host is the EC2 instance, delete
+   `~/.aws/credentials` on it (the CLI then falls through to IMDS), then delete
+   the key. If it is a non-AWS box, give it its own scoped user rather than
+   leaving admin on it.
+3. End state: `Spike` keeps console password + MFA + `Admin` as break-glass and
+   holds **zero** access keys. Every programmatic identity is then OIDC (CI), an
+   instance/task role, or an assumed scoped role (laptop).
+4. The role denies `iam:CreateAccessKey`, so the `claude-code` key cannot rotate
+   itself. Rotation is a deliberate console action; worth a 90-day reminder.
+
+## 5. Ship it
+
+One branch, one PR, combining the ECR-publish/aws-inspect commit (`bd37eda5`,
+unpushed) with the scoped-identity work. They are the same story: CI stopped
+drifting between registries, and local access stopped being an admin key.
+
+Note `bd37eda5`'s `aws-inspect` skill advertised `IAM user Spike, keys in
+~/.aws/credentials, Admin group (AdministratorAccess)` on a public repo. That
+line is rewritten to describe the scoped profile, so it never reaches public
+history. Keep it that way.
+
+## Non-secrets, for the record
+
+`<ACCOUNT_ID>` and `<VPC_ID>` are placeholders out of habit, not because either
+is sensitive. The account ID has been public in this repo's history since
+January 2024 (ECR image URIs in an old `docker-compose.yml`) and is
+unretractable; it buys reconnaissance, never access. A VPC ID is inert outside
+the account. The convention matters because it generalizes to values that *are*
+sensitive: secret ARNs with their random suffix, instance IDs, subnet IDs.

--- a/.claude/plans/fizzy-meandering-lark.md
+++ b/.claude/plans/fizzy-meandering-lark.md
@@ -49,6 +49,13 @@ CloudShell.
 
 # What is left
 
+> **Applied and verified 2026-07-27.** Both task definitions now carry
+> `SEC_CONTACT_EMAIL` (hist-load rev 3, index-load rev 2), both schedules target
+> those revisions and are `ENABLED`, the SNS subscription is confirmed
+> (`SubscriptionsConfirmed 1`), and `terraform plan` reports **"No changes."**
+> Sections 1 and 3 below are the diagnosis, kept for the record; §6 is what the
+> apply actually took.
+
 ## 1. SNS failure alerts are not being delivered (found during verification)
 
 `terraform plan` returns `1 to add`, not "No changes":
@@ -229,6 +236,47 @@ Note `bd37eda5`'s `aws-inspect` skill advertised `IAM user Spike, keys in
 ~/.aws/credentials, Admin group (AdministratorAccess)` on a public repo. That
 line is rewritten to describe the scoped profile, so it never reaches public
 history. Keep it that way.
+
+## 6. What the apply actually took (2026-07-27)
+
+Three obstacles, none of which needed an admin credential in the end.
+
+**a. The scheduler policy could not be written from here.**
+`aws_iam_role_policy.scheduler_run_task` needs `iam:PutRolePolicy`, denied by
+`DenyAllIamWrite`. CloudShell was the first answer and was wrong: state is local
+and both `*.tfstate` and `*.tfvars` are gitignored, so a clone there has nothing
+to apply against. Resolved by pasting the rendered document into the console by
+hand, after which Terraform found the policy already matching and dropped the
+resource from the plan entirely. `deploy/iam/temporary/` holds a revocable grant
+as an alternative; it went unused.
+
+This only worked because the document was first made **static** (`00a2ff95`).
+While it was built from `aws_ecs_task_definition.*.arn_without_revision`, it read
+as unknown at plan time whenever a task definition was replaced, so Terraform
+would have planned the write regardless of what AWS already held and the paste
+would have been ignored.
+
+**b. `ecs:DeregisterTaskDefinition` was denied.** `EcsTaskDefs` allows the action
+but scopes it to `task-definition/fattorestreet-*:*`, and the action takes **no
+resource-level permissions**, so it only ever matches on `"*"`. The tell is that
+AWS reports the denial against `resource: *` even though the statement names an
+ARN. Fixed with `skip_destroy = true` rather than widening the role.
+
+**c. `skip_destroy` could not apply to itself.** On a replacement the provider
+reads `skip_destroy` from the **prior state object**, not the new config. State
+held `false`, so the deregister was still attempted and the apply failed a second
+time. Broken with a two-step apply: drop the `SEC_CONTACT_EMAIL` lines so the
+only diff is `skip_destroy` (0 add / 2 change / 0 destroy, no API calls), apply
+that, restore the lines, then apply the replacement, which now skips the destroy.
+
+Superseded revisions stay `ACTIVE` by design (hist-load 2, index-load 1), which
+is the rollback: repoint a schedule at an earlier revision.
+
+**Still unverified:** that `SEC_CONTACT_EMAIL` exists as a key in
+`fattorestreet/env`. This role denies `GetSecretValue`, so it cannot be checked
+from here. If the key is absent the task now fails at container start with
+`ResourceInitializationError` instead of running and 403-ing, which is a worse
+failure mode. The next scheduled run settles it, and SNS alerts now work.
 
 ## Non-secrets, for the record
 

--- a/.claude/plans/fizzy-meandering-lark.md
+++ b/.claude/plans/fizzy-meandering-lark.md
@@ -96,19 +96,45 @@ Applied:
 - **`docs/DEPLOYMENT.md`**: bullet in the AWS hosting list.
 - **`CLAUDE.md`**: Infra bullet extended with the scoped-profile clause.
 
-## 3. Verification still outstanding
+## 3. Verification (done 2026-07-26)
 
-Both are writes, so they need a go-ahead:
+- **SSM send-command**: passed. `docker ps` against `Key=tag:App,Values=fattorestreet`
+  returned `Success` / `ResponseCode 0`, all six containers healthy. Exercises the
+  `ops` policy's tag-gated `SendCommand`.
+- **ECS run-task**: the grant passed. `RunTask` was accepted (so `PassRole` is scoped
+  right), and the task pulled from ECR, resolved both secrets, connected to Postgres,
+  and wrote logs. It exited 1 for application reasons, see below.
 
-- **SSM send-command**: `describe-instance-information`, then `docker ps` against
-  `Key=tag:App,Values=fattorestreet`, read back with `get-command-invocation`.
-  Exercises the `ops` policy's tag-gated `SendCommand`.
-- **ECS run-task**: the single-ticker `index-load` override from
-  `springboot/deploy/terraform/README.md:121`, then `describe-tasks` for
-  `exitCode 0`. Exercises `RunTask` + `PassRole`.
-- **Session Manager** (interactive, so yours): `aws ssm start-session --target <INSTANCE_ID>`.
-- **ECR push**: only meaningfully tested by an actual push; CI already covers this
-  path, so a local `get-login-password` + `docker login` is the cheap check.
+Still outstanding:
+
+- **Session Manager** (interactive, so yours): `aws ssm start-session --target i-09b3fa349b473e596`
+- **ECR push**: only meaningfully tested by an actual push, which CI already does.
+
+### Found by the run-task: two production bugs
+
+**a. Stale ECR image, silently degrading tasks to `server` mode.** Already fixed by
+`bd37eda5` in this PR, and confirmed. The 07-25 index-load ran for **23 hours**
+(09:30:28 → 08:38:30 next day) and `IndexLoadRunner` never fired; 07-24 and 07-20
+look identical, 58 startup events each and then Tomcat idling on 8080. ECR was
+serving images from 2026-07-01 and 2026-06-20. This is exactly the failure
+`.claude/rules/infrastructure.md` warns about, and it was billing Fargate the
+whole time. The 08:42 push today was the first image containing the runner, and
+the 09:30 run was the first to execute it.
+
+**b. `SEC_CONTACT_EMAIL` missing from both task definitions.** Fixed in this PR.
+`application.properties:44` reads `sec.contact-email=${SEC_CONTACT_EMAIL:}`,
+defaulting to empty, and `WebService.java:83` sends it as the User-Agent that SEC
+requires. Neither task definition passed it, so every ticker got
+`403 Undeclared Automated Tool` and the run exited non-zero having processed
+nothing. Added to the `secrets` block of both, sourced from the same
+`fattorestreet/env` JSON as `POSTGRES_PASSWORD` / `SECRET_KEY` (verified present
+in the live secret), so no new variable and no IAM change.
+
+Neither is verified end to end yet: that needs `terraform apply` plus a re-run.
+
+Note the two bugs compound. (a) hid (b): while the image lacked the runner, the
+SEC call never happened, so the missing env var could not surface. And the SNS
+gap in §1 hid both, since these runs have been exiting non-zero all along.
 
 ## 4. Key cleanup (only after the above passes)
 
@@ -116,9 +142,17 @@ This identity cannot inspect IAM users: `iam:ListAccessKeys` on `user/Spike`
 returns `AccessDenied`, since `IamReadOnly` is scoped to `role/fattorestreet-*`.
 That is by design, so all of this is console or CloudShell work.
 
-1. Delete the deactivated key `AKIAS3LMQGO5KVGCRH32`, and remove its `[default]`
-   block from `~/.aws/credentials` if still present.
-2. The 2023 key `AKIAS3LMQGO5G7HTDRO3` is the larger exposure: 2.5 years old,
+Key IDs are written truncated on purpose. They are identifiers, not credentials,
+but this repo is public and one of them is an active admin key; the last four
+characters are enough to pick the right row in the console, and publishing the
+full ID only helps someone enumerate. This is also why they are truncated rather
+than pragma-allowlisted: `.claude/rules/secrets-check.md` reserves pragmas for
+provable non-secrets, and an active admin key ID is not that.
+
+1. Delete the deactivated key ending `RH32` (created 2026-06-20 to run one
+   `terraform apply`), and remove its `[default]` block from `~/.aws/credentials`
+   if still present.
+2. The 2023 key ending `DRO3` is the larger exposure: 2.5 years old,
    admin, on a Linux host that is not this Mac, last used 2026-06-21 for
    `ecr:ListImages`. Its CloudTrail history is entirely describe/list plus
    `secretsmanager:DescribeSecret`, exactly what `EC2FattoreStreetRole` already

--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -1,37 +1,72 @@
 ---
 paths:
-  - "kubernetes/**"
+  - "deploy/**"
+  - "springboot/deploy/**"
   - "nginx/**"
-  - "aws/**"
   - "**/Dockerfile"
   - "**/docker-compose*"
+  - "**/*.tf"
 ---
 
 # Infrastructure Conventions
 
+There is no Kubernetes here. The stack is Docker Compose on a single Graviton EC2
+instance, plus two one-shot Fargate tasks managed by Terraform.
+
 ## Docker
 
 - Each service (`react-app`, `django`, `springboot`) has its own Dockerfile
-- Use multi-stage builds where applicable (e.g., Vite build stage then Nginx serve stage for the React app)
+- Use multi-stage builds where applicable (Vite build stage then Nginx serve stage for the React app)
+- Images are ARM64 (Graviton). Build with `docker buildx build --platform linux/arm64`
+- Images publish to GHCR as `ghcr.io/johnfattore/{nginx,django,springboot}`, tagged `latest` + commit SHA
 
-## Kubernetes
+## Deployment (`deploy/`)
 
-- Deployment manifests live in `kubernetes/`
-- `kubernetes/build.sh` builds container images; `kubernetes/run.sh` orchestrates deployment
-- Services: Django (Gunicorn), Spring Boot, React (Nginx), PostgreSQL, Redis
+- `deploy/docker-compose.yml` is the deploy unit (django, springboot, nginx);
+  `deploy/docker-compose.infra.yml` holds stateful infra (postgres, redis, pgadmin4)
+  and is never touched by a routine deploy
+- `deploy/deploy.sh` is the idempotent converge script run on the EC2 host as root by
+  SSM RunCommand; `deploy/compose.sh` is the operator runbook; `deploy/DEPLOY.md`
+  documents one-time setup
+- **CI is the build-and-publish path.** `.github/workflows/docker-build.yml` builds on
+  merge to `main`, pushes to GHCR, and deploys via `aws ssm send-command` targeting
+  instances tagged `App=fattorestreet`. `deploy/build.sh` is legacy/emergency only
+- `deploy/run.sh` is the pre-compose `docker run` reference, kept for historical detail;
+  don't extend it
+
+## Scheduled Fargate tasks (`springboot/deploy/terraform/`)
+
+- The nightly IEX HIST price load and index load run as **ephemeral Fargate tasks**, not
+  inside Django and not on the EC2 box. Terraform is the source of truth for the ECR repo,
+  ECS cluster, both task definitions, IAM roles, security group rule, EventBridge
+  schedules, and SNS failure alerting
+- Local state, no remote backend. `terraform apply` from `springboot/deploy/terraform/`
+- Run mode is selected purely by the `APP_RUN_MODE` env var (`server`, `hist-load`,
+  `index-load`) on the shared image. Adding a mode means a new `ApplicationRunner` gated
+  by `@ConditionalOnProperty(name = "app.run-mode", ...)` that calls `System.exit`
+- CI publishes the springboot image to **both** GHCR and ECR on merge to `main`, and the
+  task definitions pin `:latest`, so merging is what deploys a new run mode
+- **`terraform apply` is not a deploy.** A task definition can reference a runner the ECR
+  image does not contain, which silently degrades the task to `server` mode and leaves it
+  running (and billing) forever. Merge to `main` first, then apply, then check the cluster
+- A healthy cluster has **zero** running tasks between scheduled runs. Use the
+  `aws-inspect` skill to check live state
 
 ## Nginx
 
-- Config in `nginx/nginx.conf`
-- Acts as a reverse proxy routing to the three services
-- Static frontend assets are served directly by Nginx
+- Config in `nginx/nginx.conf` (`nginx.dev.conf` for local)
+- Reverse proxy routing to the three services; serves the static frontend assets directly
 
-## AWS
+## Secrets
 
-- Configs in `aws/` target EC2/Fargate and RDS
-- Database connection strings and secrets come from environment variables, never hardcoded
+- One AWS Secrets Manager secret, `fattorestreet/env`, a flat JSON shared by every service
+- EC2 containers receive only `SECRETS_ARN` and fetch the rest at start via each image's
+  `docker-entrypoint.sh`; Fargate injects individual keys natively through the task
+  definition's `secrets` block, so the entrypoint no-ops there
+- Never hardcode credentials or connection strings. See `.claude/rules/secrets-check.md`
 
 ## General
 
 - Always use environment variables for service URLs, database credentials, and API keys
 - Keep infrastructure config declarative and version-controlled
+- Region is `us-east-1` everywhere

--- a/.claude/rules/infrastructure.md
+++ b/.claude/rules/infrastructure.md
@@ -65,6 +65,24 @@ instance, plus two one-shot Fargate tasks managed by Terraform.
   definition's `secrets` block, so the entrypoint no-ops there
 - Never hardcode credentials or connection strings. See `.claude/rules/secrets-check.md`
 
+## AWS credentials
+
+- Local work runs as `AWS_PROFILE=fattorestreet`, set in `.claude/settings.json`. It
+  assumes role `FattoreStreetDeveloper` (IAM user `claude-code` can do nothing but
+  assume it), so sessions expire hourly and every call is attributable
+- **Never read or write `~/.aws/*`.** Profile setup is a human step:
+  `deploy/iam/CONSOLE-SETUP.md`
+- The policy JSON is versioned in `deploy/iam/`, with `<ACCOUNT_ID>` / `<VPC_ID>`
+  placeholders; `deploy/iam/render.sh` substitutes them into a temp dir outside the repo
+- The role has **no IAM write** and cannot call `secretsmanager:GetSecretValue`. Both are
+  explicit denies that beat any allow
+- On `AccessDenied`, the fix is to widen the policy in `deploy/iam/` and have a human
+  apply it from CloudShell. **Never reach for another credential**, never suggest
+  falling back to an admin key, and never work around it by shelling out to a
+  different profile
+- CI is unaffected by any of this: it authenticates through OIDC role
+  `github-deploy-fattorestreet` and stores no AWS key
+
 ## General
 
 - Always use environment variables for service URLs, database credentials, and API keys

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,53 @@
 {
-  "plansDirectory": ".claude/plans"
+  "plansDirectory": ".claude/plans",
+  "permissions": {
+    "allow": [
+      "Bash(aws sts get-caller-identity:*)",
+      "Bash(aws ecs list-clusters:*)",
+      "Bash(aws ecs list-tasks:*)",
+      "Bash(aws ecs list-services:*)",
+      "Bash(aws ecs list-task-definitions:*)",
+      "Bash(aws ecs describe-clusters:*)",
+      "Bash(aws ecs describe-tasks:*)",
+      "Bash(aws ecs describe-services:*)",
+      "Bash(aws ecs describe-task-definition:*)",
+      "Bash(aws logs tail:*)",
+      "Bash(aws logs describe-log-groups:*)",
+      "Bash(aws logs describe-log-streams:*)",
+      "Bash(aws logs filter-log-events:*)",
+      "Bash(aws logs get-log-events:*)",
+      "Bash(aws scheduler list-schedules:*)",
+      "Bash(aws scheduler get-schedule:*)",
+      "Bash(aws events list-rules:*)",
+      "Bash(aws events describe-rule:*)",
+      "Bash(aws events list-targets-by-rule:*)",
+      "Bash(aws ecr describe-repositories:*)",
+      "Bash(aws ecr describe-images:*)",
+      "Bash(aws ecr list-images:*)",
+      "Bash(aws ec2 describe-instances:*)",
+      "Bash(aws ec2 describe-instance-status:*)",
+      "Bash(aws ec2 describe-security-groups:*)",
+      "Bash(aws ec2 describe-subnets:*)",
+      "Bash(aws ec2 describe-vpcs:*)",
+      "Bash(aws ec2 describe-volumes:*)",
+      "Bash(aws cloudwatch get-metric-statistics:*)",
+      "Bash(aws cloudwatch get-metric-data:*)",
+      "Bash(aws cloudwatch list-metrics:*)",
+      "Bash(aws ce get-cost-and-usage:*)",
+      "Bash(aws ce get-cost-forecast:*)",
+      "Bash(aws secretsmanager list-secrets:*)",
+      "Bash(aws secretsmanager describe-secret:*)",
+      "Bash(aws sns list-topics:*)",
+      "Bash(aws sns list-subscriptions-by-topic:*)",
+      "Bash(aws ssm describe-instance-information:*)",
+      "Bash(aws iam list-attached-role-policies:*)",
+      "Bash(aws iam list-attached-user-policies:*)",
+      "Bash(aws iam list-groups-for-user:*)",
+      "Bash(aws iam list-roles:*)",
+      "Bash(aws iam get-role:*)"
+    ],
+    "deny": [
+      "Bash(aws secretsmanager get-secret-value:*)"
+    ]
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
   "plansDirectory": ".claude/plans",
+  "env": {
+    "AWS_PROFILE": "fattorestreet",
+    "AWS_REGION": "us-east-1",
+    "AWS_DEFAULT_REGION": "us-east-1"
+  },
   "permissions": {
     "allow": [
       "Bash(aws sts get-caller-identity:*)",

--- a/.claude/skills/aws-inspect/SKILL.md
+++ b/.claude/skills/aws-inspect/SKILL.md
@@ -25,7 +25,7 @@ into the transcript. Use `describe-secret` to inspect metadata instead.
 |---|---|
 | Account | `196185437114` |
 | Region | `us-east-1` (everything; no other region is in use) |
-| Local identity | IAM user `Spike`, keys in `~/.aws/credentials`, `Admin` group (AdministratorAccess) |
+| Local identity | `AWS_PROFILE=fattorestreet`, which assumes role `FattoreStreetDeveloper`. Read-heavy and non-admin: no IAM write, no `GetSecretValue`, `us-east-1` only. See `deploy/iam/` |
 | ECS cluster | `fattorestreet-hist-load` (the only one) |
 | ECS services | none, ever. Only one-shot scheduled tasks |
 | Task families | `fattorestreet-hist-load`, `fattorestreet-index-load` |

--- a/.claude/skills/aws-inspect/SKILL.md
+++ b/.claude/skills/aws-inspect/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: aws-inspect
+description: Answer ad-hoc questions about the live FattoreStreet AWS account (what is running, what it costs, why a scheduled task failed) by pulling data with read-only AWS CLI calls. Use when the user asks what is running in AWS, why a Fargate task or schedule misbehaved, what something is costing, or to check logs, images, or infrastructure state.
+---
+
+# AWS Inspect
+
+Answer questions about the live AWS account by querying it, not by reading Terraform.
+Terraform in `springboot/deploy/terraform/` describes what *should* exist; this skill
+exists because the two drift. Every real incident so far has been drift.
+
+## Hard rule: read-only
+
+Only run AWS CLI commands that read. Never run a mutating command (`run-task`,
+`stop-task`, `delete-*`, `put-*`, `update-*`, `create-*`, `terraform apply`) without
+stating what it will change and getting explicit approval first. Report the finding,
+propose the fix, let the user decide.
+
+`aws secretsmanager get-secret-value` is also off limits: it prints live credentials
+into the transcript. Use `describe-secret` to inspect metadata instead.
+
+## Account facts
+
+| Thing | Value |
+|---|---|
+| Account | `196185437114` |
+| Region | `us-east-1` (everything; no other region is in use) |
+| Local identity | IAM user `Spike`, keys in `~/.aws/credentials`, `Admin` group (AdministratorAccess) |
+| ECS cluster | `fattorestreet-hist-load` (the only one) |
+| ECS services | none, ever. Only one-shot scheduled tasks |
+| Task families | `fattorestreet-hist-load`, `fattorestreet-index-load` |
+| Schedules | EventBridge Scheduler `fattorestreet-hist-load`, `fattorestreet-index-load` |
+| Log groups | `/ecs/fattorestreet-hist-load`, `/ecs/fattorestreet-index-load` (30-day retention) |
+| ECR repo | `fattorestreet-hist-load` (one image, shared by both task families) |
+| Secret | `fattorestreet/env`, one flat JSON shared by every service |
+| EC2 | one Graviton instance, tag `App=fattorestreet`, runs the compose stack |
+
+If `AWS_PROFILE` is set in the environment, respect it. Otherwise the default profile
+is correct.
+
+## Mental model that makes findings obvious
+
+The cluster runs **one-shot tasks only**. A healthy steady state is **zero running
+tasks**. The container image runs three modes off `APP_RUN_MODE` (`server`,
+`hist-load`, `index-load`); the load modes are `ApplicationRunner` beans that call
+`System.exit` when done, and `server` mode boots Tomcat and stays up forever.
+
+So: **any task alive for more than an hour or two is a bug, not activity.** The usual
+cause is the image not containing the runner the task definition asked for, which
+silently degrades to `server` mode and pins the task forever. One orphan accumulates
+per schedule firing, at Fargate rates, until someone looks.
+
+## Recipes
+
+**What is running right now**
+
+```bash
+aws ecs list-tasks --cluster fattorestreet-hist-load
+aws ecs describe-tasks --cluster fattorestreet-hist-load \
+  --tasks $(aws ecs list-tasks --cluster fattorestreet-hist-load --query 'taskArns[]' --output text) \
+  --query 'tasks[].{group:group,last:lastStatus,started:startedAt,cpu:cpu,mem:memory,by:startedBy}' \
+  --output table
+```
+
+Read `startedAt` first. Age is the signal.
+
+**Why did a task not do its job**
+
+```bash
+aws logs tail /ecs/fattorestreet-index-load --since 24h --format short | tail -40
+```
+
+Look for the runner's own first line (`Starting one-shot index load`,
+`Starting one-shot IEX HIST load`). If the app logged `Started SecApiApplication` and
+that runner line never appears, the runner bean was never created: the deployed image
+predates the runner, or `APP_RUN_MODE` is wrong. Confirm with the two commands below.
+
+**Is the deployed image current**
+
+```bash
+aws ecr describe-images --repository-name fattorestreet-hist-load \
+  --query 'sort_by(imageDetails,&imagePushedAt)[].{pushed:imagePushedAt,tags:imageTags}' --output table
+aws ecs describe-task-definition --task-definition fattorestreet-index-load \
+  --query 'taskDefinition.containerDefinitions[].{image:image,env:environment}'
+```
+
+Compare the `latest` push date against `git log -1 --format=%ad -- <path/to/Runner.java>`.
+The task definitions pin `:latest`, so a task definition can reference a runner that
+the image does not contain. This is the single most common failure here.
+
+**Schedules**
+
+```bash
+aws scheduler list-schedules --query 'Schedules[].{name:Name,state:State}' --output table
+aws scheduler get-schedule --name fattorestreet-index-load \
+  --query '{cron:ScheduleExpression,tz:ScheduleExpressionTimezone,state:State}'
+```
+
+**Cost**
+
+```bash
+aws ce get-cost-and-usage --time-period Start=$(date -v-30d +%F),End=$(date +%F) \
+  --granularity MONTHLY --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE \
+  --query 'ResultsByTime[].Groups[].{svc:Keys[0],amt:Metrics.UnblendedCost.Amount}' --output table
+```
+
+Cost Explorer lags roughly a day, and Fargate shows up under `Amazon Elastic Container
+Service`. For a quick estimate of one orphan task instead, Fargate ARM is about
+`$0.03238/vCPU-hr` + `$0.00356/GB-hr`, so a 0.5 vCPU / 2 GB task is roughly `$0.024/hr`,
+about `$17/month` each.
+
+**EC2 and everything else**
+
+```bash
+aws ec2 describe-instances --filters Name=tag:App,Values=fattorestreet \
+  --query 'Reservations[].Instances[].{id:InstanceId,type:InstanceType,state:State.Name,ip:PrivateIpAddress}' --output table
+aws secretsmanager describe-secret --secret-id fattorestreet/env --query '{name:Name,changed:LastChangedDate}'
+```
+
+## Answering style
+
+- Lead with the answer to the question asked, then the evidence.
+- Quote real values pulled from the account (task ages, dates, counts). Do not
+  generalize from Terraform.
+- When you find drift, say what the fix is and what it costs to leave alone, then stop
+  and let the user choose. Do not fix it silently.

--- a/.claude/skills/secrets-from-arn/SKILL.md
+++ b/.claude/skills/secrets-from-arn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secrets-from-arn
-description: Convert a container so docker run passes only SECRETS_ARN and the image fetches its config from AWS Secrets Manager at start (replacing the long -e KEY=value list in kubernetes/run.sh). Use when moving a service's secrets out of run.sh into Secrets Manager.
+description: Convert a container so docker run passes only SECRETS_ARN and the image fetches its config from AWS Secrets Manager at start (replacing the long -e KEY=value list in deploy/run.sh). Use when moving a service's secrets out of run.sh into Secrets Manager.
 ---
 
 # Secrets from ARN
@@ -10,7 +10,7 @@ flags on `docker run`, and instead receives **one** env var -- `SECRETS_ARN` --
 and fetches the rest from AWS Secrets Manager at container start.
 
 Use this when the user wants to move a service's secrets/config out of
-`kubernetes/run.sh` and into Secrets Manager. The springboot service is the
+`deploy/run.sh` and into Secrets Manager. The springboot service is the
 reference implementation; mirror it for any other container.
 
 ## The pattern
@@ -32,11 +32,11 @@ reference implementation; mirror it for any other container.
 
 - Entrypoint: `springboot/docker-entrypoint.sh`
 - Dockerfile runtime stage: `springboot/Dockerfile`
-- Run command: the `# springboot` block in `kubernetes/run.sh`
+- Run command: the `# springboot` block in `deploy/run.sh`
 
 ## Steps to apply to a container `<svc>`
 
-1. **Inventory the env.** Find the `# <svc>` block in `kubernetes/run.sh` and
+1. **Inventory the env.** Find the `# <svc>` block in `deploy/run.sh` and
    list every `-e KEY=value`. These become the keys of the secret's JSON object.
    Split out anything that must stay an explicit flag (e.g. `AWS_REGION`, run-mode
    selectors read before secrets load) -- only app config moves into the secret.
@@ -66,7 +66,7 @@ reference implementation; mirror it for any other container.
      start command into `CMD [...]`. (If the old line was `CMD ["gunicorn", ...]`
      as in django, keep that CMD and just add the ENTRYPOINT.)
 
-4. **Edit `kubernetes/run.sh`.** Replace the `-e KEY=value` lines in the `# <svc>`
+4. **Edit `deploy/run.sh`.** Replace the `-e KEY=value` lines in the `# <svc>`
    block with `-e SECRETS_ARN=<arn>` and `-e AWS_REGION=us-east-1`. Leave a
    comment with the `aws secretsmanager create-secret` JSON so the source of
    truth is discoverable. Don't commit real secret *values* if avoidable -- but
@@ -94,7 +94,7 @@ reference implementation; mirror it for any other container.
 
 6. **Verify.**
    - `docker build` the image (or `docker buildx build --platform linux/arm64`
-     to match the Graviton runtime, per `kubernetes/build.sh`).
+     to match the Graviton runtime, per `deploy/build.sh`).
    - Run with a real ARN and watch for `[entrypoint] loading secrets from ...`
      and a clean app start: `docker logs <svc>`.
    - A missing/forbidden secret should make the container exit non-zero (the
@@ -107,7 +107,7 @@ reference implementation; mirror it for any other container.
 - **One shared secret**: this project keeps ALL services' config in a single
   secret, `fattorestreet/env` (a flat JSON of every key). Each container is
   pointed at the same ARN via the `SECRETS_ARN` shell var set at the top of
-  `kubernetes/run.sh`; extra keys a service doesn't read are harmless. When
+  `deploy/run.sh`; extra keys a service doesn't read are harmless. When
   onboarding a new service, add its keys to that one secret rather than creating
   a new one.
 - **Multiple secrets**: `SECRETS_ARN` also accepts a comma-separated list of

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,12 @@ name: Docker images
 # and deploy that SHA to the EC2 host via SSM RunCommand, which runs the
 # versioned deploy/deploy.sh from the host's repo clone. One-time AWS/GitHub
 # setup lives in deploy/DEPLOY.md.
+#
+# The springboot image is ALSO pushed to ECR, because the nightly Fargate
+# loads (springboot/deploy/terraform/) run that same image from ECR rather
+# than GHCR. Keep both publishes in one build so they can never diverge: an
+# ECR image older than the code silently degrades a one-shot task to
+# APP_RUN_MODE=server, which never exits and bills until someone notices.
 
 on:
   push:
@@ -29,6 +35,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # OIDC for the ECR push on the springboot image; unused by the others
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -38,12 +46,16 @@ jobs:
           - image: nginx
             context: .
             dockerfile: nginx/Dockerfile
+            ecr: ""
           - image: django
             context: django
             dockerfile: django/Dockerfile
+            ecr: ""
+          # ecr: also publish to this ECR repo for the nightly Fargate loads
           - image: springboot
             context: springboot
             dockerfile: springboot/Dockerfile
+            ecr: fattorestreet-hist-load
     steps:
       - uses: actions/checkout@v7
 
@@ -58,6 +70,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure AWS credentials (OIDC)
+        if: matrix.ecr != '' && github.ref == 'refs/heads/main'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Log in to ECR
+        id: ecr-login
+        if: matrix.ecr != '' && github.ref == 'refs/heads/main'
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: Build ${{ matrix.image }}
         uses: docker/build-push-action@v7
         with:
@@ -65,9 +89,13 @@ jobs:
           file: ${{ matrix.dockerfile }}
           # PRs build-only; main pushes publish latest + the commit SHA
           push: ${{ github.ref == 'refs/heads/main' }}
+          # The ECR lines resolve to empty (and are dropped) for the images
+          # that set ecr: "" and on PRs, where the login step is skipped.
           tags: |
             ghcr.io/johnfattore/${{ matrix.image }}:latest
             ghcr.io/johnfattore/${{ matrix.image }}:${{ github.sha }}
+            ${{ steps.ecr-login.outputs.registry && format('{0}/{1}:latest', steps.ecr-login.outputs.registry, matrix.ecr) || '' }}
+            ${{ steps.ecr-login.outputs.registry && format('{0}/{1}:{2}', steps.ecr-login.outputs.registry, matrix.ecr, github.sha) || '' }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ springboot/data/
 *.tfstate
 *.tfstate.*
 .terraform/
+# Saved plan files embed the resolved variable values, so treat them like tfvars.
+tfplan
+tfplan-*
 crash.log
 
 llm/llama.cpp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mvn clean test                                   # Clean + test
 ```
 
 ### CI
-GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs + PMD + Error Prone), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA).
+GitHub Actions (`.github/workflows/ci.yml`) runs on pushes and PRs to `main`: React lint (ESLint) + style lint (Stylelint) + format check (Prettier) + Sass compile + build + tests, Django tests, Spring Boot format check (Spotless) + lint (Checkstyle) + `mvn verify` (tests + coverage floor + SpotBugs/FindSecBugs + PMD + Error Prone), and a detect-secrets scan (`pre-commit run detect-secrets --all-files`, config in `.pre-commit-config.yaml`). All four must pass before merge. `docker-build.yml` builds the nginx/django/springboot images (build-only on PRs; pushes to `main` publish to GHCR tagged `latest` + commit SHA). The springboot image also publishes to the ECR repo `fattorestreet-hist-load`, because the nightly Fargate loads run that image from ECR; both publishes happen in the same build step so the registries cannot drift.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Additional conventions:
 - No Hungarian notation
 - Python follows PEP 8; TypeScript strict mode is enabled
 - camelCase in frontend, snake_case in Django; RTK Query `transformResponse` converts between them
-- Infra: Docker Compose stacks and deploy scripts in `deploy/` (images on GHCR, deployed via AWS SSM), Nginx in `nginx/`, Terraform for the one-shot Fargate price load in `springboot/deploy/terraform/`
+- Infra: Docker Compose stacks and deploy scripts in `deploy/` (images on GHCR, deployed via AWS SSM), Nginx in `nginx/`, Terraform for the one-shot Fargate price load in `springboot/deploy/terraform/`. Local AWS work runs under `AWS_PROFILE=fattorestreet`, a scoped non-admin role with no IAM write and no secret-value read; policy JSON in `deploy/iam/`
 
 ## Skills & Rules
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -134,6 +134,42 @@ aws iam put-role-policy --role-name github-deploy-fattorestreet \
   --policy-name ssm-deploy --policy-document file://permissions.json
 ```
 
+The same role also pushes the springboot image to ECR for the nightly Fargate
+loads, which needs a second inline policy (`ecr-push.json`):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuthToken",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "PushHistLoadImage",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ],
+      "Resource": "arn:aws:ecr:us-east-1:<ACCOUNT_ID>:repository/fattorestreet-hist-load"
+    }
+  ]
+}
+```
+
+```sh
+aws iam put-role-policy --role-name github-deploy-fattorestreet \
+  --policy-name ecr-push --policy-document file://ecr-push.json
+```
+
 Point the workflow at the role (repo Actions **variable**, not a secret):
 
 ```sh

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -200,6 +200,21 @@ Change visibility → Public.
   Session Manager replaces interactive SSH:
   `aws ssm start-session --target <INSTANCE_ID>`.
 
+### 5. Local developer credentials (laptop + Claude Code)
+
+Local `aws` / `terraform` / SSM work runs as IAM user `claude-code`, whose only
+permission is to assume role `FattoreStreetDeveloper`; that role carries the
+grants. No admin key on the laptop, sessions expire hourly, and revoking is a
+one-line trust-policy edit.
+
+The five policy documents are versioned in [`iam/`](iam/), and the console
+click-path that creates the user, the role, and the key is
+[`iam/CONSOLE-SETUP.md`](iam/CONSOLE-SETUP.md). All commands then run under
+`AWS_PROFILE=fattorestreet`.
+
+The role has **no IAM write** and cannot read secret values, so IAM changes in
+`springboot/deploy/terraform/` must be applied by an admin from CloudShell.
+
 ## Notes & limits
 
 - Images are **linux/arm64 only** — the EC2 host is a t4g (Graviton), and CI
@@ -214,3 +229,5 @@ Change visibility → Public.
   silent green.
 - Deploys are serialized by the workflow's `concurrency: deploy` group; a
   second merge queues until the first finishes.
+- CI is unaffected by the local-credential setup in §5: it authenticates through
+  OIDC role `github-deploy-fattorestreet` and stores no AWS key.

--- a/deploy/iam/CONSOLE-SETUP.md
+++ b/deploy/iam/CONSOLE-SETUP.md
@@ -1,0 +1,189 @@
+# Console setup: the `claude-code` identity
+
+Everything in this file is done **by a human, in the AWS console**, signed in as
+`Spike` (console password + MFA). Nothing here can be automated from the laptop,
+because the laptop has no working credentials until step 6 finishes.
+
+Full design rationale lives in `.claude/plans/fizzy-meandering-lark.md`; this is
+just the click-path.
+
+## What you are building
+
+| Thing | Name | Gets |
+|---|---|---|
+| IAM user | `claude-code` | one inline policy: permission to assume the role below, nothing else |
+| IAM role | `FattoreStreetDeveloper` | the three customer-managed policies below |
+
+The key that lands on the Mac belongs to the user, which can do exactly one
+thing: assume the role. Sessions expire hourly and refresh transparently.
+
+## Step 0: substitute the placeholders (do this first, or nothing works)
+
+The committed JSON uses the repo's placeholder convention, and **AWS will not
+accept it as-is**. `<ACCOUNT_ID>` inside an ARN is not a valid account field, so
+the console rejects the paste with:
+
+> The policy failed legacy parsing
+
+That message names no line and no file. It almost always means a placeholder
+survived into an ARN.
+
+`render.sh` writes substituted copies to a fresh temp directory outside the
+repo, then refuses to finish if any placeholder survived or any file stopped
+being valid JSON:
+
+```sh
+cd deploy/iam
+ACCOUNT_ID=<12 digits from the console top-right menu> ./render.sh
+```
+
+It prints the directory. **Paste from there, not from the repo.** Every step
+below that says "paste this file" means the rendered copy.
+
+`ACCOUNT_ID` has to be passed by hand for this first run: the script otherwise
+reads it from `aws sts get-caller-identity`, and during bootstrap there are no
+working credentials, which is the reason this runbook exists at all. `VPC_ID`
+is read from `springboot/deploy/terraform/terraform.tfvars` (gitignored);
+override with `VPC_ID=vpc-…` if that file is absent.
+
+Real values stay out of the repo on purpose. Neither is a credential, and the
+account ID has in fact been public in this repo's history since 2024 (ECR image
+URIs in an old `docker-compose.yml`), so the point is not that these two strings
+are sensitive. It is that the habit generalizes to the values that are: secret
+ARNs with their random suffix, instance IDs, subnet IDs.
+
+Region is hardcoded to `us-east-1` throughout, matching the rest of the repo.
+
+---
+
+## Step 1: create the three role policies
+
+**IAM → Policies → Create policy → JSON tab.** Paste the file, Next, name it
+exactly as shown, Create. Repeat three times.
+
+| Paste this file | Name the policy |
+|---|---|
+| `fattorestreet-developer-infra.json` | `FattoreStreetDeveloper-infra` |
+| `fattorestreet-developer-ops.json` | `FattoreStreetDeveloper-ops` |
+| `fattorestreet-developer-guardrails.json` | `FattoreStreetDeveloper-guardrails` |
+
+The names matter only in that step 4 attaches them by name.
+
+The console will flag `FattoreStreetDeveloper-infra` with a blue "this policy
+grants `iam:PassRole`" note and may warn that `ecs:RegisterTaskDefinition` uses
+`*`. Both are expected: neither action supports resource-level scoping, and
+`iam:PassRole` is condition-locked to `role/fattorestreet-*` passed only to
+`ecs-tasks` and `scheduler`.
+
+## Step 2: create the user
+
+**IAM → Users → Create user.**
+
+1. User name `claude-code`.
+2. **Do not** check "Provide user access to the AWS Management Console". This
+   identity gets no password.
+3. Permissions → **Attach policies directly** → skip, attach nothing. Next.
+4. Tags: `Project=FattoreStreet`, `Purpose=claude-code-local`. Create user.
+
+Then attach the inline policy: **open the user → Permissions tab → Add
+permissions → Create inline policy → JSON tab.** Paste
+**`claude-code-user-assume-role.json`**, name it `assume-developer-role`, Create.
+
+Inline rather than managed on purpose: it is meaningless outside this one user,
+and keeping it inline means it dies with the user.
+
+Do not add the user to any group. Do not create an access key yet; that is step 6.
+
+## Step 3: create the role
+
+The user must already exist, or the console rejects the trust policy with
+"Invalid principal in policy".
+
+**IAM → Roles → Create role → Custom trust policy.** Paste
+**`fattorestreet-developer-trust.json`** into the editor (replace what is
+prefilled). Next.
+
+Naming `user/Spike` alongside `user/claude-code` is what lets you assume the
+same role by hand and reproduce anything Claude Code sees.
+
+## Step 4: attach the three policies
+
+Still in the create-role wizard, on the permissions page, search
+`FattoreStreetDeveloper` and check all three: `-infra`, `-ops`, `-guardrails`.
+Next.
+
+Role name: **`FattoreStreetDeveloper`** (exact: the trust policy in step 2's
+user policy and the local profile both reference it by name). Add tag
+`Project=FattoreStreet`. Create role.
+
+## Step 5: raise the max session duration
+
+**IAM → Roles → FattoreStreetDeveloper → Summary → Edit → Maximum session
+duration → 4 hours.** Save.
+
+The local profile still requests 1 hour; this only stops a long
+`terraform apply` from dying mid-run if a session is ever requested longer.
+
+## Step 6: mint the one access key
+
+**IAM → Users → claude-code → Security credentials → Access keys → Create
+access key.**
+
+- Use case: **Other** (there is no better fit; ignore the recommendation banner).
+- Description tag: `laptop + claude code`.
+- Download the .csv or copy both values now. **This is the only time the secret
+  is shown.**
+
+Move the two values to the Mac yourself. Do not paste them into a Claude Code
+chat, into any file in this repo, or into a terminal Claude Code is reading.
+
+## Step 7: local profile (you, in a terminal, by hand)
+
+Claude Code will not read or write `~/.aws/*`.
+
+`~/.aws/credentials`: add this block, then **delete the existing `[default]`
+block** holding the dead admin key. A missing `[default]` makes an un-profiled
+call fail loudly instead of silently reaching for a stale identity:
+
+```ini
+[fattorestreet-bootstrap]
+aws_access_key_id = AKIA...
+aws_secret_access_key = ...
+```
+
+`~/.aws/config`: add:
+
+```ini
+[profile fattorestreet]
+role_arn = arn:aws:iam::<ACCOUNT_ID>:role/FattoreStreetDeveloper
+source_profile = fattorestreet-bootstrap
+role_session_name = claude-code
+duration_seconds = 3600
+region = us-east-1
+output = json
+```
+
+## Step 8: one check before handing back
+
+```sh
+aws --profile fattorestreet sts get-caller-identity
+```
+
+Expected `Arn`: `arn:aws:sts::<ACCOUNT_ID>:assumed-role/FattoreStreetDeveloper/claude-code`,
+with a `UserId` starting `AROA`.
+
+Getting the `claude-code` **user** ARN back (starting `AIDA`) means `role_arn`
+is not being picked up. Check that the `[profile fattorestreet]` header
+includes the word `profile` and that `source_profile` matches the credentials
+block name exactly.
+
+Once that returns the assumed-role ARN, Claude Code can run the rest of the
+verification (Terraform plan, ECR, logs, SSM, run-task, and the deny checks) in
+`.claude/plans/fizzy-meandering-lark.md` → Verification.
+
+## Not now: cleanup
+
+After verification passes, two keys still need deleting: the deactivated
+`Spike` key and the 2.5-year-old admin key on the Linux host. That is the
+Cleanup section of the plan, and it is deliberately last, since CloudShell as
+`Spike` is the escape hatch if anything above is wrong.

--- a/deploy/iam/claude-code-user-assume-role.json
+++ b/deploy/iam/claude-code-user-assume-role.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeDeveloperRole",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/FattoreStreetDeveloper"
+    }
+  ]
+}

--- a/deploy/iam/fattorestreet-developer-guardrails.json
+++ b/deploy/iam/fattorestreet-developer-guardrails.json
@@ -1,0 +1,128 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyOutsideUsEast1",
+      "Effect": "Deny",
+      "NotAction": [
+        "iam:*",
+        "sts:*",
+        "organizations:*",
+        "account:*",
+        "route53:*",
+        "cloudfront:*",
+        "support:*",
+        "budgets:*",
+        "ce:*",
+        "health:*"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": { "aws:RequestedRegion": "us-east-1" }
+      }
+    },
+    {
+      "Sid": "DenyAllIamWrite",
+      "Effect": "Deny",
+      "Action": [
+        "iam:Create*",
+        "iam:Put*",
+        "iam:Attach*",
+        "iam:Detach*",
+        "iam:Delete*",
+        "iam:Update*",
+        "iam:Add*",
+        "iam:Remove*",
+        "iam:Set*",
+        "iam:Tag*",
+        "iam:Untag*",
+        "iam:Enable*",
+        "iam:Deactivate*",
+        "iam:Resync*",
+        "iam:ChangePassword",
+        "iam:UploadServerCertificate",
+        "iam:UploadSigningCertificate",
+        "iam:UploadSSHPublicKey"
+      ],
+      "NotResource": "arn:aws:iam::*:role/aws-service-role/*"
+    },
+    {
+      "Sid": "DenyRoleChaining",
+      "Effect": "Deny",
+      "Action": [
+        "sts:AssumeRole",
+        "sts:AssumeRoleWithSAML",
+        "sts:AssumeRoleWithWebIdentity",
+        "sts:GetFederationToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenySecretValueAccess",
+      "Effect": "Deny",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:PutResourcePolicy",
+        "secretsmanager:DeleteResourcePolicy",
+        "secretsmanager:RestoreSecret",
+        "secretsmanager:RotateSecret"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyAuditTampering",
+      "Effect": "Deny",
+      "Action": [
+        "cloudtrail:StopLogging",
+        "cloudtrail:DeleteTrail",
+        "cloudtrail:UpdateTrail",
+        "cloudtrail:PutEventSelectors",
+        "config:Delete*",
+        "config:Stop*",
+        "guardduty:Delete*",
+        "guardduty:Update*",
+        "securityhub:Disable*",
+        "organizations:*",
+        "account:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyDestructiveOutOfScope",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:StopInstances",
+        "ec2:RebootInstances",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:AssociateIamInstanceProfile",
+        "ec2:ReplaceIamInstanceProfileAssociation",
+        "ec2:DeleteVpc",
+        "ec2:DeleteSubnet",
+        "ec2:DeleteRouteTable",
+        "ec2:DeleteInternetGateway",
+        "ec2:DeleteNatGateway",
+        "ec2:DeleteVolume",
+        "ec2:DeleteSnapshot",
+        "ec2:ReleaseAddress",
+        "rds:*",
+        "route53:ChangeResourceRecordSets",
+        "s3:DeleteBucket",
+        "s3:PutBucketPolicy",
+        "s3:PutBucketAcl",
+        "kms:ScheduleKeyDeletion",
+        "kms:DisableKey",
+        "kms:PutKeyPolicy",
+        "ses:*",
+        "lambda:*",
+        "bedrock:*",
+        "sagemaker:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/deploy/iam/fattorestreet-developer-infra.json
+++ b/deploy/iam/fattorestreet-developer-infra.json
@@ -1,0 +1,244 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GlobalReads",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity",
+        "ec2:Describe*",
+        "ecs:Describe*",
+        "ecs:List*",
+        "ecr:Describe*",
+        "ecr:List*",
+        "ecr:GetAuthorizationToken",
+        "logs:Describe*",
+        "logs:Get*",
+        "logs:FilterLogEvents",
+        "logs:StartLiveTail",
+        "logs:ListTagsForResource",
+        "scheduler:Get*",
+        "scheduler:List*",
+        "sns:Get*",
+        "sns:List*",
+        "events:Describe*",
+        "events:List*",
+        "secretsmanager:ListSecrets",
+        "cloudwatch:GetMetricData",
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics",
+        "tag:GetResources"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrRepo",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreateRepository",
+        "ecr:DeleteRepository",
+        "ecr:TagResource",
+        "ecr:UntagResource",
+        "ecr:PutImageScanningConfiguration",
+        "ecr:PutImageTagMutability",
+        "ecr:PutLifecyclePolicy",
+        "ecr:DeleteLifecyclePolicy",
+        "ecr:SetRepositoryPolicy",
+        "ecr:DeleteRepositoryPolicy",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage",
+        "ecr:BatchDeleteImage"
+      ],
+      "Resource": "arn:aws:ecr:us-east-1:<ACCOUNT_ID>:repository/fattorestreet-*"
+    },
+    {
+      "Sid": "EcsCluster",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:CreateCluster",
+        "ecs:DeleteCluster",
+        "ecs:UpdateCluster",
+        "ecs:UpdateClusterSettings",
+        "ecs:PutClusterCapacityProviders",
+        "ecs:TagResource",
+        "ecs:UntagResource"
+      ],
+      "Resource": "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:cluster/fattorestreet-*"
+    },
+    {
+      "Sid": "EcsRegisterTaskDef",
+      "Effect": "Allow",
+      "Action": "ecs:RegisterTaskDefinition",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcsTaskDefs",
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DeregisterTaskDefinition",
+        "ecs:TagResource",
+        "ecs:UntagResource"
+      ],
+      "Resource": "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:task-definition/fattorestreet-*:*"
+    },
+    {
+      "Sid": "EcsRunTask",
+      "Effect": "Allow",
+      "Action": ["ecs:RunTask", "ecs:StopTask"],
+      "Resource": [
+        "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:task-definition/fattorestreet-*:*",
+        "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:task/fattorestreet-*/*"
+      ],
+      "Condition": {
+        "ArnEquals": {
+          "ecs:cluster": "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:cluster/fattorestreet-hist-load"
+        }
+      }
+    },
+    {
+      "Sid": "LogGroups",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:DeleteRetentionPolicy",
+        "logs:TagResource",
+        "logs:UntagResource",
+        "logs:CreateLogStream"
+      ],
+      "Resource": [
+        "arn:aws:logs:us-east-1:<ACCOUNT_ID>:log-group:/ecs/fattorestreet-*",
+        "arn:aws:logs:us-east-1:<ACCOUNT_ID>:log-group:/ecs/fattorestreet-*:*"
+      ]
+    },
+    {
+      "Sid": "SecurityGroupsInVpc",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:ModifySecurityGroupRules",
+        "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+        "ec2:UpdateSecurityGroupRuleDescriptionsEgress"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:Vpc": "arn:aws:ec2:us-east-1:<ACCOUNT_ID>:vpc/<VPC_ID>"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSecurityGroup",
+      "Effect": "Allow",
+      "Action": "ec2:CreateSecurityGroup",
+      "Resource": [
+        "arn:aws:ec2:us-east-1:<ACCOUNT_ID>:vpc/<VPC_ID>",
+        "arn:aws:ec2:us-east-1:<ACCOUNT_ID>:security-group/*"
+      ]
+    },
+    {
+      "Sid": "TagSecurityGroupsOnCreate",
+      "Effect": "Allow",
+      "Action": ["ec2:CreateTags", "ec2:DeleteTags"],
+      "Resource": "arn:aws:ec2:us-east-1:<ACCOUNT_ID>:security-group/*",
+      "Condition": {
+        "StringEquals": { "ec2:CreateAction": "CreateSecurityGroup" }
+      }
+    },
+    {
+      "Sid": "IamReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListRoleTags",
+        "iam:ListInstanceProfilesForRole"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/fattorestreet-*"
+    },
+    {
+      "Sid": "PassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/fattorestreet-*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": [
+            "ecs-tasks.amazonaws.com",
+            "scheduler.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "ServiceLinkedRoles",
+      "Effect": "Allow",
+      "Action": "iam:CreateServiceLinkedRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": [
+            "ecs.amazonaws.com",
+            "scheduler.amazonaws.com",
+            "events.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "Scheduler",
+      "Effect": "Allow",
+      "Action": [
+        "scheduler:CreateSchedule",
+        "scheduler:UpdateSchedule",
+        "scheduler:DeleteSchedule",
+        "scheduler:TagResource",
+        "scheduler:UntagResource"
+      ],
+      "Resource": "arn:aws:scheduler:us-east-1:<ACCOUNT_ID>:schedule/default/fattorestreet-*"
+    },
+    {
+      "Sid": "Sns",
+      "Effect": "Allow",
+      "Action": [
+        "sns:CreateTopic",
+        "sns:DeleteTopic",
+        "sns:SetTopicAttributes",
+        "sns:AddPermission",
+        "sns:RemovePermission",
+        "sns:Subscribe",
+        "sns:Unsubscribe",
+        "sns:TagResource",
+        "sns:UntagResource"
+      ],
+      "Resource": "arn:aws:sns:us-east-1:<ACCOUNT_ID>:fattorestreet-*"
+    },
+    {
+      "Sid": "EventBridge",
+      "Effect": "Allow",
+      "Action": [
+        "events:PutRule",
+        "events:DeleteRule",
+        "events:PutTargets",
+        "events:RemoveTargets",
+        "events:EnableRule",
+        "events:DisableRule",
+        "events:TagResource",
+        "events:UntagResource"
+      ],
+      "Resource": "arn:aws:events:us-east-1:<ACCOUNT_ID>:rule/fattorestreet-*"
+    }
+  ]
+}

--- a/deploy/iam/fattorestreet-developer-ops.json
+++ b/deploy/iam/fattorestreet-developer-ops.json
@@ -1,0 +1,60 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SsmReads",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeInstanceInformation",
+        "ssm:DescribeInstanceProperties",
+        "ssm:GetConnectionStatus",
+        "ssm:DescribeSessions",
+        "ssm:ListCommands",
+        "ssm:ListCommandInvocations",
+        "ssm:GetCommandInvocation",
+        "ssm:DescribeDocument",
+        "ssm:GetDocument"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SsmTargetTaggedInstances",
+      "Effect": "Allow",
+      "Action": ["ssm:SendCommand", "ssm:StartSession"],
+      "Resource": "arn:aws:ec2:us-east-1:<ACCOUNT_ID>:instance/*",
+      "Condition": {
+        "StringEquals": { "ssm:resourceTag/App": "fattorestreet" }
+      }
+    },
+    {
+      "Sid": "SsmDocuments",
+      "Effect": "Allow",
+      "Action": ["ssm:SendCommand", "ssm:StartSession"],
+      "Resource": [
+        "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
+        "arn:aws:ssm:us-east-1::document/SSM-SessionManagerRunShell",
+        "arn:aws:ssm:us-east-1::document/AWS-StartInteractiveCommand"
+      ]
+    },
+    {
+      "Sid": "SsmSessionControl",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:TerminateSession",
+        "ssm:ResumeSession",
+        "ssm:CancelCommand"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsMetadataOnly",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecretVersionIds",
+        "secretsmanager:GetResourcePolicy"
+      ],
+      "Resource": "arn:aws:secretsmanager:us-east-1:<ACCOUNT_ID>:secret:fattorestreet/*"
+    }
+  ]
+}

--- a/deploy/iam/fattorestreet-developer-trust.json
+++ b/deploy/iam/fattorestreet-developer-trust.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "LocalDeveloperIdentities",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::<ACCOUNT_ID>:user/claude-code",
+          "arn:aws:iam::<ACCOUNT_ID>:user/Spike"
+        ]
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "Bool": { "aws:SecureTransport": "true" }
+      }
+    }
+  ]
+}

--- a/deploy/iam/render.sh
+++ b/deploy/iam/render.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+# Render the policy JSON in this directory with real values, into a fresh temp
+# directory outside the repo. Prints the directory path; paste from there.
+#
+#   ./render.sh                      # resolve both values automatically
+#   ACCOUNT_ID=123456789012 ./render.sh
+#
+# During the initial bootstrap there are no working local credentials, which is
+# the whole reason the console runbook exists. So ACCOUNT_ID falls back to STS
+# rather than depending on it; pass it explicitly when the CLI cannot call AWS.
+set -eu
+
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TFVARS="$DIR/../../springboot/deploy/terraform/terraform.tfvars"
+
+ACCOUNT_ID="${ACCOUNT_ID:-}"
+VPC_ID="${VPC_ID:-}"
+
+if [ -z "$ACCOUNT_ID" ]; then
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
+fi
+if [ -z "$VPC_ID" ] && [ -f "$TFVARS" ]; then
+  VPC_ID=$(sed -n 's/^[[:space:]]*vpc_id[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$TFVARS")
+fi
+
+case "$ACCOUNT_ID" in
+  [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]) ;;
+  *)
+    echo "ACCOUNT_ID must be 12 digits; got '${ACCOUNT_ID}'." >&2
+    echo "No local credentials during bootstrap: read it from the console" >&2
+    echo "top-right account menu and pass ACCOUNT_ID=... explicitly." >&2
+    exit 1 ;;
+esac
+
+case "$VPC_ID" in
+  vpc-*) ;;
+  *)
+    echo "VPC_ID must look like vpc-...; got '${VPC_ID}'." >&2
+    echo "Expected it in $TFVARS (gitignored), or pass VPC_ID=... explicitly." >&2
+    exit 1 ;;
+esac
+
+OUT=$(mktemp -d)
+for f in "$DIR"/*.json; do
+  sed -e "s/<ACCOUNT_ID>/$ACCOUNT_ID/g" -e "s|<VPC_ID>|$VPC_ID|g" \
+    "$f" > "$OUT/$(basename "$f")"
+done
+
+# A surviving placeholder produces an ARN AWS rejects as "The policy failed
+# legacy parsing", which names neither the file nor the line. Catch it here.
+if grep -l '<ACCOUNT_ID>\|<VPC_ID>' "$OUT"/*.json 2>/dev/null; then
+  echo "Unsubstituted placeholders remain in the files above." >&2
+  exit 1
+fi
+
+for f in "$OUT"/*.json; do
+  python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" || {
+    echo "Invalid JSON: $f" >&2; exit 1; }
+done
+
+echo "Rendered for account $ACCOUNT_ID, vpc $VPC_ID:"
+echo "$OUT"

--- a/deploy/iam/temporary/README.md
+++ b/deploy/iam/temporary/README.md
@@ -19,7 +19,7 @@ actions. Five are already inside the role. Exactly one is not:
 
 | Resource | Action | API call | Covered by |
 |---|---|---|---|
-| `aws_ecs_task_definition.this` | replace | `ecs:RegisterTaskDefinition`, `ecs:DeregisterTaskDefinition`, `iam:PassRole` | `EcsRegisterTaskDef`, `EcsTaskDefs`, `PassRole` |
+| `aws_ecs_task_definition.this` | replace | `ecs:RegisterTaskDefinition`, `iam:PassRole` | `EcsRegisterTaskDef`, `PassRole` |
 | `aws_ecs_task_definition.index_load` | replace | same | same |
 | `aws_scheduler_schedule.this` | update | `scheduler:GetSchedule`, `scheduler:UpdateSchedule`, `iam:PassRole` | `GlobalReads`, `Scheduler`, `PassRole` |
 | `aws_scheduler_schedule.index_load` | update | same | same |
@@ -27,6 +27,15 @@ actions. Five are already inside the role. Exactly one is not:
 | `aws_iam_role_policy.scheduler_run_task` | update | **`iam:PutRolePolicy`** | **nothing, and explicitly denied** |
 
 So the whole grant is one action on one role.
+
+The task definition rows originally listed `ecs:DeregisterTaskDefinition` as
+covered by `EcsTaskDefs`. That was wrong, and an apply proved it: the statement
+scopes the action to `task-definition/fattorestreet-*:*`, but
+`ecs:DeregisterTaskDefinition` takes no resource-level permissions, so it only
+matches on `"*"`. Rather than widen it, both task definitions now set
+`skip_destroy = true` and the call is never made. Worth remembering as a general
+trap: an ECS action scoped to an ARN may silently never match, and AWS names the
+resource as `*` in the denial when that happens.
 
 ### Why an allow policy alone does not work
 

--- a/deploy/iam/temporary/README.md
+++ b/deploy/iam/temporary/README.md
@@ -1,0 +1,131 @@
+# Temporary IAM grants
+
+Policies in this directory are **not** part of the steady state. They widen
+`FattoreStreetDeveloper` for one apply and are meant to be revoked immediately
+after. `render.sh` in the parent directory globs `*.json` non-recursively, so
+nothing here is picked up by normal bootstrap.
+
+The steady-state documents are the four in `deploy/iam/`. If a file here is
+attached and you are not mid-apply, that is drift: revoke it.
+
+---
+
+## Grant: write the scheduler role's inline policy
+
+### Why it is needed
+
+`terraform apply` in `springboot/deploy/terraform/` currently plans six resource
+actions. Five are already inside the role. Exactly one is not:
+
+| Resource | Action | API call | Covered by |
+|---|---|---|---|
+| `aws_ecs_task_definition.this` | replace | `ecs:RegisterTaskDefinition`, `ecs:DeregisterTaskDefinition`, `iam:PassRole` | `EcsRegisterTaskDef`, `EcsTaskDefs`, `PassRole` |
+| `aws_ecs_task_definition.index_load` | replace | same | same |
+| `aws_scheduler_schedule.this` | update | `scheduler:GetSchedule`, `scheduler:UpdateSchedule`, `iam:PassRole` | `GlobalReads`, `Scheduler`, `PassRole` |
+| `aws_scheduler_schedule.index_load` | update | same | same |
+| `aws_sns_topic_subscription.task_failures_email[0]` | create | `sns:GetTopicAttributes`, `sns:Subscribe` | `GlobalReads`, `Sns` |
+| `aws_iam_role_policy.scheduler_run_task` | update | **`iam:PutRolePolicy`** | **nothing, and explicitly denied** |
+
+So the whole grant is one action on one role.
+
+### Why an allow policy alone does not work
+
+`FattoreStreetDeveloper-guardrails` carries `DenyAllIamWrite`, an explicit `Deny`
+on `iam:Put*`. An explicit deny beats every allow, so attaching a permissions
+policy changes nothing on its own: the call still fails with `AccessDenied`.
+
+The deny itself has to stop covering this one role, which is what the carve-out
+file does. Both halves are required:
+
+- `fattorestreet-developer-guardrails-iam-carveout.json` adds
+  `role/fattorestreet-hist-load-sched-*` to `DenyAllIamWrite`'s `NotResource`, so
+  the deny no longer reaches that role.
+- `fattorestreet-developer-temp-scheduler-policy-write.json` then allows
+  `iam:PutRolePolicy` on it. Without this, removing the deny grants nothing,
+  since no allow exists.
+
+The carve-out exempts that role from *all* the IAM-write denies, but the allow is
+the limiting factor, so the effective grant stays `iam:PutRolePolicy` on one role.
+
+### Apply
+
+Run as an admin (console or CloudShell), not as `FattoreStreetDeveloper`.
+
+```sh
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+GUARDRAILS="arn:aws:iam::${ACCOUNT_ID}:policy/FattoreStreetDeveloper-guardrails"
+
+sed "s/<ACCOUNT_ID>/${ACCOUNT_ID}/g" \
+  fattorestreet-developer-temp-scheduler-policy-write.json > /tmp/temp-grant.json
+
+# 1. Carve the scheduler role out of the deny, as a new default version.
+aws iam create-policy-version \
+  --policy-arn "$GUARDRAILS" \
+  --policy-document file://fattorestreet-developer-guardrails-iam-carveout.json \
+  --set-as-default
+
+# 2. Add the allow.
+TEMP_ARN=$(aws iam create-policy \
+  --policy-name FattoreStreetDeveloper-temp-scheduler-policy-write \
+  --policy-document file:///tmp/temp-grant.json \
+  --query Policy.Arn --output text)
+
+aws iam attach-role-policy \
+  --role-name FattoreStreetDeveloper --policy-arn "$TEMP_ARN"
+```
+
+Note the version id `create-policy-version` prints. Rolling back needs the
+*previous* one (`v1` unless the guardrails have been revised since).
+
+Policy changes take effect on the next API call, within seconds. There is no need
+to re-assume the role or refresh credentials.
+
+### Then, from `springboot/deploy/terraform/`
+
+```sh
+terraform plan     # confirm still 3 to add, 3 to change, 2 to destroy
+terraform apply
+```
+
+### Revoke, immediately after
+
+```sh
+aws iam detach-role-policy \
+  --role-name FattoreStreetDeveloper --policy-arn "$TEMP_ARN"
+aws iam delete-policy --policy-arn "$TEMP_ARN"
+
+# Restore the guardrails to the version from before step 1.
+aws iam set-default-policy-version --policy-arn "$GUARDRAILS" --version-id v1
+aws iam delete-policy-version --policy-arn "$GUARDRAILS" --version-id v2
+```
+
+Verify the deny is back. This must fail with `AccessDenied`:
+
+```sh
+AWS_PROFILE=fattorestreet aws iam put-role-policy \
+  --role-name "$(aws iam list-roles \
+    --query 'Roles[?starts_with(RoleName,`fattorestreet-hist-load-sched-`)].RoleName' \
+    --output text)" \
+  --policy-name run-task --policy-document file:///tmp/temp-grant.json
+```
+
+A managed policy holds at most five versions. If `create-policy-version` ever
+fails on that limit, delete an old version rather than skipping the rollback.
+
+### What the grant is worth while it is live
+
+`iam:PutRolePolicy` on the scheduler role means the developer role could rewrite
+that role's permissions, and the scheduler role can `iam:PassRole` the task and
+execution roles. Combined with `scheduler:CreateSchedule`, which the developer
+role already has, that is a real if bounded escalation path: it ends at what a
+Fargate task in this cluster can do, and `DenyRoleChaining` still blocks assuming
+the role directly. It is scoped to one role, held for one apply, and revoked by
+the two commands above. Do not leave it attached.
+
+### The alternative that needs no grant
+
+Pasting the rendered policy into the console by hand also works and changes no
+IAM configuration at all. See the Credentials section of
+`springboot/deploy/terraform/README.md`. It is fewer moving parts for a one-off;
+this grant is better if you would rather `terraform apply` do the whole thing in
+one run with nothing hand-copied.

--- a/deploy/iam/temporary/fattorestreet-developer-guardrails-iam-carveout.json
+++ b/deploy/iam/temporary/fattorestreet-developer-guardrails-iam-carveout.json
@@ -1,0 +1,131 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyOutsideUsEast1",
+      "Effect": "Deny",
+      "NotAction": [
+        "iam:*",
+        "sts:*",
+        "organizations:*",
+        "account:*",
+        "route53:*",
+        "cloudfront:*",
+        "support:*",
+        "budgets:*",
+        "ce:*",
+        "health:*"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotEquals": { "aws:RequestedRegion": "us-east-1" }
+      }
+    },
+    {
+      "Sid": "DenyAllIamWrite",
+      "Effect": "Deny",
+      "Action": [
+        "iam:Create*",
+        "iam:Put*",
+        "iam:Attach*",
+        "iam:Detach*",
+        "iam:Delete*",
+        "iam:Update*",
+        "iam:Add*",
+        "iam:Remove*",
+        "iam:Set*",
+        "iam:Tag*",
+        "iam:Untag*",
+        "iam:Enable*",
+        "iam:Deactivate*",
+        "iam:Resync*",
+        "iam:ChangePassword",
+        "iam:UploadServerCertificate",
+        "iam:UploadSigningCertificate",
+        "iam:UploadSSHPublicKey"
+      ],
+      "NotResource": [
+        "arn:aws:iam::*:role/aws-service-role/*",
+        "arn:aws:iam::*:role/fattorestreet-hist-load-sched-*"
+      ]
+    },
+    {
+      "Sid": "DenyRoleChaining",
+      "Effect": "Deny",
+      "Action": [
+        "sts:AssumeRole",
+        "sts:AssumeRoleWithSAML",
+        "sts:AssumeRoleWithWebIdentity",
+        "sts:GetFederationToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenySecretValueAccess",
+      "Effect": "Deny",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:PutResourcePolicy",
+        "secretsmanager:DeleteResourcePolicy",
+        "secretsmanager:RestoreSecret",
+        "secretsmanager:RotateSecret"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyAuditTampering",
+      "Effect": "Deny",
+      "Action": [
+        "cloudtrail:StopLogging",
+        "cloudtrail:DeleteTrail",
+        "cloudtrail:UpdateTrail",
+        "cloudtrail:PutEventSelectors",
+        "config:Delete*",
+        "config:Stop*",
+        "guardduty:Delete*",
+        "guardduty:Update*",
+        "securityhub:Disable*",
+        "organizations:*",
+        "account:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyDestructiveOutOfScope",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:StopInstances",
+        "ec2:RebootInstances",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:AssociateIamInstanceProfile",
+        "ec2:ReplaceIamInstanceProfileAssociation",
+        "ec2:DeleteVpc",
+        "ec2:DeleteSubnet",
+        "ec2:DeleteRouteTable",
+        "ec2:DeleteInternetGateway",
+        "ec2:DeleteNatGateway",
+        "ec2:DeleteVolume",
+        "ec2:DeleteSnapshot",
+        "ec2:ReleaseAddress",
+        "rds:*",
+        "route53:ChangeResourceRecordSets",
+        "s3:DeleteBucket",
+        "s3:PutBucketPolicy",
+        "s3:PutBucketAcl",
+        "kms:ScheduleKeyDeletion",
+        "kms:DisableKey",
+        "kms:PutKeyPolicy",
+        "ses:*",
+        "lambda:*",
+        "bedrock:*",
+        "sagemaker:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/deploy/iam/temporary/fattorestreet-developer-temp-scheduler-policy-write.json
+++ b/deploy/iam/temporary/fattorestreet-developer-temp-scheduler-policy-write.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TempWriteSchedulerInlinePolicy",
+      "Effect": "Allow",
+      "Action": "iam:PutRolePolicy",
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/fattorestreet-hist-load-sched-*"
+    }
+  ]
+}

--- a/django/README.md
+++ b/django/README.md
@@ -101,8 +101,8 @@ uv sync                 # sync .venv to the lockfile
 - Nginx reverse proxy
 - PostgreSQL database
 - All services run in Docker containers
-- Kubernetes manifests in `kubernetes/`
-- Hosted on AWS EC2
+- Docker Compose stack and deploy scripts in `deploy/`
+- Hosted on AWS EC2 (Graviton/ARM64)
 - Django admin: with `DJANGO_FORCE_SCRIPT_NAME=/django` (matching nginx `location /django/`), use **`/django/admin/`** in the browser; local dev without that env continues to use **`/admin/`**.
 
 ## Documentation

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -34,6 +34,7 @@ The production environment runs on a single EC2 instance behind Route 53:
   - `SECRETS_ARN`/`AWS_REGION` come from `deploy/.env` on the host (template: `deploy/.env.example`).
 - **Rollback**: re-run the deploy with an older commit's SHA, or on the host `sudo ./deploy.sh <old-sha>`.
 - **Runbook**: `deploy/compose.sh` documents one-time host setup and emergency manual commands. `deploy/run.sh` is kept as reference for the pre-Compose setup (including secret creation and certbot commands).
+- **Local AWS access**: laptop and Claude Code work runs under `AWS_PROFILE=fattorestreet`, an IAM user whose only permission is to assume the scoped role `FattoreStreetDeveloper` (no IAM write, no secret-value read, `us-east-1` only, hourly sessions). No admin key on the laptop. Policy JSON in [`deploy/iam/`](../deploy/iam/), console setup in [`deploy/iam/CONSOLE-SETUP.md`](../deploy/iam/CONSOLE-SETUP.md). CI is separate and unaffected: it uses OIDC and stores no key.
 
 Watchtower-based auto-updates are retired: deploys are an explicit, ordered, health-checked `deploy.sh` run, so nginx and the backends restart in a coordinated way.
 

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -88,8 +88,29 @@ role still needs CloudShell.
 
 That property starts one apply from now. The change that removed the pinned
 revision ARNs rewrites `aws_iam_role_policy.scheduler_run_task` itself, and
-`iam:Put*` is an explicit deny, so the **first** apply carrying it must run from
-CloudShell as an admin. Every task-definition apply after that is local.
+`iam:Put*` is an explicit deny, so that one update cannot come from here.
+
+**CloudShell is not the way to do it.** State is local and gitignored, so a
+CloudShell clone has the config but neither `terraform.tfstate` nor
+`terraform.tfvars`. Uploading both, applying, and downloading the state back
+works, but it puts the only copy of state on a round trip, and forgetting the
+return leg leaves this directory silently stale.
+
+Do the single IAM write in the console instead, then apply from here:
+
+1. IAM → Roles → `fattorestreet-hist-load-sched-*` → inline policy `run-task` → edit.
+2. Replace the document with the one `terraform console -plan` renders:
+   ```
+   terraform console -plan <<< 'data.aws_iam_policy_document.scheduler_run_task.json'
+   ```
+   Paste it verbatim. Anything else leaves a permanent diff.
+3. `terraform apply` locally. The policy now matches, so Terraform plans no
+   change to it and never calls `iam:PutRolePolicy`.
+
+Step 3 only works because the document is static (see the comment in `main.tf`).
+Were it still derived from the task definition resources, it would read as
+unknown at plan time, Terraform would plan the update regardless of what is
+already in AWS, and the apply would fail on the deny.
 
 ## Deploy
 

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -60,6 +60,22 @@ Cost shape: you pay for ~4 GB only for the minutes the task runs each night, not
 2. **tfvars** — `cp terraform.tfvars.example terraform.tfvars` and fill in VPC, subnets, the EC2
    instance's security group id, and its private IP/DNS for `db_host`.
 
+## Credentials
+
+Every command below runs under `AWS_PROFILE=fattorestreet`, which assumes the
+scoped role `FattoreStreetDeveloper` rather than using an admin key. Claude Code
+sets it automatically via `.claude/settings.json`; set it yourself in a plain
+shell. Setup is [`deploy/iam/CONSOLE-SETUP.md`](../../../deploy/iam/CONSOLE-SETUP.md),
+rationale is [`deploy/DEPLOY.md`](../../../deploy/DEPLOY.md) §5.
+
+The role deliberately has **no IAM write**. It can read the `fattorestreet-*`
+roles, so `plan` is accurate, but any change to the IAM resources in `main.tf`
+(the execution, task, or scheduler role) fails on `apply` with `AccessDenied`.
+That is not a bug to route around by switching credentials: apply those from
+CloudShell as an admin, then resume here. It also cannot read secret *values*,
+which the module never needs, since `env_secret_arn` is only ever passed through
+as a string.
+
 ## Deploy
 
 ```bash

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -80,6 +80,17 @@ CloudShell as an admin, then resume here. It also cannot read secret *values*,
 which the module never needs, since `env_secret_arn` is only ever passed through
 as a string.
 
+Editing a task definition does **not** count as an IAM change. The scheduler's
+`ecs:RunTask` policy is scoped to `family:*` wildcards only, which already match
+every revision, so bumping a task definition leaves the policy byte-identical and
+the apply stays inside what this role can do. Adding a *new* task definition or
+role still needs CloudShell.
+
+That property starts one apply from now. The change that removed the pinned
+revision ARNs rewrites `aws_iam_role_policy.scheduler_run_task` itself, and
+`iam:Put*` is an explicit deny, so the **first** apply carrying it must run from
+CloudShell as an admin. Every task-definition apply after that is local.
+
 ## Deploy
 
 ```bash

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -45,10 +45,14 @@ Cost shape: you pay for ~4 GB only for the minutes the task runs each night, not
 ## One-time prerequisites
 
 1. **Secret** — the task reads the single `fattorestreet/env` secret (the same JSON secret the EC2
-   containers use), pulling `POSTGRES_PASSWORD` and `SECRET_KEY` out of it by key. It should already
-   exist; if not, create it as a JSON object:
+   containers use), pulling `POSTGRES_PASSWORD`, `SECRET_KEY`, and `SEC_CONTACT_EMAIL` out of it by
+   key. `SEC_CONTACT_EMAIL` is not sensitive, but it lives in the same JSON, and sourcing it there
+   beats a variable that would put an email address in tfvars. It is **required**: SEC sends it as
+   the User-Agent, and an empty one gets `403 Undeclared Automated Tool` on every ticker. It should
+   already exist; if not, create it as a JSON object:
    ```bash
    aws secretsmanager create-secret --name fattorestreet/env --secret-string '{
+     "SEC_CONTACT_EMAIL": "<your-email>",
      "POSTGRES_PASSWORD": "<postgres-password>",
      "SECRET_KEY": "<django-secret-key>"
    }'   # ...plus the other app keys; see deploy/run.sh

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -68,7 +68,23 @@ terraform init
 terraform apply        # creates ECR repo, cluster, task def, IAM, SG rule, schedule
 ```
 
-Then build the **ARM64** image and push it to the ECR repo Terraform created:
+The image comes from CI. `.github/workflows/docker-build.yml` builds the springboot image on
+every merge to `main` and pushes it to **both** GHCR (for the EC2 compose stack) and this ECR
+repo, tagged `latest` + commit SHA. The task definitions pin `:latest`, so a merge to `main` is
+all it takes for the next nightly run to pick up new code.
+
+> The Dockerfile needs no changes — run mode is selected purely by the `APP_RUN_MODE` env var that
+> the task definition sets.
+
+**`terraform apply` is not a deploy.** Terraform can add a task definition referencing a runner
+that the ECR image does not yet contain; the container then falls through to `APP_RUN_MODE=server`,
+boots Tomcat, and **never exits**, so the task runs (and bills) forever and the failure alert below
+never fires, because it only triggers on a task that *stops*. This happened once: `IndexLoadRunner`
+landed 2026-07-18 against an image built 2026-07-01, and six orphaned tasks accumulated at ~$17/mo
+each before anyone looked. If you add a run mode, merge it to `main` (so CI publishes the image)
+before or with the `terraform apply`, and check the cluster afterwards.
+
+To build and push by hand (CI unavailable, or bootstrapping before the repo exists):
 
 ```bash
 REPO=$(terraform output -raw ecr_repository_url)
@@ -79,9 +95,6 @@ aws ecr get-login-password --region "$REGION" | docker login --username AWS --pa
 cd ../..                       # -> springboot/
 docker buildx build --platform linux/arm64 -t "$REPO:latest" --push .
 ```
-
-> The Dockerfile needs no changes — run mode is selected purely by the `APP_RUN_MODE` env var that
-> the task definition sets.
 
 ## Test a run before trusting the schedule
 

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -115,7 +115,16 @@ resource "aws_ecs_cluster" "this" {
 }
 
 resource "aws_ecs_task_definition" "this" {
-  family                   = var.name_prefix
+  family = var.name_prefix
+
+  # Leave superseded revisions registered instead of deregistering them.
+  # ecs:DeregisterTaskDefinition does not support resource-level permissions, so
+  # allowing it means granting it on "*", and the developer role scopes ECS
+  # writes to fattorestreet-* on purpose. Keeping old revisions costs nothing,
+  # and the schedules always target the revision this module just registered.
+  # It also leaves a rollback: repoint a schedule at an earlier revision.
+  skip_destroy = true
+
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = var.task_cpu
@@ -280,7 +289,11 @@ resource "aws_cloudwatch_log_group" "index_load" {
 }
 
 resource "aws_ecs_task_definition" "index_load" {
-  family                   = var.index_load_name_prefix
+  family = var.index_load_name_prefix
+
+  # See the note on aws_ecs_task_definition.this.
+  skip_destroy = true
+
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = var.index_load_task_cpu

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 locals {
   container_name       = "hist-load"
   tags                 = merge({ Project = "FattoreStreet", Component = "springboot-hist-load" }, var.tags)
@@ -188,14 +190,22 @@ resource "aws_iam_role" "scheduler" {
 data "aws_iam_policy_document" "scheduler_run_task" {
   statement {
     actions = ["ecs:RunTask"]
-    # Wildcards only. `family:*` already matches every revision, so pinning the
-    # current one adds nothing but makes this policy change on every task
-    # definition edit -- which turns a routine apply into an IAM write, and the
-    # local developer role has none by design. Keeping it static means an apply
-    # that only touches task definitions needs no admin.
+    # Wildcards only, and built from variables rather than from the task
+    # definition resources. `family:*` already matches every revision, so
+    # pinning the current one adds nothing.
+    #
+    # The string interpolation is deliberate. Referencing
+    # `aws_ecs_task_definition.this.arn_without_revision` would be tidier, but it
+    # makes this document unknown at plan time whenever a task definition is
+    # replaced, so Terraform plans a policy update and calls iam:PutRolePolicy on
+    # every apply. `iam:Put*` is an explicit deny on the local developer role, so
+    # that turns every routine task definition change into CloudShell work. The
+    # family names are plain variables, so composing the ARNs by hand keeps this
+    # document static: it is known at plan time and does not change when a task
+    # definition is replaced.
     resources = [
-      "${aws_ecs_task_definition.this.arn_without_revision}:*",
-      "${aws_ecs_task_definition.index_load.arn_without_revision}:*",
+      "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${var.name_prefix}:*",
+      "arn:aws:ecs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:task-definition/${var.index_load_name_prefix}:*",
     ]
     condition {
       test     = "ArnLike"

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -141,9 +141,15 @@ resource "aws_ecs_task_definition" "this" {
 
       # Pull individual keys out of the single fattorestreet/env JSON secret.
       # ECS syntax: <secret-arn>:<json-key>:<version-stage>:<version-id> (last two left empty).
+      # SEC_CONTACT_EMAIL is not sensitive, but it lives in the same JSON secret,
+      # so pulling it from there beats adding a variable that would put an email
+      # address in tfvars. Without it the SEC User-Agent is empty and data.sec.gov
+      # answers 403 "Undeclared Automated Tool", which fails corporate-action
+      # detection after the price load.
       secrets = [
         { name = "POSTGRES_PASSWORD", valueFrom = "${var.env_secret_arn}:POSTGRES_PASSWORD::" },
         { name = "SECRET_KEY", valueFrom = "${var.env_secret_arn}:SECRET_KEY::" },
+        { name = "SEC_CONTACT_EMAIL", valueFrom = "${var.env_secret_arn}:SEC_CONTACT_EMAIL::" },
       ]
 
       logConfiguration = {
@@ -290,9 +296,13 @@ resource "aws_ecs_task_definition" "index_load" {
 
       # Pull individual keys out of the single fattorestreet/env JSON secret.
       # ECS syntax: <secret-arn>:<json-key>:<version-stage>:<version-id> (last two left empty).
+      # SEC_CONTACT_EMAIL is required: the metrics refresh calls data.sec.gov for
+      # every ticker, and an empty User-Agent gets 403 "Undeclared Automated Tool",
+      # which skips every ticker and exits the task non-zero.
       secrets = [
         { name = "POSTGRES_PASSWORD", valueFrom = "${var.env_secret_arn}:POSTGRES_PASSWORD::" },
         { name = "SECRET_KEY", valueFrom = "${var.env_secret_arn}:SECRET_KEY::" },
+        { name = "SEC_CONTACT_EMAIL", valueFrom = "${var.env_secret_arn}:SEC_CONTACT_EMAIL::" },
       ]
 
       logConfiguration = {

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -188,11 +188,14 @@ resource "aws_iam_role" "scheduler" {
 data "aws_iam_policy_document" "scheduler_run_task" {
   statement {
     actions = ["ecs:RunTask"]
+    # Wildcards only. `family:*` already matches every revision, so pinning the
+    # current one adds nothing but makes this policy change on every task
+    # definition edit -- which turns a routine apply into an IAM write, and the
+    # local developer role has none by design. Keeping it static means an apply
+    # that only touches task definitions needs no admin.
     resources = [
       "${aws_ecs_task_definition.this.arn_without_revision}:*",
-      aws_ecs_task_definition.this.arn,
       "${aws_ecs_task_definition.index_load.arn_without_revision}:*",
-      aws_ecs_task_definition.index_load.arn,
     ]
     condition {
       test     = "ArnLike"


### PR DESCRIPTION
## Why

Local AWS access ran through IAM user `Spike` (`Admin` group, `AdministratorAccess`) using a static key created by hand to run one `terraform apply` in June, which then simply stayed. That key is now deactivated, so the CLI, Terraform, SSM, and ECR push had no working credentials.

Two commits, same story: CI stopped drifting between registries, and local access stopped being an admin key.

## What changed

**`bd37eda5`** publishes the springboot image to ECR alongside GHCR in the same build step, so the registries cannot drift, and adds the `aws-inspect` skill.

**`4389e14c`** replaces the admin key with IAM user `claude-code`, whose only permission is `sts:AssumeRole` on `FattoreStreetDeveloper`. The role carries the grants, so the key on disk is worthless alone, sessions expire hourly and refresh transparently, and CloudTrail attributes every call to `assumed-role/FattoreStreetDeveloper/claude-code`. Revoking is one edit to the trust policy.

`deploy/iam/` holds the five policy documents with `<ACCOUNT_ID>`/`<VPC_ID>` placeholders, `render.sh` to substitute them into a temp dir outside the repo, and `CONSOLE-SETUP.md` for the browser click-path. Splitting the role into `infra`/`ops`/`guardrails` keeps each document well under the 6,144-char managed-policy limit and makes the deny layer reviewable on its own.

## Notes for review

- **No IAM write, no secret-value read.** Both are explicit denies that beat any allow. Terraform needs neither: the module has no `aws_secretsmanager_*` data source, and `env_secret_arn` is only ever passed through as a string, with the execution role resolving it at container launch. IAM changes in the module are applied by a human from CloudShell.
- **No `mfa_serial`**, deliberately: a prompt would block every non-interactive call. The indirection, hourly expiry, and one-line revocability carry the weight instead.
- `iam:PassRole` to `ecs-tasks` is unavoidable for `ecs run-task`. Not an escalation path here: the roles it can pass are narrow by construction (execution role = ECR pull + log write + read one secret; task role = empty).
- `ecs:RegisterTaskDefinition` and `sns:ListSecrets`-style reads sit on `*` because those actions have no resource-level scoping. The region deny covers them.

## Verified

Under `AWS_PROFILE=fattorestreet`:

- `sts:GetCallerIdentity` returns `assumed-role/FattoreStreetDeveloper/claude-code`, `AROA…`
- Reads work: ECR, ECS cluster, both schedules, both log groups
- All eight guardrails deny: self-minting a key, attaching `AdministratorAccess`, role chaining, `GetSecretValue`, `us-west-2`, S3, RDS, Lambda

CI is unaffected throughout; it uses OIDC and stores no key.

## Found, not fixed here

`terraform plan` returns `1 to add` for `aws_sns_topic_subscription.task_failures_email[0]`. This is real pre-existing drift, not a permissions gap: the read succeeds and returns `SubscriptionsConfirmed 0 / Pending 0 / Deleted 0` while state holds it as `pending_confirmation = true`. The confirmation email was never clicked and AWS deletes unconfirmed email subscriptions after 3 days, so **nightly load failures have alerted nobody since ~2026-07-22**. Fix is `apply` plus clicking the link; tracked in the plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)