### PR TITLE
Restrict the nightly price adjustment to equities

### DIFF
--- a/springboot/README.md
+++ b/springboot/README.md
@@ -72,6 +72,7 @@ Before adding or changing any external data source:
 | (property) `fattore50.rebuild.top-n` | `50` | How many names the Fattore 50 rebuild includes. Set in `.env` as `fattore50.rebuild.top-n=50` if needed. |
 | (property) `fattore100.rebuild.top-n` | `100` | How many names the Fattore 100 rebuild includes. Set in `.env` as `fattore100.rebuild.top-n=100` if needed. |
 | (property) `fattore1000.rebuild.top-n` | `1000` | How many names the Fattore 1000 rebuild includes. Set in `.env` as `fattore1000.rebuild.top-n=1000` if needed. |
+| `HIST_LOAD_EQUITY_ONLY` | `false` | When `true`, the post-load price adjustment skips fund tickers. ETF detection fetches hundreds of filings per fund and dominates the runtime; the scheduled Fargate task sets this to `true`. |
 | `INDEX_LOAD_YEAR` | `0` (current year) | Target calendar year for the one-shot index load (`APP_RUN_MODE=index-load`) |
 | `INDEX_LOAD_SCOPE` | `russell1000` | Index-load metrics refresh scope: `russell1000` (IWB universe) or `all` |
 | `INDEX_LOAD_SKIP_REFRESH` | `false` | When `true`, the index load skips the metrics refresh and only rebuilds |
@@ -182,7 +183,17 @@ most recent closes is re-detected immediately (split signature; the check scans 
 a multi-day catch-up load cannot bury the break). A failed SEC fetch does **not** stamp
 `last_sec_detection_at`, so the ticker retries the next run instead of waiting out the interval.
 Price rows are only written when an adjusted value actually changes, so the nightly run writes just
-the new rows unless detection changed an action. The endpoints below stay available for manual runs:
+the new rows unless detection changed an action.
+
+The scheduled task sets `HIST_LOAD_EQUITY_ONLY=true` (property `app.hist-load.equity-only`,
+Terraform variable `hist_load_equity_only`), so the nightly adjustment covers equities only. ETFs
+have no XBRL dividend facts, so `EtfCorporateActionService` brute-force fetches the filing index and
+hundreds of documents per fund against the SEC rate limit; leaving funds in stretched nightly runs
+past 17 hours. Fund detection stays available on demand through the `etfOnly` parameter on the
+endpoints below. The property defaults to `false`, so a manual `hist-load` run still covers
+everything.
+
+The endpoints below stay available for manual runs:
 
 ```bash
 # Adjust all tickers (rolling SEC re-detection: stalest ~1/7 of tickers + price-jump triggers)

--- a/springboot/deploy/terraform/README.md
+++ b/springboot/deploy/terraform/README.md
@@ -7,7 +7,9 @@ the one-shot loads on Fargate — run mode is selected purely by the `APP_RUN_MO
 - **`hist-load`** (`HistLoadRunner`) — the bulky IEX price load (`IexHistService.loadHistData`),
   which runs once and exits. After a successful load the task also runs corporate-action price
   adjustment (`adjustAllTickers`, rolling SEC re-detection included); set
-  `HIST_LOAD_ADJUST_ENABLED=false` on the task to skip it.
+  `HIST_LOAD_ADJUST_ENABLED=false` on the task to skip it. The adjustment is restricted to
+  equities via `HIST_LOAD_EQUITY_ONLY=true` (variable `hist_load_equity_only`) because ETF
+  detection is SEC-fetch bound and dominates the runtime.
 - **`index-load`** (`IndexLoadRunner`) — index metrics refresh (SEC companyfacts/submissions for
   the Russell 1000 universe) followed by cap-ranked rebuilds of FAT100, FAT1000, FAT50. Scheduled
   a few hours **after** the hist load so fresh `DailyPrice` rows exist. Guard: if the refresh
@@ -276,6 +278,7 @@ That is pennies a month for now; add a second `imageCountMoreThan` rule if it gr
 |----------|---------|-------|
 | `task_memory` | `4096` | Lower to `2048` after profiling a real run. |
 | `hist_load_days` | `20` | Days walked back; already-loaded days are skipped (idempotent). |
+| `hist_load_equity_only` | `true` | Restricts the post-load adjustment to non-fund tickers. Set `false` to include ETFs, accepting a much longer run. |
 | `schedule_expression` / `schedule_timezone` | `cron(30 6 * * ? *)` / `Etc/UTC` | When the hist load runs (tfvars example: `cron(0 2 * * ? *)` / `America/New_York`). |
 | `schedule_enabled` | `true` | Toggle the nightly hist-load trigger. |
 | `index_load_task_cpu` / `index_load_task_memory` | `512` / `2048` | The index load is SEC-rate-limit bound (mostly idle); profile the first real run. |

--- a/springboot/deploy/terraform/main.tf
+++ b/springboot/deploy/terraform/main.tf
@@ -181,6 +181,7 @@ resource "aws_ecs_task_definition" "this" {
       environment = [
         { name = "APP_RUN_MODE", value = "hist-load" },
         { name = "HIST_LOAD_DAYS", value = tostring(var.hist_load_days) },
+        { name = "HIST_LOAD_EQUITY_ONLY", value = tostring(var.hist_load_equity_only) },
         { name = "DB_URL", value = "jdbc:postgresql://${var.db_host}:${var.db_port}/${var.db_name}" },
         { name = "DB_USERNAME", value = var.db_username },
       ]

--- a/springboot/deploy/terraform/variables.tf
+++ b/springboot/deploy/terraform/variables.tf
@@ -100,6 +100,17 @@ variable "hist_load_days" {
   default     = 20
 }
 
+variable "hist_load_equity_only" {
+  description = <<-EOT
+    Restrict the post-load corporate-action adjustment to non-fund tickers (HIST_LOAD_EQUITY_ONLY).
+    ETF detection has no XBRL equivalent and brute-force fetches hundreds of filings per fund against
+    the SEC rate limit, which is what stretched nightly runs past 17 hours. Set false to include funds
+    again, accepting that runtime.
+  EOT
+  type        = bool
+  default     = true
+}
+
 # ---------------------------------------------------------------------------
 # Schedule.
 # ---------------------------------------------------------------------------

--- a/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/HistLoadRunner.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/marketdata/HistLoadRunner.java
@@ -26,11 +26,17 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * runner executes once the context is up, then exits) — port 8080 binds but receives no traffic
  * inside the isolated task, which keeps the boot path identical to the running service.
  *
- * <p>After a successful load, the corporate-action price adjustment runs
- * (default {@code AdjustmentOptions}, i.e. no force) unless {@code app.hist-load.adjust-enabled=false}: the
- * newly loaded rows have NULL adjusted columns, which selects exactly the tickers needing
- * recomputation, and the service's rolling staleness window plus price-jump trigger keep SEC
- * detection fresh. yfinance validation is never invoked here (dev-only diagnostics).
+ * <p>After a successful load, the corporate-action price adjustment runs (no force) unless
+ * {@code app.hist-load.adjust-enabled=false}: the newly loaded rows have NULL adjusted columns, which
+ * selects exactly the tickers needing recomputation, and the service's rolling staleness window plus
+ * price-jump trigger keep SEC detection fresh. yfinance validation is never invoked here (dev-only
+ * diagnostics).
+ *
+ * <p>{@code app.hist-load.equity-only=true} (env {@code HIST_LOAD_EQUITY_ONLY}) restricts the adjustment
+ * phase to non-fund tickers. ETF detection has no XBRL equivalent, so it fetches hundreds of filings per
+ * fund against the SEC rate limit and dominates the task's runtime; the scheduled Fargate task sets this
+ * so the nightly run stays short, leaving ETFs to the admin endpoint. Defaults to {@code false} so a
+ * manual {@code hist-load} run still covers everything.
  *
  * <p>Exit codes (surfaced as the container exit code): {@code 0} on completion, {@code 1} when the
  * load throws, every attempted day failed, or the adjustment phase throws. Per-day errors with at
@@ -53,6 +59,9 @@ public class HistLoadRunner implements ApplicationRunner {
 
     @Value("${app.hist-load.adjust-enabled:true}")
     private boolean adjustEnabled;
+
+    @Value("${app.hist-load.equity-only:false}")
+    private boolean equityOnly;
 
     public HistLoadRunner(IexHistService iexHistService,
                           PriceAdjustmentService priceAdjustmentService,
@@ -109,9 +118,11 @@ public class HistLoadRunner implements ApplicationRunner {
             return 0;
         }
         long startTime = System.currentTimeMillis();
-        log.info("Starting corporate-action price adjustment");
+        log.info("Starting corporate-action price adjustment (equityOnly={})", equityOnly);
         try {
-            Map<String, Object> result = priceAdjustmentService.adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS);
+            PriceAdjustmentService.AdjustmentOptions options =
+                    new PriceAdjustmentService.AdjustmentOptions(false, false, equityOnly, false);
+            Map<String, Object> result = priceAdjustmentService.adjustAllTickers(options);
             long elapsedMs = System.currentTimeMillis() - startTime;
             log.info("Price adjustment finished in {}m {}s -- tickersProcessed={}, failedTickers={}, "
                             + "scheduledDetections={}, jumpTriggeredDetections={}, pricesUpdated={}, snappedActions={}",

--- a/springboot/src/main/resources/application.properties
+++ b/springboot/src/main/resources/application.properties
@@ -8,6 +8,9 @@ app.run-mode=${APP_RUN_MODE:server}
 app.hist-load.days=${HIST_LOAD_DAYS:20}
 # Run corporate-action price adjustment after the one-shot load (hist-load mode only).
 app.hist-load.adjust-enabled=${HIST_LOAD_ADJUST_ENABLED:true}
+# Restrict that adjustment to non-fund tickers. ETF detection fetches hundreds of filings per fund
+# and dominates the runtime; the scheduled Fargate task sets this to true.
+app.hist-load.equity-only=${HIST_LOAD_EQUITY_ONLY:false}
 app.index-load.year=${INDEX_LOAD_YEAR:0}
 app.index-load.scope=${INDEX_LOAD_SCOPE:russell1000}
 app.index-load.skip-refresh=${INDEX_LOAD_SKIP_REFRESH:false}

--- a/springboot/src/test/java/com/fattorestreet/sec_api/marketdata/HistLoadRunnerTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/marketdata/HistLoadRunnerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.fattorestreet.sec_api.corporateaction.PriceAdjustmentService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,14 @@ class HistLoadRunnerTest {
     @Mock
     private ConfigurableApplicationContext context;
 
+    /** What the runner passes when equity-only is off: no force, no fund filter, no yfinance. */
+    private static final PriceAdjustmentService.AdjustmentOptions ALL_TICKERS =
+            new PriceAdjustmentService.AdjustmentOptions(false, false, false, false);
+
+    /** What the scheduled Fargate task passes (HIST_LOAD_EQUITY_ONLY=true): funds skipped. */
+    private static final PriceAdjustmentService.AdjustmentOptions EQUITY_ONLY =
+            new PriceAdjustmentService.AdjustmentOptions(false, false, true, false);
+
     private HistLoadRunner runner;
 
     @BeforeEach
@@ -36,6 +45,7 @@ class HistLoadRunnerTest {
         runner = new HistLoadRunner(iexHistService, priceAdjustmentService, context);
         ReflectionTestUtils.setField(runner, "days", 20);
         ReflectionTestUtils.setField(runner, "adjustEnabled", true);
+        ReflectionTestUtils.setField(runner, "equityOnly", false);
     }
 
     private void stubSuccessfulLoad() throws Exception {
@@ -44,7 +54,7 @@ class HistLoadRunnerTest {
     }
 
     private void stubSuccessfulAdjustment() {
-        when(priceAdjustmentService.adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS)).thenReturn(
+        when(priceAdjustmentService.adjustAllTickers(ALL_TICKERS)).thenReturn(
                 Map.of("tickersProcessed", 5, "failedTickers", 0, "scheduledDetections", 1,
                         "jumpTriggeredDetections", 0, "totalPricesUpdated", 100, "totalSnappedActions", 0));
     }
@@ -55,7 +65,7 @@ class HistLoadRunnerTest {
         stubSuccessfulAdjustment();
 
         assertEquals(0, runner.runLoad());
-        verify(priceAdjustmentService).adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS);
+        verify(priceAdjustmentService).adjustAllTickers(ALL_TICKERS);
     }
 
     @Test
@@ -83,7 +93,7 @@ class HistLoadRunnerTest {
                 Map.of("processed", 0, "skipped", 0, "notAvailable", 0, "errors", 4));
 
         assertEquals(1, runner.runLoad());
-        verify(priceAdjustmentService, never()).adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS);
+        verify(priceAdjustmentService, never()).adjustAllTickers(any());
     }
 
     @Test
@@ -91,15 +101,27 @@ class HistLoadRunnerTest {
         when(iexHistService.loadHistData(20)).thenThrow(new RuntimeException("boom"));
 
         assertEquals(1, runner.runLoad());
-        verify(priceAdjustmentService, never()).adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS);
+        verify(priceAdjustmentService, never()).adjustAllTickers(any());
     }
 
     @Test
     void returnsOneWhenAdjustmentThrows() throws Exception {
         stubSuccessfulLoad();
-        when(priceAdjustmentService.adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS)).thenThrow(new RuntimeException("adjust boom"));
+        when(priceAdjustmentService.adjustAllTickers(ALL_TICKERS)).thenThrow(new RuntimeException("adjust boom"));
 
         assertEquals(1, runner.runLoad());
+    }
+
+    @Test
+    void passesEquityOnlyWhenConfigured() throws Exception {
+        stubSuccessfulLoad();
+        ReflectionTestUtils.setField(runner, "equityOnly", true);
+        when(priceAdjustmentService.adjustAllTickers(EQUITY_ONLY)).thenReturn(
+                Map.of("tickersProcessed", 3, "failedTickers", 0, "scheduledDetections", 1,
+                        "jumpTriggeredDetections", 0, "totalPricesUpdated", 60, "totalSnappedActions", 0));
+
+        assertEquals(0, runner.runLoad());
+        verify(priceAdjustmentService).adjustAllTickers(EQUITY_ONLY);
     }
 
     @Test
@@ -108,6 +130,6 @@ class HistLoadRunnerTest {
         ReflectionTestUtils.setField(runner, "adjustEnabled", false);
 
         assertEquals(0, runner.runLoad());
-        verify(priceAdjustmentService, never()).adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS);
+        verify(priceAdjustmentService, never()).adjustAllTickers(any());
     }
 }


### PR DESCRIPTION
## Summary

- The nightly hist-load Fargate task ran **17h33m** on 2026-07-28 and had to be stopped by hand. The IEX price load finished early; the remainder was the corporate-action adjustment phase grinding through fund tickers.
- ETFs have no XBRL dividend facts, so `EtfCorporateActionService` brute-force fetches the filing index and hundreds of documents per fund. That run made **51,609 filing fetches across 88 ETFs** (avg 586 each) against the SEC rate limit, which accounts for essentially the entire runtime. Yield was 351 actions saved, with 51 of the 88 funds producing nothing. The 71 equities used the cheap companyfacts path.
- `HistLoadRunner` passed `AdjustmentOptions.DEFAULTS`, which sets neither `etfOnly` nor `equityOnly`, so the scheduled task had no way to opt out even though the knob already existed on the admin endpoint. This threads it through as `app.hist-load.equity-only` and sets `HIST_LOAD_EQUITY_ONLY=true` on the Fargate task definition.
- The property **defaults to `false`**, so a manual `hist-load` run still covers everything; the Terraform variable `hist_load_equity_only` defaults to `true` so only the scheduled task opts in. Fund detection stays reachable on demand through the `etfOnly` parameter on the admin endpoints.

## Test plan

- [x] `mvn -Dtest=HistLoadRunnerTest test` — 8 tests pass, including a new `passesEquityOnlyWhenConfigured` asserting the runner forwards the flag
- [x] The three `never()` verifies now match on `any()` rather than the old `DEFAULTS` instance, so they fail on a call with *any* options
- [x] `mvn spotless:check checkstyle:check` clean
- [x] `terraform fmt -check` and `terraform validate` clean
- [x] `terraform plan`: 1 to add, 1 to change, 1 to destroy (new task definition revision, schedule repointed, old revision deregistered) — the expected shape for a task-definition env change

## Deploy order

Merge first so CI publishes the image to ECR, **then** `terraform apply`. Applying first would point the schedule at a revision whose image does not yet read the property; harmless, since it would fall back to `false`, but it would not shorten tonight's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)