### PR TITLE
Upgrade Spring Boot service to Java 25 LTS

### DIFF
--- a/.claude/plans/it-looks-like-the-memoized-conway.md
+++ b/.claude/plans/it-looks-like-the-memoized-conway.md
@@ -1,0 +1,211 @@
+# Upgrade the Spring Boot service to Java 25 LTS
+
+## Context
+
+`springboot/Dockerfile` currently builds on `maven:3.9.9-eclipse-temurin-17` and runs on
+`eclipse-temurin:19-jre-focal`. Both halves of that runtime line are dead:
+
+- **Java 19** is a non-LTS release that went EOL in March 2023.
+- **`focal`** (Ubuntu 20.04) left standard support in April 2025, so the apt layer that
+  installs `curl unzip jq ca-certificates` + AWS CLI v2 is pulling from a distro that no
+  longer gets routine security updates.
+
+Dependabot has never offered a fix because `eclipse-temurin:19-jre-focal` is a dead tag
+*family*, not an outdated tag: there is no newer version within `19`/`focal` to bump to.
+The move has to be made by hand.
+
+There is also a second-order problem: the jar is compiled for 17 and run on 19, so the
+build and runtime JDKs already disagree. Bumping only the runtime image would fix the EOL
+exposure but leave that drift in place.
+
+**Intended outcome:** the whole Spring Boot toolchain (build JDK, compile target, CI, and
+container runtime) lands on **Java 25 LTS**, supported into the 2030s, with build and
+runtime versions equal for the first time. Spring Boot 4.1 supports Java 17 through 26,
+so 25 is comfortably inside the supported range and is the newest LTS available.
+
+Java 26 was considered and rejected: it is the newest stable release, but non-LTS, and
+goes EOL around September 2026, which is exactly how the repo ended up on Java 19.
+
+## Target versions
+
+| Thing | Now | Target | Why |
+|---|---|---|---|
+| Runtime base image | `eclipse-temurin:19-jre-focal` | `eclipse-temurin:25-jre-noble` | LTS JRE on Ubuntu 24.04; arm64 published |
+| Build base image | `maven:3.9.9-eclipse-temurin-17` | `maven:3.9.16-eclipse-temurin-25` | newest Maven 3.9.x on JDK 25 |
+| `<java.version>` | `17` | `25` | compile target follows the runtime |
+| Enforcer `requireJavaVersion` | `[17,)` | `[25,)` | stop a stale local JDK compiling a jar the image can't run |
+| Enforcer `requireMavenVersion` | `[3.9.0,)` | `[3.9.0,)` (unchanged) | floor is still correct |
+| Maven wrapper | `3.9.9` | `3.9.16` | keeps the "wrapper == builder image" invariant the Dockerfile comment asserts |
+| CI `setup-java` | `17` | `25` | must match the enforcer floor |
+| Error Prone | `2.36.0` | `2.50.0` | **required**: 2.36.0 predates JDK 25 and cannot run on it |
+| maven-pmd-plugin | `3.27.0` | `3.28.0` | **required**: 3.27.0 bundles PMD 7.14.0, which rejects `targetJdk 25`; 3.28.0 bundles PMD 7.17.0 (Java 25 support landed in PMD 7.16.0) |
+| spotbugs-annotations | `4.9.6` | `4.10.3` | consistency with `spotbugs-maven-plugin` 4.10.3.0 |
+
+Already Java 25-ready, leave alone: JaCoCo `0.8.15` (officially supports class files
+through Java 26), `spotbugs-maven-plugin` `4.10.3.0` (documented on JDK 25), Checkstyle
+`10.26.1` + plugin `3.6.0`, Spotless `2.46.1`, FindSecBugs `1.14.0`, enforcer `3.6.2`.
+
+`springboot/.mvn/jvm.config` needs **no change**. Its ten `--add-exports` /`--add-opens`
+flags are byte-for-byte the set Error Prone still documents for JDK 16+, and 2.50.0 wants
+the same ones.
+
+## Changes
+
+### 1. `springboot/Dockerfile`
+
+Two `FROM` lines plus the comment block above them.
+
+- Line 5: `FROM maven:3.9.16-eclipse-temurin-25 AS build`
+- Line 15: `FROM eclipse-temurin:25-jre-noble`
+- Rewrite the lines 2-4 comment so it names 3.9.16/25 and explains the LTS choice instead
+  of describing the old `maven:3.8-openjdk-18` problem.
+
+`noble` is glibc, so the existing apt + `awscli-exe-linux-$(uname -m).zip` install at
+lines 20-25 works unchanged (alpine would break it; AWS CLI v2 ships no musl build). The
+`-Dquality.skip=true` on line 12 stays: `.mvn/` and `config/` are still outside the build
+context, so the errorprone profile must stay deactivated there.
+
+### 2. `springboot/pom.xml`
+
+- Line 31: `<java.version>25</java.version>`
+- Line 56: `<errorprone.version>2.50.0</errorprone.version>`
+- Line 55: `<pmd.plugin.version>3.28.0</pmd.plugin.version>`
+- Line 54: `<spotbugs.annotations.version>4.10.3</spotbugs.annotations.version>`
+- Lines 192-194: `requireJavaVersion` -> `[25,)`
+- Lines 187-188: update the comment that names `maven:3.9.9`
+
+Nothing else in the pom is version-coupled. The Boot 4.1 parent derives
+`maven.compiler.release` from `<java.version>`, and maven-pmd-plugin derives `targetJdk`
+from the same property, which is exactly why the PMD bump is mandatory.
+
+### 3. `springboot/.mvn/wrapper/maven-wrapper.properties`
+
+Point `distributionUrl` at `apache-maven-3.9.16-bin.zip`. Leave `wrapperUrl`
+(maven-wrapper 3.3.2) alone.
+
+### 4. `.github/workflows/ci.yml`
+
+In the `springboot` job, `java-version: "17"` -> `"25"` (around line 96). Distribution
+stays `temurin`, `cache: maven` stays. No other job touches Java.
+
+`docker-build.yml` needs **no change**: it builds from the Dockerfile on
+`ubuntu-24.04-arm`, and both new base images publish linux/arm64.
+
+### 5. Terraform / deploy
+
+**No changes.** `springboot/deploy/terraform/main.tf` pins `runtime_platform` ARM64 and
+`image_tag = "latest"` for both task definitions; the new image is still arm64 and still
+`:latest`. `deploy/docker-compose.yml`, `deploy/docker-compose.dev.yml` and `deploy/run.sh`
+reference the image by name only.
+
+### 6. Docs
+
+Mechanical version-string updates, all currently saying "Java 17":
+
+- `CLAUDE.md:13` (component table row for the SEC microservice)
+- `README.md:55`
+- `springboot/README.md:28`, `:59`, `:333` (the enforcer row: "Maven 3.9+, Java 25+")
+- `.claude/rules/springboot-java.md:30` ("Java 17 features are available...") -> Java 25,
+  and refresh the feature examples (records/sealed/pattern matching are now table stakes;
+  virtual threads, sequenced collections, pattern matching for switch are the new ones)
+
+While in `springboot/README.md:28`, also fix the stale **"Spring Boot 3.4.2"** on that same
+line: the pom parent has been `4.1.0` for a while and the README never caught up.
+
+## Expected fallout, and how to handle it
+
+This is the part that will take the actual time. Two independent sources of new build
+failures, both in `mvn verify`, neither visible until the toolchain is switched:
+
+**a) Error Prone 2.36.0 -> 2.50.0 is fourteen releases of new checks**, and
+`springboot/pom.xml:428` sets `-Werror` on main sources, so *any* new WARNING-tier finding
+fails the build. Triage each one against the convention already documented in the pom at
+lines 62-63: fix the code where the check is right, and only add a `-Xep:<Check>:OFF` to
+`errorprone.checks.common` with a comment saying why it does not apply. Do not remove
+`-Werror` to make the build pass.
+
+Also confirm the nine check names currently referenced (`MissingSummary`, `NonApiType`,
+`InlineFormatString`, `MixedMutabilityReturnType`, `ArrayRecordComponent`,
+`JavaTimeDefaultTimeZone`, `UnusedMethod`, `UnusedVariable`, `UnusedNestedClass`) all still
+exist in 2.50.0. Error Prone hard-fails on an unrecognised `-Xep:` flag, so a rename would
+surface immediately as a compiler error rather than a silent no-op.
+
+**b) `-Xlint:deprecation` on JDK 25.** javac will now warn about APIs deprecated between
+17 and 25 that were fine before, and `-Werror` turns each into a failure. These are real
+findings and should be fixed rather than suppressed.
+
+Test sources deliberately do not get `-Werror` (`errorprone.checks.test`, pom line 90), so
+fallout there is advisory only.
+
+Note that (a) cannot be de-risked by landing the Error Prone bump separately first: 2.43.0+
+requires JDK 21 or newer to run, so 2.50.0 is unusable until the JDK moves. The two are
+one atomic change. Plan on working the findings down on the branch before opening the PR.
+
+## Verification
+
+Local prerequisite: this machine has only Homebrew OpenJDK 17
+(`java -version` -> `17.0.18`). Install a JDK 25 first, e.g. `brew install openjdk@25`,
+and point `JAVA_HOME` at it for the session. Local Maven is already 3.9.16, matching the
+new wrapper and builder image.
+
+1. **Full quality gate, the same sequence CI runs:**
+   ```bash
+   cd springboot
+   ./mvnw -B -ntp spotless:check      # confirms Spotless/GJF removeUnusedImports works on 25
+   ./mvnw -B -ntp checkstyle:check    # confirms Checkstyle 10.26.1 runs on 25
+   ./mvnw -B -ntp verify              # errorprone + tests + jacoco floor + spotbugs + PMD
+   ```
+   `verify` is the one that matters: it is the only step that exercises Error Prone, the
+   PMD `targetJdk 25` path, JaCoCo's class-file reader, and SpotBugs' BCEL bytecode parse
+   against real Java 25 class files (major version 69).
+
+2. **Confirm the compile target actually moved** (guards against the release flag being
+   ignored):
+   ```bash
+   javap -v -cp target/classes com/fattorestreet/sec_api/util/MarketTime.class | grep major
+   # expect: major version: 69
+   ```
+
+3. **Build the image for the deployment architecture and check both JVMs:**
+   ```bash
+   docker buildx build --platform linux/arm64 -t springboot:jdk25 springboot/
+   docker run --rm --entrypoint java springboot:jdk25 -version   # expect Temurin 25
+   ```
+   arm64 explicitly, because the EC2 host is Graviton and both Fargate task definitions
+   pin `cpu_architecture = "ARM64"`. This also proves the AWS CLI v2 install still
+   succeeds on noble, which the entrypoint depends on for `SECRETS_ARN`.
+
+4. **Run the service end to end** via the dev compose stack, which builds from the
+   Dockerfile rather than pulling GHCR:
+   ```bash
+   docker compose -f deploy/docker-compose.infra.yml -f deploy/docker-compose.dev.yml up -d springboot
+   docker logs -f springboot   # Boot 4.1 banner, no JVM/module warnings, Flyway migrations apply
+   curl -s localhost:8080/actuator/health   # or a known public endpoint such as /fred-data
+   ```
+   Watch specifically for Hibernate/ByteBuddy complaints about an unsupported class file
+   version at proxy-generation time, which is the classic way a JDK bump fails at runtime
+   rather than at build time.
+
+5. **After merge**, `docker-build.yml` publishes to GHCR *and* the `fattorestreet-hist-load`
+   ECR repo in the same step, and both task definitions pin `:latest`, so the next nightly
+   Fargate run picks up Java 25 automatically. Don't wait for the schedule: trigger one
+   `hist-load` task manually and confirm it reaches `STOPPED` with exit code 0 rather than
+   silently degrading. Use the `aws-inspect` skill to read the CloudWatch logs and to
+   confirm the cluster is back to zero running tasks afterwards.
+
+**Rollback:** the change is confined to base image tags and plugin versions, so reverting
+the commit and re-running `docker-build.yml` restores the old image. The Fargate task
+definitions are untouched, so no `terraform apply` is involved in either direction.
+
+## Out of scope
+
+Called out because they are adjacent and tempting, but are separate decisions:
+
+- **No JVM flags added.** There is currently no `-XX:MaxRAMPercentage` or `-Xmx` anywhere
+  in the repo; the JVM runs on container defaults in compose, `run.sh`, and Fargate
+  (1024 CPU / 4096 MiB). Worth doing, but it is a memory-tuning change, not a version bump.
+- **Container still runs as root.** No `USER` directive is being added here.
+- **No move to alpine or distroless.** The AWS CLI v2 + jq entrypoint requires glibc and a
+  package manager.
+- **Not touching Maven 4.** Only `4.0.0-rc-*` images exist; staying on Maven 3.9.x.
+- **Django and nginx images are untouched.**

--- a/.claude/rules/springboot-java.md
+++ b/.claude/rules/springboot-java.md
@@ -27,7 +27,9 @@ Mirror the same package names under `src/test/java/.../sec_api/` for unit tests.
 
 ## Code Style
 
-- Java 17 features are available (records, sealed classes, pattern matching, text blocks)
+- Java 25 features are available: records, sealed classes, text blocks, pattern matching
+  for `switch`, record patterns, sequenced collections (`getFirst()`/`getLast()`), and
+  virtual threads
 - Use constructor injection (not field injection with `@Autowired`)
 - Logging via SLF4J: `private static final Logger log = LoggerFactory.getLogger(MyClass.class);`
 - Use `Map.ofEntries()` and `List.of()` for immutable collections

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "25"
           cache: maven
 
       # Fast gate first: fails in seconds, before the 564-test suite. Runs as a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ FattoreStreet is a full-stack financial portfolio and social platform. It's a mo
 |-----------|-----------|------------|
 | Frontend | `react-app/` | React 18, TypeScript, Vite, Redux Toolkit (RTK Query) |
 | Backend API | `django/` | Django 5, DRF, Redis cache, SimpleJWT |
-| SEC Microservice | `springboot/` | Spring Boot 4.1, Java 17, Spring Data JPA |
+| SEC Microservice | `springboot/` | Spring Boot 4.1, Java 25, Spring Data JPA |
 | Local AI | `llm/` | llama.cpp (Qwen2.5-7B), stable-diffusion.cpp, Kokoro TTS |
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ uv run python manage.py migrate
 uv run python manage.py runserver
 ```
 
-**Spring Boot (SEC / filings service)** — requires **Java 17**, **Maven**, and **PostgreSQL**. Copy or create `springboot/.env` with database credentials and **`SECRET_KEY` set to the same value as Django** (JWT verification for `/admin/**`; see [springboot/README.md](springboot/README.md)):
+**Spring Boot (SEC / filings service)** — requires **Java 25**, **Maven**, and **PostgreSQL**. Copy or create `springboot/.env` with database credentials and **`SECRET_KEY` set to the same value as Django** (JWT verification for `/admin/**`; see [springboot/README.md](springboot/README.md)):
 
 ```bash
 cd springboot

--- a/springboot/.mvn/wrapper/maven-wrapper.properties
+++ b/springboot/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/springboot/Dockerfile
+++ b/springboot/Dockerfile
@@ -1,8 +1,10 @@
 # Stage 1: Build
-# maven:3.9.9 matches .mvn/wrapper/maven-wrapper.properties and the enforcer
-# requireMavenVersion floor; temurin-17 matches <java.version>. The previous
-# maven:3.8-openjdk-18 was EOL and ran a JDK the project never targets.
-FROM maven:3.9.9-eclipse-temurin-17 AS build
+# maven:3.9.16 matches .mvn/wrapper/maven-wrapper.properties and clears the
+# enforcer requireMavenVersion floor; temurin-25 matches <java.version> and the
+# stage-2 runtime, so the jar is built and run on the same JDK. Always take an
+# LTS here: the previous eclipse-temurin:19 was non-LTS, went EOL, and left this
+# image stranded on a dead tag family that Dependabot could not bump.
+FROM maven:3.9.16-eclipse-temurin-25 AS build
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
@@ -12,7 +14,9 @@ COPY src ./src
 RUN mvn -B clean package -DskipTests -Dquality.skip=true
 
 # Stage 2: Runtime
-FROM eclipse-temurin:19-jre-focal
+# noble (Ubuntu 24.04) is deliberate: the AWS CLI v2 install below is a glibc
+# binary with no musl build, so alpine is not an option here.
+FROM eclipse-temurin:25-jre-noble
 WORKDIR /app
 
 # AWS CLI v2 + jq so the entrypoint can pull config from Secrets Manager at start.

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -25,7 +25,7 @@ Application code under `com.fattorestreet.sec_api`: `client` (SEC HTTP / `WebSer
 
 ## Stack
 
-- Java 17, Spring Boot 3.4.2
+- Java 25 (LTS), Spring Boot 4.1
 - Spring Data JPA + Hibernate (PostgreSQL)
 - **Hibernate Envers** — all JPA entities are audited (`@Audited`). Hibernate creates a `revinfo` table and per-entity `*_AUD` tables (for example `assets_AUD`, `daily_prices_AUD`). Expect **large** audit table growth on high-churn data, especially `daily_prices` ingests; plan disk and retention accordingly. The inverse `Asset.listings` collection is `@NotAudited` so listing history is tracked only via `listings_AUD`.
 - Spring Security OAuth2 Resource Server (JWT): admin routes verify Django SimpleJWT access tokens (HS256, same `SECRET_KEY`; only `user_id` claim `1` is granted admin)
@@ -56,7 +56,7 @@ Before adding or changing any external data source:
 
 ### Prerequisites
 
-- Java 17
+- Java 25 (the Maven enforcer fails the build on anything older)
 - Maven
 - PostgreSQL
 
@@ -330,7 +330,7 @@ Tests run from `target/` (surefire `workingDirectory`), so the optional `.env` i
 
 | Gate | Phase | Config |
 |---|---|---|
-| Maven enforcer (Maven 3.9+, Java 17+) | `validate` | `pom.xml` |
+| Maven enforcer (Maven 3.9+, Java 25+) | `validate` | `pom.xml` |
 | Spotless | `validate` | `pom.xml` (inline) |
 | Checkstyle | `validate` | `config/checkstyle/checkstyle.xml` |
 | SpotBugs + FindSecBugs | `verify` | `config/spotbugs/exclude.xml` |

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -28,7 +28,7 @@
 		<url />
 	</scm>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>25</java.version>
 
 		<!-- One switch that disables every format/static-analysis gate.
 		     The Docker build stage passes -Dquality.skip=true because it copies
@@ -51,9 +51,16 @@
 		     pass. Overridable on the command line so the gate itself can be
 		     tested (-Djacoco.line.minimum=0.95 should fail). -->
 		<jacoco.line.minimum>0.76</jacoco.line.minimum>
-		<spotbugs.annotations.version>4.9.6</spotbugs.annotations.version>
-		<pmd.plugin.version>3.27.0</pmd.plugin.version>
-		<errorprone.version>2.36.0</errorprone.version>
+		<spotbugs.annotations.version>4.10.3</spotbugs.annotations.version>
+		<!-- 3.28.0 bundles PMD 7.17.0. Do not drop below it: 3.27.0 shipped PMD
+		     7.14.0, which rejects the targetJdk value maven-pmd-plugin derives
+		     from java.version above with "Unsupported targetJdk value '25'".
+		     Java 25 support landed in PMD 7.16.0. -->
+		<pmd.plugin.version>3.28.0</pmd.plugin.version>
+		<!-- Error Prone 2.43.0 raised its own floor to JDK 21, and versions
+		     before that cannot run on JDK 25 at all, so this property is pinned
+		     to java.version above rather than being independently upgradable. -->
+		<errorprone.version>2.50.0</errorprone.version>
 		<!-- Error Prone check severities.
 
 		     Default tiers: ERROR-tier checks fail the build, WARNING-tier ones are
@@ -184,13 +191,16 @@
 						</goals>
 						<configuration>
 							<rules>
-								<!-- Matches .mvn/wrapper/maven-wrapper.properties and the
-								     maven:3.9.9 builder image in Dockerfile -->
+								<!-- Cleared by .mvn/wrapper/maven-wrapper.properties and the
+								     maven:3.9.16 builder image in Dockerfile -->
 								<requireMavenVersion>
 									<version>[3.9.0,)</version>
 								</requireMavenVersion>
+								<!-- Matches <java.version> and the eclipse-temurin:25 runtime
+								     image. A lower local JDK would silently produce a jar the
+								     container cannot load, so fail at validate instead. -->
 								<requireJavaVersion>
-									<version>[17,)</version>
+									<version>[25,)</version>
 								</requireJavaVersion>
 								<banDuplicatePomDependencyVersions />
 							</rules>

--- a/springboot/src/main/java/com/fattorestreet/sec_api/config/SecurityConfig.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
         if (raw == null) {
             return List.of();
         }
-        long userId = raw instanceof Number ? ((Number) raw).longValue() : Long.parseLong(raw.toString());
+        long userId = raw instanceof Number number ? number.longValue() : Long.parseLong(raw.toString());
         if (userId == ADMIN_DJANGO_USER_ID) {
             return List.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
         }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/controller/PublicController.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/controller/PublicController.java
@@ -309,8 +309,8 @@ public class PublicController {
         if (val == null) {
             return "0.00";
         }
-        if (val instanceof Number) {
-            return String.format("%.2f", ((Number) val).doubleValue());
+        if (val instanceof Number number) {
+            return String.format("%.2f", number.doubleValue());
         }
         return val.toString();
     }

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionFilingDateService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionFilingDateService.java
@@ -161,7 +161,7 @@ public class CorporateActionFilingDateService {
         List<DividendDeclarationTupleExtractor.DividendDeclaration> declarations = new ArrayList<>(declarationsByKey.values());
         declarations.sort(Comparator
                 .comparing(DividendDeclarationTupleExtractor.DividendDeclaration::recordDate)
-                .thenComparing(DividendDeclarationTupleExtractor.DividendDeclaration::amountPerShare));
+                .thenComparingDouble(DividendDeclarationTupleExtractor.DividendDeclaration::amountPerShare));
         log.info("[CIK {}] Dividend record-date scan finished: {} record-date candidates, {} direct ex-date candidates, {} declaration tuples ({} cached, {} fetched, {} failed, {} deferred)",
                 cik, out.size(), exOut.size(), declarations.size(), cachedFilings, fetchedFilings, failedFilings, budgetSkipped);
         return new RecordDateScanResult(out, exOut, declarations, selection.discoveredByForm(), selection.selectedByForm(), selection.rejectedByForm(),
@@ -988,8 +988,12 @@ public class CorporateActionFilingDateService {
         }
     }
 
-    /** Shared shape of candidates extracted from a dated SEC filing. */
-    private interface FilingDatedCandidate {
+    /**
+     * Shared shape of candidates extracted from a dated SEC filing. Package-private rather
+     * than private: the three candidate records below are public and name it in their
+     * {@code implements} clause, which a private type cannot appear in.
+     */
+    interface FilingDatedCandidate {
         LocalDate filingDate();
         String accessionNumber();
         int confidenceScore();

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/CorporateActionValidationService.java
@@ -124,7 +124,7 @@ public class CorporateActionValidationService {
                 out.add(new NormalizedEvent(ActionType.SPLIT, action.getEffectiveDate(), round4(action.getRatio()), "sec"));
             }
         }
-        out.sort(Comparator.comparing(NormalizedEvent::date).thenComparing(NormalizedEvent::value));
+        out.sort(Comparator.comparing(NormalizedEvent::date).thenComparingDouble(NormalizedEvent::value));
         return out;
     }
 
@@ -144,7 +144,7 @@ public class CorporateActionValidationService {
                     encodedTicker));
             parseDjangoDividends(dividends, minDateInclusive, out);
             parseDjangoSplits(splits, minDateInclusive, out);
-            out.sort(Comparator.comparing(NormalizedEvent::date).thenComparing(NormalizedEvent::value));
+            out.sort(Comparator.comparing(NormalizedEvent::date).thenComparingDouble(NormalizedEvent::value));
             return out;
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityDividendNormalizer.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityDividendNormalizer.java
@@ -162,7 +162,7 @@ public class EquityDividendNormalizer {
         combined.addAll(dedupedSpecials.values());
         combined.sort(Comparator
                 .comparing(EquityCorporateActionService.DividendEvent::fiscalPeriodEnd)
-                .thenComparing(EquityCorporateActionService.DividendEvent::rawAmount));
+                .thenComparingDouble(EquityCorporateActionService.DividendEvent::rawAmount));
         return combined;
     }
 

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityDividendUpserter.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityDividendUpserter.java
@@ -198,7 +198,7 @@ public class EquityDividendUpserter {
             keptByDate.put(event.effectiveDate(), sameDateCount + 1);
         }
         return deduped.values().stream()
-                .sorted(Comparator.comparing(EquityCorporateActionService.DividendEvent::effectiveDate).thenComparing(EquityCorporateActionService.DividendEvent::rawAmount))
+                .sorted(Comparator.comparing(EquityCorporateActionService.DividendEvent::effectiveDate).thenComparingDouble(EquityCorporateActionService.DividendEvent::rawAmount))
                 .toList();
     }
 

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityExDateAssigner.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/support/EquityExDateAssigner.java
@@ -188,7 +188,7 @@ public class EquityExDateAssigner {
             }
         }
         int promotedTupleEvents = promoteUnmatchedDeclarations(mapped, regularEvents, tuples, usedTuples);
-        mapped.sort(Comparator.comparing(EquityCorporateActionService.DividendEvent::effectiveDate).thenComparing(EquityCorporateActionService.DividendEvent::rawAmount));
+        mapped.sort(Comparator.comparing(EquityCorporateActionService.DividendEvent::effectiveDate).thenComparingDouble(EquityCorporateActionService.DividendEvent::rawAmount));
         return new EquityCorporateActionService.AssignmentResult(
                 mapped, tupleMatchedAssignments, directExAssignments, dpAssignments, syntheticAssignments,
                 promotedTupleEvents);

--- a/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/fundamentals/EdgarService.java
@@ -437,54 +437,25 @@ public class EdgarService {
         if (val == null || !(val instanceof Number num))
             return;
         switch (field) {
-            case "revenues":
-                q.setRevenues(num.longValue());
-                break;
-            case "netIncomeLoss":
-                q.setNetIncomeLoss(num.longValue());
-                break;
-            case "operatingIncomeLoss":
-                q.setOperatingIncomeLoss(num.longValue());
-                break;
-            case "grossProfit":
-                q.setGrossProfit(num.longValue());
-                break;
-            case "earningsPerShareBasic":
-                q.setEarningsPerShareBasic(num.doubleValue());
-                break;
-            case "earningsPerShareDiluted":
-                q.setEarningsPerShareDiluted(num.doubleValue());
-                break;
-            case "assets":
-                q.setAssets(num.longValue());
-                break;
-            case "liabilities":
-                q.setLiabilities(num.longValue());
-                break;
-            case "stockholdersEquity":
-                q.setStockholdersEquity(num.longValue());
-                break;
-            case "cashAndCashEquivalentsAtCarryingValue":
+            case "revenues" -> q.setRevenues(num.longValue());
+            case "netIncomeLoss" -> q.setNetIncomeLoss(num.longValue());
+            case "operatingIncomeLoss" -> q.setOperatingIncomeLoss(num.longValue());
+            case "grossProfit" -> q.setGrossProfit(num.longValue());
+            case "earningsPerShareBasic" -> q.setEarningsPerShareBasic(num.doubleValue());
+            case "earningsPerShareDiluted" -> q.setEarningsPerShareDiluted(num.doubleValue());
+            case "assets" -> q.setAssets(num.longValue());
+            case "liabilities" -> q.setLiabilities(num.longValue());
+            case "stockholdersEquity" -> q.setStockholdersEquity(num.longValue());
+            case "cashAndCashEquivalentsAtCarryingValue" ->
                 q.setCashAndCashEquivalentsAtCarryingValue(num.longValue());
-                break;
-            case "accountsReceivableNetCurrent":
-                q.setAccountsReceivableNetCurrent(num.longValue());
-                break;
-            case "inventoryNet":
-                q.setInventoryNet(num.longValue());
-                break;
-            case "netCashProvidedByUsedInOperatingActivities":
+            case "accountsReceivableNetCurrent" -> q.setAccountsReceivableNetCurrent(num.longValue());
+            case "inventoryNet" -> q.setInventoryNet(num.longValue());
+            case "netCashProvidedByUsedInOperatingActivities" ->
                 q.setNetCashProvidedByUsedInOperatingActivities(num.longValue());
-                break;
-            case "paymentsOfDividends":
-                q.setPaymentsOfDividends(num.longValue());
-                break;
-            case "paymentsForRepurchaseOfCommonStock":
-                q.setPaymentsForRepurchaseOfCommonStock(num.longValue());
-                break;
-            default:
-                // field is not one this method maps onto Quarter; ignore it
-                break;
+            case "paymentsOfDividends" -> q.setPaymentsOfDividends(num.longValue());
+            case "paymentsForRepurchaseOfCommonStock" -> q.setPaymentsForRepurchaseOfCommonStock(num.longValue());
+            // field is not one this method maps onto Quarter; ignore it
+            default -> {}
         }
     }
 

--- a/springboot/src/main/java/com/fattorestreet/sec_api/index/SecIndexFactsParser.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/index/SecIndexFactsParser.java
@@ -210,7 +210,7 @@ public final class SecIndexFactsParser {
     /**
      * Classifies SEC "state or country" / incorporation strings into country + optional US state or opaque code.
      */
-    static LocationParts classifyJurisdiction(String raw) {
+    private static LocationParts classifyJurisdiction(String raw) {
         if (raw == null || raw.isBlank()) {
             return LocationParts.empty();
         }


### PR DESCRIPTION
## Why

`springboot/Dockerfile` ran on `eclipse-temurin:19-jre-focal`. Both halves of that were dead:

- **Java 19** is non-LTS and went EOL in March 2023.
- **focal** (Ubuntu 20.04) left standard support in April 2025, so the apt layer installing `curl unzip jq ca-certificates` + AWS CLI v2 was pulling from a distro with no routine security updates.

Dependabot never offered a fix because both are dead tag *families*, not outdated tags: there is no newer version within `19`/`focal` to bump to.

The build JDK (17) and runtime JDK (19) also disagreed. This moves the whole toolchain to **Java 25 LTS** so they match, rather than bumping only the runtime and leaving that drift in place. Java 26 was rejected as non-LTS: it goes EOL around September 2026, which is exactly how this repo ended up on Java 19.

## Changes

| Thing | Before | After |
|---|---|---|
| Runtime image | `eclipse-temurin:19-jre-focal` | `eclipse-temurin:25-jre-noble` |
| Build image | `maven:3.9.9-eclipse-temurin-17` | `maven:3.9.16-eclipse-temurin-25` |
| `<java.version>` | 17 | 25 |
| Enforcer `requireJavaVersion` | `[17,)` | `[25,)` |
| Maven wrapper | 3.9.9 | 3.9.16 |
| CI `setup-java` | 17 | 25 |
| Error Prone | 2.36.0 | 2.50.0 |
| maven-pmd-plugin | 3.27.0 | 3.28.0 |
| spotbugs-annotations | 4.9.6 | 4.10.3 |

The two plugin bumps are **forced by the JDK move, not optional**:

- Error Prone before 2.43.0 cannot run on JDK 25 at all.
- maven-pmd-plugin 3.27.0 bundles PMD 7.14.0, which rejects the `targetJdk` it derives from `java.version` with `Unsupported targetJdk value '25'`. Java 25 support landed in PMD 7.16.0, bundled by 3.28.0.

JaCoCo 0.8.15, SpotBugs 4.10.3.0, Checkstyle 10.26.1 and Spotless 2.46.1 already support JDK 25 and are unchanged. `.mvn/jvm.config` is unchanged: its ten `--add-exports`/`--add-opens` flags are still exactly what Error Prone documents.

**No infra changes.** Terraform task definitions and compose files are untouched: the image is still `linux/arm64` and still tagged `latest`, so the nightly Fargate loads pick it up on merge with no `terraform apply`.

## Error Prone fallout

2.50.0 adds checks that `-Werror` on main sources turns into build failures. All eight findings were **fixed rather than silenced**, and each is behaviour-preserving:

- **BoxingComparator** (×6): `thenComparing` → `thenComparingDouble` on primitive `double` getters. Both paths end in `Double.compare`, so ordering (including NaN/-0.0) is identical.
- **PatternMatchingInstanceof** (×2): `instanceof` + explicit cast → pattern binding.
- **StatementSwitchToExpressionSwitch**: `EdgarService.setQuarterField` converted to an arrow switch, matching `getQuarterField` directly below it. Every case already had its own `break`, and `default` was already a no-op.
- **ExposedPrivateType** (×2): `SecIndexFactsParser.classifyJurisdiction` made `private` (both call sites are in-class, no test references it); `FilingDatedCandidate` made package-private, since three **public** records name it in their `implements` clause.

No `-Xep:...:OFF` entries were added and `-Werror` stays on.

## Verification

- `./mvnw verify` green on JDK 25: **571 tests**, coverage floor met, Spotless + Checkstyle + PMD + SpotBugs/FindSecBugs all clean
- Compiled class files at **major version 69** (Java 25), confirming `--release 25` took effect
- `docker buildx build --platform linux/arm64` succeeds; image reports **Temurin 25.0.3 LTS**, `linux/arm64`, with AWS CLI v2 (`aarch64.ubuntu.24`) still installing on noble, which the `SECRETS_ARN` entrypoint depends on
- Service boots against postgres via the dev compose stack: Flyway connects and migrates, Hibernate/ByteBuddy raise no class-file-version complaints, app starts in 4.5s, `GET /indexes` returns 200
- `detect-secrets` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)