### PR TITLE
Route first-time SEC detection through the nightly cap

### DIFF
--- a/springboot/README.md
+++ b/springboot/README.md
@@ -196,6 +196,12 @@ among its most recent closes is re-detected immediately (split signature; the ch
 few rows so a multi-day catch-up load cannot bury the break). A failed SEC fetch does **not** stamp
 `last_sec_detection_at`, so the ticker retries the next run instead of waiting out the interval.
 
+First-time detection goes through the same rolling cap, not around it. A ticker that has never been
+detected sorts first in the staleness queue (null stamps rank oldest), so a fresh index drains a
+1/7 slice per night like any other refresh. Do not add a separate "never detected" trigger: it
+un-defers exactly the tickers the cap just deferred, so the cap bounds nothing and the run grows to
+the entire in-scope backlog, which is what makes the nightly task overrun its window.
+
 Price adjustment itself still covers every ticker with unadjusted rows regardless of scope:
 out-of-scope tickers get their adjusted columns filled from raw prices (or from actions already
 stored), so they drain out of the backlog instead of being re-examined every night. Price rows are

--- a/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/PriceAdjustmentService.java
+++ b/springboot/src/main/java/com/fattorestreet/sec_api/corporateaction/PriceAdjustmentService.java
@@ -265,15 +265,17 @@ public class PriceAdjustmentService {
                 boolean hasEquityDividends = existingActions.stream()
                         .anyMatch(a -> a.getActionType() == ActionType.DIVIDEND);
                 Listing listing = listingByTicker.get(ticker);
-                boolean neverDetected = listing == null || listing.getLastSecDetectionAt() == null;
-                // Every automatic trigger is gated on the detection scope; without that gate the
-                // never-detected clause below pulls SEC for the whole unadjusted backlog and the
-                // rolling cap stops bounding the run. force() stays the deliberate escape hatch.
+                // Every automatic trigger is gated on the detection scope, and first-time detection
+                // goes through scheduleStaleDetections like every other refresh: it sorts nulls
+                // first, so a never-detected ticker is already at the head of the queue and drains
+                // under the nightly cap. Re-adding a separate "never detected" clause here would
+                // un-defer exactly the tickers the cap just deferred, so the cap would bound
+                // nothing and the run would grow to the whole in-scope backlog.
+                // force() stays the deliberate escape hatch.
                 boolean inDetectionScope = detectionScope.contains(ticker);
                 boolean shouldFetchSec = options.force()
                         || (inDetectionScope
                                 && (scheduledDetections.contains(ticker)
-                                        || (!hasExistingActions && neverDetected)
                                         || (!isFund && options.validateWithYfinance() && !hasEquityDividends)));
                 // A huge overnight raw move on freshly loaded prices is the signature of a
                 // just-effective split; re-detect immediately instead of waiting for the

--- a/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/PriceAdjustmentServiceTest.java
+++ b/springboot/src/test/java/com/fattorestreet/sec_api/corporateaction/PriceAdjustmentServiceTest.java
@@ -609,6 +609,43 @@ class PriceAdjustmentServiceTest {
     }
 
     @Test
+    void adjustAllTickers_capBindsWhenInScopeTickersHaveNoActionsAndNoDetectionStamp() {
+        // The real nightly shape, and the one the cap used to miss: every in-scope ticker has
+        // unadjusted prices (so it enters the loop), no corporate actions yet, and no detection
+        // stamp. A trigger keyed on "never detected" un-defers exactly the tickers the cap just
+        // deferred, so the cap must be the only thing that decides who gets a SEC pull.
+        // 14 members => ceil(14/7) = 2 detections, not 14.
+        List<String> members = new ArrayList<>();
+        List<Asset> assets = new ArrayList<>();
+        for (int i = 0; i < 14; i++) {
+            String ticker = "M" + i;
+            members.add(ticker);
+            assets.add(buildAssetWithListing(ticker, (long) i + 1));
+        }
+
+        scopeDetectionTo(FattoreIndexCodes.FAT1000, members.toArray(new String[0]));
+        when(dailyPriceRepository.findTickersWithUnadjustedPrices()).thenReturn(members);
+        when(corporateActionRepository.findDistinctTickers()).thenReturn(Collections.emptyList());
+        when(assetRepository.findAllWithListings()).thenReturn(assets);
+        when(dailyPriceRepository.findDistinctTickers()).thenReturn(members);
+        when(equityCorporateActionService.detectAndPersistWithDiagnostics(anyString(), anyLong()))
+                .thenReturn(buildEquityReport("M", 1L, 0));
+        when(corporateActionRepository.findByTickerOrderByEffectiveDateDesc(anyString()))
+                .thenReturn(Collections.emptyList());
+        when(dailyPriceRepository.findByTickerOrderByTradeDateDesc(anyString()))
+                .thenReturn(List.of(buildPrice("M", LocalDate.of(2025, 1, 1), 100.0)));
+
+        Map<String, Object> result = service.adjustAllTickers(PriceAdjustmentService.AdjustmentOptions.DEFAULTS);
+
+        assertEquals(2, result.get("scheduledDetections"));
+        verify(equityCorporateActionService, times(2)).detectAndPersistWithDiagnostics(anyString(), anyLong());
+        verify(listingRepository, times(2)).save(any(Listing.class));
+        // Only the SEC pull is rationed; all 14 still get their adjusted columns filled, so they
+        // drain out of the unadjusted backlog on this run rather than returning every night.
+        assertEquals(14, result.get("tickersProcessed"));
+    }
+
+    @Test
     void adjustAllTickers_emptyDetectionIndexFailsClosed() {
         // An unbuilt index must not silently fall back to the full price universe; that is the
         // multi-day run the scope exists to prevent.


### PR DESCRIPTION
## Summary

- The rolling refresh caps the nightly SEC pull at `ceil(scope/7)` in-scope tickers, but a second trigger sat beside it with no cap: `(!hasExistingActions && neverDetected)` fetched any in-scope ticker lacking corporate actions and a detection stamp, whether or not the scheduler picked it.
- Because `scheduleStaleDetections` sorts `nullsFirst`, never-detected tickers are already at the head of the queue. The clause therefore un-deferred precisely the tickers the cap had just deferred, so the cap bounded nothing and each run grew toward the entire in-scope backlog.
- Observed on the 2026-07-30 Fargate hist-load: `133 scheduled for re-detection` against a 927-ticker `FAT1000` scope, yet 200 distinct tickers had run detection 15 hours in and were still climbing. Logs confirmed 0 price-jump triggers, 0 failed-stamp retries and 0 ETF-path detections that run, so every ticker above the cap came through this clause.
- Consequence: the nightly task cannot finish. It has been killed manually three nights running (7/28 at 17h32m, 7/29 at 15h15m, 7/30 at 15h20m), and tickers it never reaches stay unstamped, so they re-qualify uncapped the following night and the backlog never drains.
- Removing the clause loses no coverage. First-time detection still happens, just through the capped scheduler, so a fresh index bootstraps over roughly a week instead of in one unbounded run. `force=true` remains the escape hatch for a full re-fetch.

## Test plan

- `mvn verify` on JDK 25: 577 tests pass, plus JaCoCo coverage check, Checkstyle, PMD, SpotBugs/FindSecBugs, Error Prone and Spotless.
- New regression test `adjustAllTickers_capBindsWhenInScopeTickersHaveNoActionsAndNoDetectionStamp` builds the real nightly shape (14 in-scope tickers, all with unadjusted prices so they enter the loop, none with corporate actions, none with a detection stamp) and asserts 2 detections, 2 listing saves, 14 processed.
- Verified the test actually catches the bug rather than merely passing: with the removed clause temporarily restored, the suite fails with exactly one failure, this test, seeing 14 detections instead of 2. Restoring the fix returns it to green.
- The pre-existing `adjustAllTickers_capLimitsScheduledDetectionsPerRun` missed this because all three of its fixtures have existing corporate actions, which short-circuits the clause before it can fire.

## Runtime outlook

The ~13 tickers/hour observed on 7/30 is the **cold** rate, not the steady-state one. `FilingExtractionStore` persists per-accession extractions to `filing_extractions` and scans reuse them at zero HTTP cost, so a ticker scanned before is fast:

```
[CIK 947484] Split effective-date scan finished: 3 unique candidates (260 cached, ...)   18:07:45
[CIK 947484] Dividend record-date scan finished: 64 record-date candidates (...)         18:07:56
[CIK 720672] Split effective-date scan finished: 25 unique candidates (200 cached, ...)  19:55:41
[CIK 720672] Dividend record-date scan finished: 29 record-date candidates (...)         19:55:42
```

Warm tickers finish both scans in 1-11 seconds against roughly 4 minutes cold. The logs are dominated by `0 cached` for the same reason this PR exists: nearly every ticker scanned came from the never-detected backlog and had never been scanned before. Once the ~700 unstamped in-scope tickers drain at 133/night, weekly refreshes hit the cache and the nightly run should be short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

